### PR TITLE
marc21: fix indicator ranges and repeatable subfields

### DIFF
--- a/dojson/contrib/marc21/fields/bd01x09x.py
+++ b/dojson/contrib/marc21/fields/bd01x09x.py
@@ -19,12 +19,16 @@ from ..model import marc21
 def library_of_congress_control_number(self, key, value):
     """Library of Congress Control Number."""
     return {
-        'lc_control_number': utils.force_list(
-            value.get('a')
+        'lc_control_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'nucmc_control_number': value.get('b'),
-        'canceled_invalid_lc_control_number': value.get('z'),
+        'nucmc_control_number': utils.force_list(
+            value.get('b')
+        ),
+        'canceled_invalid_lc_control_number': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -34,22 +38,22 @@ def library_of_congress_control_number(self, key, value):
 def patent_control_information(self, key, value):
     """Patent Control Information."""
     return {
-        'number': utils.force_list(
-            value.get('a')
+        'number': value.get('a'),
+        'type_of_number': value.get('c'),
+        'country': value.get('b'),
+        'status': utils.force_list(
+            value.get('e')
         ),
-        'type_of_number': utils.force_list(
-            value.get('c')
+        'date': utils.force_list(
+            value.get('d')
         ),
-        'country': utils.force_list(
-            value.get('b')
+        'party_to_document': utils.force_list(
+            value.get('f')
         ),
-        'status': value.get('e'),
-        'date': value.get('d'),
-        'party_to_document': value.get('f'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -59,16 +63,20 @@ def patent_control_information(self, key, value):
 def national_bibliography_number(self, key, value):
     """National Bibliography Number."""
     return {
-        'national_bibliography_number': value.get('a'),
-        'qualifying_information': value.get('q'),
-        'source': utils.force_list(
-            value.get('2')
+        'national_bibliography_number': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'qualifying_information': utils.force_list(
+            value.get('q')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_national_bibliography_number': value.get('z'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'canceled_invalid_national_bibliography_number': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -81,14 +89,14 @@ def national_bibliographic_agency_control_number(self, key, value):
         "#": "Library and Archives Canada",
         "7": "Source specified in subfield $2"}
     return {
-        'record_control_number': utils.force_list(
-            value.get('a')
+        'record_control_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': utils.force_list(
-            value.get('2')
+        'source': value.get('2'),
+        'canceled_invalid_control_number': utils.force_list(
+            value.get('z')
         ),
-        'canceled_invalid_control_number': value.get('z'),
         'national_bibliographic_agency': indicator_map1.get(key[3]),
     }
 
@@ -102,24 +110,20 @@ def copyright_or_legal_deposit_number(self, key, value):
         "#": "Copyright or legal deposit number",
         "8": "No display constant generated"}
     return {
-        'copyright_or_legal_deposit_number': value.get('a'),
-        'assigning_agency': utils.force_list(
-            value.get('b')
+        'copyright_or_legal_deposit_number': utils.force_list(
+            value.get('a')
         ),
-        'date': utils.force_list(
-            value.get('d')
+        'assigning_agency': value.get('b'),
+        'date': value.get('d'),
+        'display_text': value.get('i'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'display_text': utils.force_list(
-            value.get('i')
+        'canceled_invalid_copyright_or_legal_deposit_number': utils.force_list(
+            value.get('z')
         ),
-        'source': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_copyright_or_legal_deposit_number': value.get('z'),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
@@ -129,11 +133,13 @@ def copyright_or_legal_deposit_number(self, key, value):
 def copyright_article_fee_code(self, key, value):
     """Copyright Article-Fee Code."""
     return {
-        'copyright_article_fee_code_nr': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'copyright_article_fee_code_nr': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -143,18 +149,18 @@ def copyright_article_fee_code(self, key, value):
 def international_standard_book_number(self, key, value):
     """International Standard Book Number."""
     return {
-        'international_standard_book_number': utils.force_list(
-            value.get('a')
+        'international_standard_book_number': value.get('a'),
+        'terms_of_availability': value.get('c'),
+        'qualifying_information': utils.force_list(
+            value.get('q')
         ),
-        'terms_of_availability': utils.force_list(
-            value.get('c')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'qualifying_information': value.get('q'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_invalid_isbn': utils.force_list(
+            value.get('z')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_isbn': value.get('z'),
     }
 
 
@@ -168,22 +174,22 @@ def international_standard_serial_number(self, key, value):
         "0": "Continuing resource of international interest",
         "1": "Continuing resource not of international interest"}
     return {
-        'international_standard_serial_number': utils.force_list(
-            value.get('a')
+        'international_standard_serial_number': value.get('a'),
+        'canceled_issn_l': utils.force_list(
+            value.get('m')
         ),
-        'canceled_issn_l': value.get('m'),
-        'issn_l': utils.force_list(
-            value.get('l')
+        'issn_l': value.get('l'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'incorrect_issn': utils.force_list(
+            value.get('y')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_issn': utils.force_list(
+            value.get('z')
         ),
-        'incorrect_issn': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_issn': value.get('z'),
         'level_of_international_interest': indicator_map1.get(key[3]),
     }
 
@@ -206,24 +212,20 @@ def other_standard_identifier(self, key, value):
         "0": "No difference",
         "1": "Difference"}
     return {
-        'standard_number_or_code': utils.force_list(
-            value.get('a')
+        'standard_number_or_code': value.get('a'),
+        'terms_of_availability': value.get('c'),
+        'additional_codes_following_the_standard_number_or_code': value.get('d'),
+        'qualifying_information': utils.force_list(
+            value.get('q')
         ),
-        'terms_of_availability': utils.force_list(
-            value.get('c')
+        'source_of_number_or_code': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'additional_codes_following_the_standard_number_or_code': utils.force_list(
-            value.get('d')
+        'canceled_invalid_standard_number_or_code': utils.force_list(
+            value.get('z')
         ),
-        'qualifying_information': value.get('q'),
-        'source_of_number_or_code': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_standard_number_or_code': value.get('z'),
         'type_of_standard_number_or_code': indicator_map1.get(key[3]),
         'difference_indicator': indicator_map2.get(key[4]),
     }
@@ -235,8 +237,12 @@ def other_standard_identifier(self, key, value):
 def overseas_acquisition_number(self, key, value):
     """Overseas Acquisition Number."""
     return {
-        'overseas_acquisition_number': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
+        'overseas_acquisition_number': utils.force_list(
+            value.get('a')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -246,27 +252,21 @@ def overseas_acquisition_number(self, key, value):
 def fingerprint_identifier(self, key, value):
     """Fingerprint Identifier."""
     return {
-        'first_and_second_groups_of_characters': utils.force_list(
-            value.get('a')
+        'first_and_second_groups_of_characters': value.get('a'),
+        'date': value.get('c'),
+        'third_and_fourth_groups_of_characters': value.get('b'),
+        'unparsed_fingerprint': value.get('e'),
+        'number_of_volume_or_part': utils.force_list(
+            value.get('d')
         ),
-        'date': utils.force_list(
-            value.get('c')
+        'source': value.get('2'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'third_and_fourth_groups_of_characters': utils.force_list(
-            value.get('b')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'unparsed_fingerprint': utils.force_list(
-            value.get('e')
-        ),
-        'number_of_volume_or_part': value.get('d'),
-        'source': utils.force_list(
-            value.get('2')
-        ),
-        'institution_to_which_field_applies': value.get('5'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -276,15 +276,17 @@ def fingerprint_identifier(self, key, value):
 def standard_technical_report_number(self, key, value):
     """Standard Technical Report Number."""
     return {
-        'standard_technical_report_number': utils.force_list(
-            value.get('a')
+        'standard_technical_report_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_number': value.get('z'),
-        'qualifying_information': value.get('q'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_invalid_number': utils.force_list(
+            value.get('z')
         ),
+        'qualifying_information': utils.force_list(
+            value.get('q')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -306,17 +308,15 @@ def publisher_number(self, key, value):
         "2": "Note, no added entry",
         "3": "No note, added entry"}
     return {
-        'publisher_number': utils.force_list(
-            value.get('a')
+        'publisher_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': utils.force_list(
-            value.get('b')
+        'source': value.get('b'),
+        'qualifying_information': utils.force_list(
+            value.get('q')
         ),
-        'qualifying_information': value.get('q'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'type_of_publisher_number': indicator_map1.get(key[3]),
         'note_added_entry_controller': indicator_map2.get(key[4]),
     }
@@ -328,14 +328,14 @@ def publisher_number(self, key, value):
 def coden_designation(self, key, value):
     """CODEN Designation."""
     return {
-        'coden': utils.force_list(
-            value.get('a')
+        'coden': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_coden': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_invalid_coden': utils.force_list(
+            value.get('z')
         ),
+        'linkage': value.get('6'),
     }
 
 
@@ -345,50 +345,42 @@ def coden_designation(self, key, value):
 def musical_incipits_information(self, key, value):
     """Musical Incipits Information."""
     return {
-        'number_of_work': utils.force_list(
-            value.get('a')
+        'number_of_work': value.get('a'),
+        'number_of_excerpt': value.get('c'),
+        'number_of_movement': value.get('b'),
+        'role': value.get('e'),
+        'caption_or_heading': utils.force_list(
+            value.get('d')
         ),
-        'number_of_excerpt': utils.force_list(
-            value.get('c')
+        'clef': value.get('g'),
+        'public_note': utils.force_list(
+            value.get('z')
         ),
-        'number_of_movement': utils.force_list(
-            value.get('b')
+        'voice_instrument': value.get('m'),
+        'time_signature': value.get('o'),
+        'key_signature': value.get('n'),
+        'general_note': utils.force_list(
+            value.get('q')
         ),
-        'role': utils.force_list(
-            value.get('e')
+        'musical_notation': value.get('p'),
+        'coded_validity_note': utils.force_list(
+            value.get('s')
         ),
-        'caption_or_heading': value.get('d'),
-        'clef': utils.force_list(
-            value.get('g')
+        'system_code': value.get('2'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'public_note': value.get('z'),
-        'voice_instrument': utils.force_list(
-            value.get('m')
+        'text_incipit': utils.force_list(
+            value.get('t')
         ),
-        'time_signature': utils.force_list(
-            value.get('o')
+        'linkage': value.get('6'),
+        'link_text': utils.force_list(
+            value.get('y')
         ),
-        'key_signature': utils.force_list(
-            value.get('n')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'general_note': value.get('q'),
-        'musical_notation': utils.force_list(
-            value.get('p')
-        ),
-        'coded_validity_note': value.get('s'),
-        'system_code': utils.force_list(
-            value.get('2')
-        ),
-        'uniform_resource_identifier': value.get('u'),
-        'text_incipit': value.get('t'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'link_text': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'key_or_mode': utils.force_list(
-            value.get('r')
-        ),
+        'key_or_mode': value.get('r'),
     }
 
 
@@ -398,16 +390,12 @@ def musical_incipits_information(self, key, value):
 def postal_registration_number(self, key, value):
     """Postal Registration Number."""
     return {
-        'postal_registration_number': utils.force_list(
-            value.get('a')
+        'postal_registration_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_agency_assigning_number': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'source_agency_assigning_number': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -427,19 +415,29 @@ def date_time_and_place_of_an_event(self, key, value):
         "1": "Broadcast ",
         "2": "Finding "}
     return {
-        'formatted_date_time': value.get('a'),
-        'geographic_classification_subarea_code': value.get('c'),
-        'geographic_classification_area_code': value.get('b'),
-        'place_of_event': value.get('p'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'formatted_date_time': utils.force_list(
+            value.get('a')
         ),
-        'source_of_term': value.get('2'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'geographic_classification_subarea_code': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'geographic_classification_area_code': utils.force_list(
+            value.get('b')
+        ),
+        'place_of_event': utils.force_list(
+            value.get('p')
+        ),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source_of_term': utils.force_list(
+            value.get('2')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'type_of_date_in_subfield_a': indicator_map1.get(key[3]),
         'type_of_event': indicator_map2.get(key[4]),
     }
@@ -459,64 +457,44 @@ def coded_cartographic_mathematical_data(self, key, value):
         "0": "Outer ring",
         "1": "Exclusion ring"}
     return {
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'category_of_scale': value.get('a'),
+        'constant_ratio_linear_vertical_scale': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'category_of_scale': utils.force_list(
-            value.get('a')
+        'constant_ratio_linear_horizontal_scale': utils.force_list(
+            value.get('b')
         ),
-        'constant_ratio_linear_vertical_scale': value.get('c'),
-        'constant_ratio_linear_horizontal_scale': value.get('b'),
-        'coordinates_easternmost_longitude': utils.force_list(
-            value.get('e')
+        'coordinates_easternmost_longitude': value.get('e'),
+        'coordinates_westernmost_longitude': value.get('d'),
+        'coordinates_southernmost_latitude': value.get('g'),
+        'coordinates_northernmost_latitude': value.get('f'),
+        'angular_scale': utils.force_list(
+            value.get('h')
         ),
-        'coordinates_westernmost_longitude': utils.force_list(
-            value.get('d')
+        'declination_southern_limit': value.get('k'),
+        'declination_northern_limit': value.get('j'),
+        'right_ascension_eastern_limit': value.get('m'),
+        'right_ascension_western_limit': value.get('n'),
+        'equinox': value.get('p'),
+        'g_ring_latitude': utils.force_list(
+            value.get('s')
         ),
-        'coordinates_southernmost_latitude': utils.force_list(
-            value.get('g')
+        'distance_from_earth': value.get('r'),
+        'g_ring_longitude': utils.force_list(
+            value.get('t')
         ),
-        'coordinates_northernmost_latitude': utils.force_list(
-            value.get('f')
-        ),
-        'angular_scale': value.get('h'),
-        'declination_southern_limit': utils.force_list(
-            value.get('k')
-        ),
-        'declination_northern_limit': utils.force_list(
-            value.get('j')
-        ),
-        'right_ascension_eastern_limit': utils.force_list(
-            value.get('m')
-        ),
-        'right_ascension_western_limit': utils.force_list(
-            value.get('n')
-        ),
-        'equinox': utils.force_list(
-            value.get('p')
-        ),
-        'g_ring_latitude': value.get('s'),
-        'distance_from_earth': utils.force_list(
-            value.get('r')
-        ),
-        'g_ring_longitude': value.get('t'),
-        'ending_date': utils.force_list(
-            value.get('y')
-        ),
-        'beginning_date': utils.force_list(
-            value.get('x')
-        ),
-        'name_of_extraterrestrial_body': utils.force_list(
-            value.get('z')
-        ),
+        'ending_date': value.get('y'),
+        'beginning_date': value.get('x'),
+        'name_of_extraterrestrial_body': value.get('z'),
         'type_of_scale': indicator_map1.get(key[3]),
         'type_of_ring': indicator_map2.get(key[4]),
     }
@@ -528,14 +506,14 @@ def coded_cartographic_mathematical_data(self, key, value):
 def system_control_number(self, key, value):
     """System Control Number."""
     return {
-        'system_control_number': utils.force_list(
-            value.get('a')
+        'system_control_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_control_number': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_invalid_control_number': utils.force_list(
+            value.get('z')
         ),
+        'linkage': value.get('6'),
     }
 
 
@@ -544,16 +522,12 @@ def system_control_number(self, key, value):
 def original_study_number_for_computer_data_files(self, key, value):
     """Original Study Number for Computer Data Files."""
     return {
-        'original_study_number': utils.force_list(
-            value.get('a')
+        'original_study_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_agency_assigning_number': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'source_agency_assigning_number': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -563,20 +537,24 @@ def original_study_number_for_computer_data_files(self, key, value):
 def source_of_acquisition(self, key, value):
     """Source of Acquisition."""
     return {
-        'stock_number': utils.force_list(
-            value.get('a')
+        'stock_number': value.get('a'),
+        'terms_of_availability': utils.force_list(
+            value.get('c')
         ),
-        'terms_of_availability': value.get('c'),
-        'source_of_stock_number_acquisition': utils.force_list(
-            value.get('b')
+        'source_of_stock_number_acquisition': value.get('b'),
+        'additional_format_characteristics': utils.force_list(
+            value.get('g')
         ),
-        'additional_format_characteristics': value.get('g'),
-        'form_of_issue': value.get('f'),
-        'note': value.get('n'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'form_of_issue': utils.force_list(
+            value.get('f')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'note': utils.force_list(
+            value.get('n')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -585,13 +563,11 @@ def source_of_acquisition(self, key, value):
 def record_content_licensor(self, key, value):
     """Record Content Licensor."""
     return {
-        'record_content_licensor': utils.force_list(
-            value.get('a')
+        'record_content_licensor': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -600,21 +576,19 @@ def record_content_licensor(self, key, value):
 def cataloging_source(self, key, value):
     """Cataloging Source."""
     return {
-        'original_cataloging_agency': utils.force_list(
-            value.get('a')
+        'original_cataloging_agency': value.get('a'),
+        'transcribing_agency': value.get('c'),
+        'language_of_cataloging': value.get('b'),
+        'description_conventions': utils.force_list(
+            value.get('e')
         ),
-        'transcribing_agency': utils.force_list(
-            value.get('c')
+        'modifying_agency': utils.force_list(
+            value.get('d')
         ),
-        'language_of_cataloging': utils.force_list(
-            value.get('b')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'description_conventions': value.get('e'),
-        'modifying_agency': value.get('d'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -628,24 +602,44 @@ def language_code(self, key, value):
         "0": "Item not a translation/does not include a\n                  \t\t\t\t\t\ttranslation",
         "1": "Item is or includes a translation"}
     return {
-        'language_code_of_text_sound_track_or_separate_title': value.get('a'),
-        'language_code_of_summary_or_abstract': value.get('b'),
-        'language_code_of_librettos': value.get('e'),
-        'language_code_of_sung_or_spoken_text': value.get('d'),
-        'language_code_of_accompanying_material_other_than_librettos': value.get('g'),
-        'language_code_of_table_of_contents': value.get('f'),
-        'language_code_of_original': value.get('h'),
-        'language_code_of_intermediate_translations': value.get('k'),
-        'language_code_of_subtitles_or_captions': value.get('j'),
-        'language_code_of_original_accompanying_materials_other_than_librettos': value.get('m'),
-        'language_code_of_original_libretto': value.get('n'),
-        'source_of_code': utils.force_list(
-            value.get('2')
+        'language_code_of_text_sound_track_or_separate_title': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'language_code_of_summary_or_abstract': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'language_code_of_librettos': utils.force_list(
+            value.get('e')
+        ),
+        'language_code_of_sung_or_spoken_text': utils.force_list(
+            value.get('d')
+        ),
+        'language_code_of_accompanying_material_other_than_librettos': utils.force_list(
+            value.get('g')
+        ),
+        'language_code_of_table_of_contents': utils.force_list(
+            value.get('f')
+        ),
+        'language_code_of_original': utils.force_list(
+            value.get('h')
+        ),
+        'language_code_of_intermediate_translations': utils.force_list(
+            value.get('k')
+        ),
+        'language_code_of_subtitles_or_captions': utils.force_list(
+            value.get('j')
+        ),
+        'language_code_of_original_accompanying_materials_other_than_librettos': utils.force_list(
+            value.get('m')
+        ),
+        'language_code_of_original_libretto': utils.force_list(
+            value.get('n')
+        ),
+        'source_of_code': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'translation_indication': indicator_map1.get(key[3]),
     }
 
@@ -655,7 +649,9 @@ def language_code(self, key, value):
 def authentication_code(self, key, value):
     """Authentication Code."""
     return {
-        'authentication_code': value.get('a'),
+        'authentication_code': utils.force_list(
+            value.get('a')
+        ),
     }
 
 
@@ -664,15 +660,25 @@ def authentication_code(self, key, value):
 def geographic_area_code(self, key, value):
     """Geographic Area Code."""
     return {
-        'geographic_area_code': value.get('a'),
-        'iso_code': value.get('c'),
-        'local_gac_code': value.get('b'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'source_of_local_code': value.get('2'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'geographic_area_code': utils.force_list(
+            value.get('a')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'iso_code': utils.force_list(
+            value.get('c')
+        ),
+        'local_gac_code': utils.force_list(
+            value.get('b')
+        ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_local_code': utils.force_list(
+            value.get('2')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -681,14 +687,22 @@ def geographic_area_code(self, key, value):
 def country_of_publishing_producing_entity_code(self, key, value):
     """Country of Publishing/Producing Entity Code."""
     return {
-        'marc_country_code': value.get('a'),
-        'iso_country_code': value.get('c'),
-        'local_subentity_code': value.get('b'),
-        'source_of_local_subentity_code': value.get('2'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'marc_country_code': utils.force_list(
+            value.get('a')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'iso_country_code': utils.force_list(
+            value.get('c')
+        ),
+        'local_subentity_code': utils.force_list(
+            value.get('b')
+        ),
+        'source_of_local_subentity_code': utils.force_list(
+            value.get('2')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -702,13 +716,19 @@ def time_period_of_content(self, key, value):
         "1": "Multiple single dates/times",
         "2": "Range of dates/times"}
     return {
-        'time_period_code': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'formatted_pre_9999_bc_time_period': value.get('c'),
-        'formatted_9999_bc_through_ce_time_period': value.get('b'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'time_period_code': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'formatted_pre_9999_bc_time_period': utils.force_list(
+            value.get('c')
+        ),
+        'formatted_9999_bc_through_ce_time_period': utils.force_list(
+            value.get('b')
+        ),
+        'linkage': value.get('6'),
         'type_of_time_period_in_subfield_b_or_c': indicator_map1.get(key[3]),
     }
 
@@ -719,49 +739,23 @@ def time_period_of_content(self, key, value):
 def special_coded_dates(self, key, value):
     """Special Coded Dates."""
     return {
-        'type_of_date_code': utils.force_list(
-            value.get('a')
+        'type_of_date_code': value.get('a'),
+        'date_1_ce_date': value.get('c'),
+        'date_1_bc_date': value.get('b'),
+        'date_2_ce_date': value.get('e'),
+        'date_2_bc_date': value.get('d'),
+        'beginning_or_single_date_created': value.get('k'),
+        'date_resource_modified': value.get('j'),
+        'beginning_of_date_valid': value.get('m'),
+        'ending_date_created': value.get('l'),
+        'single_or_starting_date_for_aggregated_content': value.get('o'),
+        'end_of_date_valid': value.get('n'),
+        'ending_date_for_aggregated_content': value.get('p'),
+        'source_of_date': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'date_1_ce_date': utils.force_list(
-            value.get('c')
-        ),
-        'date_1_bc_date': utils.force_list(
-            value.get('b')
-        ),
-        'date_2_ce_date': utils.force_list(
-            value.get('e')
-        ),
-        'date_2_bc_date': utils.force_list(
-            value.get('d')
-        ),
-        'beginning_or_single_date_created': utils.force_list(
-            value.get('k')
-        ),
-        'date_resource_modified': utils.force_list(
-            value.get('j')
-        ),
-        'beginning_of_date_valid': utils.force_list(
-            value.get('m')
-        ),
-        'ending_date_created': utils.force_list(
-            value.get('l')
-        ),
-        'single_or_starting_date_for_aggregated_content': utils.force_list(
-            value.get('o')
-        ),
-        'end_of_date_valid': utils.force_list(
-            value.get('n')
-        ),
-        'ending_date_for_aggregated_content': utils.force_list(
-            value.get('p')
-        ),
-        'source_of_date': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -771,11 +765,13 @@ def special_coded_dates(self, key, value):
 def form_of_musical_composition_code(self, key, value):
     """Form of Musical Composition Code."""
     return {
-        'form_of_musical_composition_code': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_of_code': utils.force_list(
-            value.get('2')
+        'form_of_musical_composition_code': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'source_of_code': value.get('2'),
     }
 
 
@@ -785,12 +781,16 @@ def form_of_musical_composition_code(self, key, value):
 def number_of_musical_instruments_or_voices_code(self, key, value):
     """Number of Musical Instruments or Voices Code."""
     return {
-        'performer_or_ensemble': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_of_code': utils.force_list(
-            value.get('2')
+        'performer_or_ensemble': utils.force_list(
+            value.get('a')
         ),
-        'soloist': value.get('b'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'source_of_code': value.get('2'),
+        'soloist': utils.force_list(
+            value.get('b')
+        ),
     }
 
 
@@ -807,17 +807,15 @@ def library_of_congress_call_number(self, key, value):
         "0": "Assigned by LC",
         "4": "Assigned by agency other than LC"}
     return {
-        'classification_number': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
-        'item_number': utils.force_list(
-            value.get('b')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'item_number': value.get('b'),
+        'linkage': value.get('6'),
         'existence_in_lc_collection': indicator_map1.get(key[3]),
         'source_of_call_number': indicator_map2.get(key[4]),
     }
@@ -829,16 +827,12 @@ def library_of_congress_call_number(self, key, value):
 def library_of_congress_copy_issue_offprint_statement(self, key, value):
     """Library of Congress Copy, Issue, Offprint Statement."""
     return {
-        'classification_number': utils.force_list(
-            value.get('a')
+        'classification_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'copy_information': utils.force_list(
-            value.get('c')
-        ),
-        'item_number': utils.force_list(
-            value.get('b')
-        ),
+        'copy_information': value.get('c'),
+        'item_number': value.get('b'),
     }
 
 
@@ -848,18 +842,18 @@ def library_of_congress_copy_issue_offprint_statement(self, key, value):
 def geographic_classification(self, key, value):
     """Geographic Classification."""
     return {
-        'geographic_classification_area_code': utils.force_list(
-            value.get('a')
+        'geographic_classification_area_code': value.get('a'),
+        'geographic_classification_subarea_code': utils.force_list(
+            value.get('b')
         ),
-        'geographic_classification_subarea_code': value.get('b'),
-        'populated_place_name': value.get('d'),
-        'code_source': utils.force_list(
-            value.get('2')
+        'populated_place_name': utils.force_list(
+            value.get('d')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'code_source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -885,19 +879,13 @@ def classification_numbers_assigned_in_canada(self, key, value):
         "8": "Other call number assigned by the contributing library",
         "9": "Other class number assigned by the contributing library"}
     return {
-        'classification_number': utils.force_list(
-            value.get('a')
+        'classification_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_of_call_class_number': utils.force_list(
-            value.get('2')
-        ),
-        'item_number': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'source_of_call_class_number': value.get('2'),
+        'item_number': value.get('b'),
+        'linkage': value.get('6'),
         'existence_in_lac_collection': indicator_map1.get(key[3]),
         'type_completeness_source_of_class_call_number': indicator_map2.get(key[4]),
     }
@@ -916,11 +904,13 @@ def national_library_of_medicine_call_number(self, key, value):
         "0": "Assigned by NLM",
         "4": "Assigned by agency other than NLM"}
     return {
-        'classification_number_r': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'item_number': utils.force_list(
-            value.get('b')
+        'classification_number_r': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'item_number': value.get('b'),
         'existence_in_nlm_collection': indicator_map1.get(key[3]),
         'source_of_call_number': indicator_map2.get(key[4]),
     }
@@ -932,14 +922,14 @@ def national_library_of_medicine_call_number(self, key, value):
 def national_library_of_medicine_copy_statement(self, key, value):
     """National Library of Medicine Copy Statement."""
     return {
-        'classification_number': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'copy_information': utils.force_list(
-            value.get('c')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
-        'item_number': utils.force_list(
-            value.get('b')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
+        'copy_information': value.get('c'),
+        'item_number': value.get('b'),
     }
 
 
@@ -948,13 +938,11 @@ def national_library_of_medicine_copy_statement(self, key, value):
 def character_sets_present(self, key, value):
     """Character Sets Present."""
     return {
-        'primary_g0_character_set': utils.force_list(
-            value.get('a')
+        'primary_g0_character_set': value.get('a'),
+        'alternate_g0_or_g1_character_set': utils.force_list(
+            value.get('c')
         ),
-        'alternate_g0_or_g1_character_set': value.get('c'),
-        'primary_g1_character_set': utils.force_list(
-            value.get('b')
-        ),
+        'primary_g1_character_set': value.get('b'),
     }
 
 
@@ -965,11 +953,13 @@ def national_agricultural_library_call_number(self, key, value):
     """National Agricultural Library Call Number."""
     indicator_map1 = {"0": "Item is in NAL", "1": "Item is not in NAL"}
     return {
-        'classification_number': value.get('a'),
-        'field_link_and_sequence_number_r': value.get('8'),
-        'item_number': utils.force_list(
-            value.get('b')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number_r': utils.force_list(
+            value.get('8')
+        ),
+        'item_number': value.get('b'),
         'existence_in_nal_collection': indicator_map1.get(key[3]),
     }
 
@@ -980,12 +970,16 @@ def national_agricultural_library_call_number(self, key, value):
 def national_agricultural_library_copy_statement(self, key, value):
     """National Agricultural Library Copy Statement."""
     return {
-        'classification_number': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'copy_information': value.get('c'),
-        'item_number': utils.force_list(
-            value.get('b')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'copy_information': utils.force_list(
+            value.get('c')
+        ),
+        'item_number': value.get('b'),
     }
 
 
@@ -995,17 +989,15 @@ def national_agricultural_library_copy_statement(self, key, value):
 def subject_category_code(self, key, value):
     """Subject Category Code."""
     return {
-        'subject_category_code': utils.force_list(
-            value.get('a')
+        'subject_category_code': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': utils.force_list(
-            value.get('2')
+        'source': value.get('2'),
+        'subject_category_code_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'subject_category_code_subdivision': value.get('x'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -1015,11 +1007,13 @@ def subject_category_code(self, key, value):
 def gpo_item_number(self, key, value):
     """GPO Item Number."""
     return {
-        'gpo_item_number': utils.force_list(
-            value.get('a')
+        'gpo_item_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_gpo_item_number': value.get('z'),
+        'canceled_invalid_gpo_item_number': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -1033,20 +1027,16 @@ def universal_decimal_classification_number(self, key, value):
         "0": "Full",
         "1": "Abridged"}
     return {
-        'universal_decimal_classification_number': utils.force_list(
-            value.get('a')
+        'universal_decimal_classification_number': value.get('a'),
+        'item_number': value.get('b'),
+        'linkage': value.get('6'),
+        'edition_identifier': value.get('2'),
+        'common_auxiliary_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'item_number': utils.force_list(
-            value.get('b')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'edition_identifier': utils.force_list(
-            value.get('2')
-        ),
-        'common_auxiliary_subdivision': value.get('x'),
-        'field_link_and_sequence_number': value.get('8'),
         'type_of_edition': indicator_map1.get(key[3]),
     }
 
@@ -1065,23 +1055,17 @@ def dewey_decimal_classification_number(self, key, value):
         "0": "Assigned by LC",
         "4": "Assigned by agency other than LC"}
     return {
-        'classification_number': value.get('a'),
-        'item_number': utils.force_list(
-            value.get('b')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
-        'standard_or_optional_designation': utils.force_list(
-            value.get('m')
+        'item_number': value.get('b'),
+        'standard_or_optional_designation': value.get('m'),
+        'assigning_agency': value.get('q'),
+        'edition_number': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'assigning_agency': utils.force_list(
-            value.get('q')
-        ),
-        'edition_number': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'type_of_edition': indicator_map1.get(key[3]),
         'source_of_classification_number': indicator_map2.get(key[4]),
     }
@@ -1097,23 +1081,25 @@ def additional_dewey_decimal_classification_number(self, key, value):
         "1": "Abridged edition",
         "7": "Other edition specified in subfield $2"}
     return {
-        'classification_number': value.get('a'),
-        'classification_number_ending_number_of_span': value.get('c'),
-        'standard_or_optional_designation': utils.force_list(
-            value.get('m')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
-        'assigning_agency': utils.force_list(
-            value.get('q')
+        'classification_number_ending_number_of_span': utils.force_list(
+            value.get('c')
         ),
-        'edition_number': utils.force_list(
-            value.get('2')
+        'standard_or_optional_designation': value.get('m'),
+        'assigning_agency': value.get('q'),
+        'edition_number': value.get('2'),
+        'linkage': value.get('6'),
+        'table_sequence_number_for_internal_subarrangement_or_add_table': utils.force_list(
+            value.get('y')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'table_sequence_number_for_internal_subarrangement_or_add_table': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'table_identification': value.get('z'),
+        'table_identification': utils.force_list(
+            value.get('z')
+        ),
         'type_of_edition': indicator_map1.get(key[3]),
     }
 
@@ -1124,20 +1110,16 @@ def additional_dewey_decimal_classification_number(self, key, value):
 def other_classification_number(self, key, value):
     """Other Classification Number."""
     return {
-        'classification_number': value.get('a'),
-        'item_number': utils.force_list(
-            value.get('b')
+        'classification_number': utils.force_list(
+            value.get('a')
         ),
-        'assigning_agency': utils.force_list(
-            value.get('q')
+        'item_number': value.get('b'),
+        'assigning_agency': value.get('q'),
+        'number_source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'number_source': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -1147,22 +1129,46 @@ def other_classification_number(self, key, value):
 def synthesized_classification_number_components(self, key, value):
     """Synthesized Classification Number Components."""
     return {
-        'number_where_instructions_are_found_single_number_or_beginning_number_of_span': value.get('a'),
-        'classification_number_ending_number_of_span': value.get('c'),
-        'base_number': value.get('b'),
-        'facet_designator': value.get('f'),
-        'number_in_internal_subarrangement_or_add_table_where_instructions_are_found': value.get('v'),
-        'digits_added_from_classification_number_in_schedule_or_external_table': value.get('s'),
-        'root_number': value.get('r'),
-        'number_being_analyzed': value.get('u'),
-        'digits_added_from_internal_subarrangement_or_add_table': value.get('t'),
-        'table_identification_internal_subarrangement_or_add_table': value.get('w'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'number_where_instructions_are_found_single_number_or_beginning_number_of_span': utils.force_list(
+            value.get('a')
         ),
-        'table_sequence_number_for_internal_subarrangement_or_add_table': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'table_identification': value.get('z'),
+        'classification_number_ending_number_of_span': utils.force_list(
+            value.get('c')
+        ),
+        'base_number': utils.force_list(
+            value.get('b')
+        ),
+        'facet_designator': utils.force_list(
+            value.get('f')
+        ),
+        'number_in_internal_subarrangement_or_add_table_where_instructions_are_found': utils.force_list(
+            value.get('v')
+        ),
+        'digits_added_from_classification_number_in_schedule_or_external_table': utils.force_list(
+            value.get('s')
+        ),
+        'root_number': utils.force_list(
+            value.get('r')
+        ),
+        'number_being_analyzed': utils.force_list(
+            value.get('u')
+        ),
+        'digits_added_from_internal_subarrangement_or_add_table': utils.force_list(
+            value.get('t')
+        ),
+        'table_identification_internal_subarrangement_or_add_table': utils.force_list(
+            value.get('w')
+        ),
+        'linkage': value.get('6'),
+        'table_sequence_number_for_internal_subarrangement_or_add_table': utils.force_list(
+            value.get('y')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'table_identification': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -1172,17 +1178,15 @@ def synthesized_classification_number_components(self, key, value):
 def government_document_classification_number(self, key, value):
     """Government Document Classification Number."""
     return {
-        'classification_number': utils.force_list(
-            value.get('a')
+        'classification_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'number_source': utils.force_list(
-            value.get('2')
+        'number_source': value.get('2'),
+        'canceled_invalid_classification_number': utils.force_list(
+            value.get('z')
         ),
-        'canceled_invalid_classification_number': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -1192,12 +1196,12 @@ def government_document_classification_number(self, key, value):
 def report_number(self, key, value):
     """Report Number."""
     return {
-        'report_number': utils.force_list(
-            value.get('a')
+        'report_number': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'canceled_invalid_report_number': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'canceled_invalid_report_number': utils.force_list(
+            value.get('z')
         ),
+        'linkage': value.get('6'),
     }

--- a/dojson/contrib/marc21/fields/bd01x09x.py
+++ b/dojson/contrib/marc21/fields/bd01x09x.py
@@ -77,8 +77,9 @@ def national_bibliography_number(self, key, value):
 @utils.filter_values
 def national_bibliographic_agency_control_number(self, key, value):
     """National Bibliographic Agency Control Number."""
-    indicator_map1 = {"#": "Library and Archives Canada",
-                      "7": "Source specified in subfield $2"}
+    indicator_map1 = {
+        "#": "Library and Archives Canada",
+        "7": "Source specified in subfield $2"}
     return {
         'record_control_number': utils.force_list(
             value.get('a')
@@ -206,22 +207,25 @@ def other_standard_identifier(self, key, value):
         "1": "Difference"}
     return {
         'standard_number_or_code': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'terms_of_availability': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'additional_codes_following_the_standard_number_or_code': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'qualifying_information': value.get('q'),
         'source_of_number_or_code': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'canceled_invalid_standard_number_or_code': value.get('z'),
-        'type_of_standard_number_or_code': indicator_map1.get(
-            key[3]),
-        'difference_indicator': indicator_map2.get(
-            key[4]),
+        'type_of_standard_number_or_code': indicator_map1.get(key[3]),
+        'difference_indicator': indicator_map2.get(key[4]),
     }
 
 
@@ -296,8 +300,11 @@ def publisher_number(self, key, value):
         "3": "Other music number",
         "4": "Videorecording number",
         "5": "Other publisher number"}
-    indicator_map2 = {"0": "No note, no added entry", "1": "Note, added entry",
-                      "2": "Note, no added entry", "3": "No note, added entry"}
+    indicator_map2 = {
+        "0": "No note, no added entry",
+        "1": "Note, added entry",
+        "2": "Note, no added entry",
+        "3": "No note, added entry"}
     return {
         'publisher_number': utils.force_list(
             value.get('a')
@@ -409,10 +416,16 @@ def postal_registration_number(self, key, value):
 @utils.filter_values
 def date_time_and_place_of_an_event(self, key, value):
     """Date/Time and Place of an Event."""
-    indicator_map1 = {"#": "No date information ", "0": "Single date ",
-                      "1": "Multiple single dates ", "2": "Range of dates "}
-    indicator_map2 = {"#": "No information provided ",
-                      "0": "Capture ", "1": "Broadcast ", "2": "Finding "}
+    indicator_map1 = {
+        "#": "No date information ",
+        "0": "Single date ",
+        "1": "Multiple single dates ",
+        "2": "Range of dates "}
+    indicator_map2 = {
+        "#": "No information provided ",
+        "0": "Capture ",
+        "1": "Broadcast ",
+        "2": "Finding "}
     return {
         'formatted_date_time': value.get('a'),
         'geographic_classification_subarea_code': value.get('c'),
@@ -437,10 +450,14 @@ def date_time_and_place_of_an_event(self, key, value):
 @utils.filter_values
 def coded_cartographic_mathematical_data(self, key, value):
     """Coded Cartographic Mathematical Data."""
-    indicator_map1 = {"0": "Scale indeterminable/No scale recorded",
-                      "1": "Single scale", "3": "Range of scales"}
+    indicator_map1 = {
+        "0": "Scale indeterminable/No scale recorded",
+        "1": "Single scale",
+        "3": "Range of scales"}
     indicator_map2 = {
-        "#": "Not applicable", "0": "Outer ring", "1": "Exclusion ring"}
+        "#": "Not applicable",
+        "0": "Outer ring",
+        "1": "Exclusion ring"}
     return {
         'authority_record_control_number_or_standard_number': value.get('0'),
         'materials_specified': utils.force_list(
@@ -608,7 +625,7 @@ def language_code(self, key, value):
     """Language Code."""
     indicator_map1 = {
         "#": "No information provided",
-        "0": "Item not a translation/does not include a translation",
+        "0": "Item not a translation/does not include a\n                  \t\t\t\t\t\ttranslation",
         "1": "Item is or includes a translation"}
     return {
         'language_code_of_text_sound_track_or_separate_title': value.get('a'),
@@ -623,12 +640,13 @@ def language_code(self, key, value):
         'language_code_of_original_accompanying_materials_other_than_librettos': value.get('m'),
         'language_code_of_original_libretto': value.get('n'),
         'source_of_code': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
-        'translation_indication': indicator_map1.get(
-            key[3]),
+        'translation_indication': indicator_map1.get(key[3]),
     }
 
 
@@ -781,10 +799,13 @@ def number_of_musical_instruments_or_voices_code(self, key, value):
 @utils.filter_values
 def library_of_congress_call_number(self, key, value):
     """Library of Congress Call Number."""
-    indicator_map1 = {"#": "No information provided",
-                      "0": "Item is in LC", "1": "Item is not in LC"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "Item is in LC",
+        "1": "Item is not in LC"}
     indicator_map2 = {
-        "0": "Assigned by LC", "4": "Assigned by agency other than LC"}
+        "0": "Assigned by LC",
+        "4": "Assigned by agency other than LC"}
     return {
         'classification_number': value.get('a'),
         'field_link_and_sequence_number': value.get('8'),
@@ -848,8 +869,10 @@ def geographic_classification(self, key, value):
 @utils.filter_values
 def classification_numbers_assigned_in_canada(self, key, value):
     """Classification Numbers Assigned in Canada."""
-    indicator_map1 = {"#": "Information not provided",
-                      "0": "Work held by LAC", "1": "Work not held by LAC"}
+    indicator_map1 = {
+        "#": "Information not provided",
+        "0": "Work held by LAC",
+        "1": "Work not held by LAC"}
     indicator_map2 = {
         "0": "LC-based call number assigned by LAC",
         "1": "Complete LC class number assigned by LAC",
@@ -863,18 +886,20 @@ def classification_numbers_assigned_in_canada(self, key, value):
         "9": "Other class number assigned by the contributing library"}
     return {
         'classification_number': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'source_of_call_class_number': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'item_number': utils.force_list(
-            value.get('b')),
+            value.get('b')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
-        'existence_in_lac_collection': indicator_map1.get(
-            key[3]),
-        'type_completeness_source_of_class_call_number': indicator_map2.get(
-            key[4]),
+            value.get('6')
+        ),
+        'existence_in_lac_collection': indicator_map1.get(key[3]),
+        'type_completeness_source_of_class_call_number': indicator_map2.get(key[4]),
     }
 
 
@@ -883,10 +908,13 @@ def classification_numbers_assigned_in_canada(self, key, value):
 @utils.filter_values
 def national_library_of_medicine_call_number(self, key, value):
     """National Library of Medicine Call Number."""
-    indicator_map1 = {"#": "No information provided",
-                      "0": "Item is in NLM", "1": "Item is not in NLM"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "Item is in NLM",
+        "1": "Item is not in NLM"}
     indicator_map2 = {
-        "0": "Assigned by NLM", "4": "Assigned by agency other than NLM"}
+        "0": "Assigned by NLM",
+        "4": "Assigned by agency other than NLM"}
     return {
         'classification_number_r': value.get('a'),
         'field_link_and_sequence_number': value.get('8'),
@@ -1001,7 +1029,9 @@ def gpo_item_number(self, key, value):
 def universal_decimal_classification_number(self, key, value):
     """Universal Decimal Classification Number."""
     indicator_map1 = {
-        "#": "No information provided", "0": "Full", "1": "Abridged"}
+        "#": "No information provided",
+        "0": "Full",
+        "1": "Abridged"}
     return {
         'universal_decimal_classification_number': utils.force_list(
             value.get('a')
@@ -1026,8 +1056,10 @@ def universal_decimal_classification_number(self, key, value):
 @utils.filter_values
 def dewey_decimal_classification_number(self, key, value):
     """Dewey Decimal Classification Number."""
-    indicator_map1 = {"0": "Full edition", "1": "Abridged edition",
-                      "7": "Other edition specified in subfield $2"}
+    indicator_map1 = {
+        "0": "Full edition",
+        "1": "Abridged edition",
+        "7": "Other edition specified in subfield $2"}
     indicator_map2 = {
         "#": "No information provided",
         "0": "Assigned by LC",
@@ -1060,24 +1092,29 @@ def dewey_decimal_classification_number(self, key, value):
 @utils.filter_values
 def additional_dewey_decimal_classification_number(self, key, value):
     """Additional Dewey Decimal Classification Number."""
-    indicator_map1 = {"0": "Full edition", "1": "Abridged edition",
-                      "7": "Other edition specified in subfield $2"}
+    indicator_map1 = {
+        "0": "Full edition",
+        "1": "Abridged edition",
+        "7": "Other edition specified in subfield $2"}
     return {
         'classification_number': value.get('a'),
         'classification_number_ending_number_of_span': value.get('c'),
         'standard_or_optional_designation': utils.force_list(
-            value.get('m')),
+            value.get('m')
+        ),
         'assigning_agency': utils.force_list(
-            value.get('q')),
+            value.get('q')
+        ),
         'edition_number': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'table_sequence_number_for_internal_subarrangement_or_add_table': value.get('y'),
         'field_link_and_sequence_number': value.get('8'),
         'table_identification': value.get('z'),
-        'type_of_edition': indicator_map1.get(
-            key[3]),
+        'type_of_edition': indicator_map1.get(key[3]),
     }
 
 
@@ -1121,7 +1158,8 @@ def synthesized_classification_number_components(self, key, value):
         'digits_added_from_internal_subarrangement_or_add_table': value.get('t'),
         'table_identification_internal_subarrangement_or_add_table': value.get('w'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'table_sequence_number_for_internal_subarrangement_or_add_table': value.get('y'),
         'field_link_and_sequence_number': value.get('8'),
         'table_identification': value.get('z'),

--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -20,45 +20,43 @@ def main_entry_personal_name(self, key, value):
     """Main Entry-Personal Name."""
     indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
     return {
-        'personal_name': utils.force_list(
-            value.get('a')
+        'personal_name': value.get('a'),
+        'titles_and_words_associated_with_a_name': utils.force_list(
+            value.get('c')
         ),
-        'titles_and_words_associated_with_a_name': value.get('c'),
-        'numeration': utils.force_list(
-            value.get('b')
+        'numeration': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_term': value.get('e'),
-        'dates_associated_with_a_name': utils.force_list(
-            value.get('d')
+        'dates_associated_with_a_name': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'attribution_qualifier': utils.force_list(
+            value.get('j')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'language_of_a_work': value.get('l'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'form_subheading': value.get('k'),
-        'attribution_qualifier': value.get('j'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'fuller_form_of_name': utils.force_list(
-            value.get('q')
+        'fuller_form_of_name': value.get('q'),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'authority_record_control_number': value.get('0'),
-        'affiliation': utils.force_list(
-            value.get('u')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
+        'title_of_a_work': value.get('t'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -72,39 +70,41 @@ def main_entry_corporate_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     return {
-        'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'subordinate_unit': value.get('b'),
-        'relator_term': value.get('e'),
-        'date_of_meeting_or_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'form_subheading': value.get('k'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'number_of_part_section_meeting': value.get('n'),
-        'authority_record_control_number': value.get('0'),
-        'affiliation': utils.force_list(
-            value.get('u')
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'field_link_and_sequence_number_r': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number_r': utils.force_list(
+            value.get('8')
+        ),
+        'title_of_a_work': value.get('t'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -118,44 +118,40 @@ def main_entry_meeting_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     return {
-        'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'date_of_meeting': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'subordinate_unit': value.get('e'),
-        'date_of_meeting': utils.force_list(
-            value.get('d')
+        'relator_term': utils.force_list(
+            value.get('j')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'language_of_a_work': value.get('l'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'form_subheading': value.get('k'),
-        'relator_term': value.get('j'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'authority_record_control_number': value.get('0'),
-        'affiliation': utils.force_list(
-            value.get('u')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
+        'title_of_a_work': value.get('t'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -176,42 +172,36 @@ def main_entry_uniform_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'authority_record_control_number': value.get('0'),
-        'version': utils.force_list(
-            value.get('s')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'title_of_a_work': value.get('t'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'nonfiling_characters': indicator_map1.get(key[3]),
     }

--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -73,32 +73,39 @@ def main_entry_corporate_name(self, key, value):
         "2": "Name in direct order"}
     return {
         'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'location_of_meeting': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'subordinate_unit': value.get('b'),
         'relator_term': value.get('e'),
         'date_of_meeting_or_treaty_signing': value.get('d'),
         'miscellaneous_information': utils.force_list(
-            value.get('g')),
+            value.get('g')
+        ),
         'date_of_a_work': utils.force_list(
-            value.get('f')),
+            value.get('f')
+        ),
         'form_subheading': value.get('k'),
         'language_of_a_work': utils.force_list(
-            value.get('l')),
+            value.get('l')
+        ),
         'name_of_part_section_of_a_work': value.get('p'),
         'number_of_part_section_meeting': value.get('n'),
         'authority_record_control_number': value.get('0'),
         'affiliation': utils.force_list(
-            value.get('u')),
+            value.get('u')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number_r': value.get('8'),
         'title_of_a_work': utils.force_list(
-            value.get('t')),
-        'type_of_corporate_name_entry_element': indicator_map1.get(
-            key[3]),
+            value.get('t')
+        ),
+        'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
     }
 
 
@@ -112,42 +119,62 @@ def main_entry_meeting_name(self, key, value):
         "2": "Name in direct order"}
     return {
         'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'location_of_meeting': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'subordinate_unit': value.get('e'),
         'date_of_meeting': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'miscellaneous_information': utils.force_list(
-            value.get('g')),
+            value.get('g')
+        ),
         'date_of_a_work': utils.force_list(
-            value.get('f')),
+            value.get('f')
+        ),
         'form_subheading': value.get('k'),
         'relator_term': value.get('j'),
         'language_of_a_work': utils.force_list(
-            value.get('l')),
+            value.get('l')
+        ),
         'name_of_part_section_of_a_work': value.get('p'),
         'number_of_part_section_meeting': value.get('n'),
         'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')),
+            value.get('q')
+        ),
         'authority_record_control_number': value.get('0'),
         'affiliation': utils.force_list(
-            value.get('u')),
+            value.get('u')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'title_of_a_work': utils.force_list(
-            value.get('t')),
-        'type_of_meeting_name_entry_element': indicator_map1.get(
-            key[3]),
+            value.get('t')
+        ),
+        'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('main_entry_uniform_title', '^130..')
+@marc21.over('main_entry_uniform_title', '^130[_1032547698].')
 @utils.filter_values
 def main_entry_uniform_title(self, key, value):
     """Main Entry-Uniform Title."""
+    indicator_map1 = {
+        "0": "Number of nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'uniform_title': utils.force_list(
             value.get('a')
@@ -186,4 +213,5 @@ def main_entry_uniform_title(self, key, value):
             value.get('6')
         ),
         'field_link_and_sequence_number': value.get('8'),
+        'nonfiling_characters': indicator_map1.get(key[3]),
     }

--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -24,17 +24,15 @@ def abbreviated_title(self, key, value):
         "#": "Abbreviated key title",
         "0": "Other abbreviated title"}
     return {
-        'abbreviated_title': utils.force_list(
-            value.get('a')
+        'abbreviated_title': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': value.get('2'),
-        'qualifying_information': utils.force_list(
-            value.get('b')
+        'source': utils.force_list(
+            value.get('2')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'qualifying_information': value.get('b'),
+        'linkage': value.get('6'),
         'title_added_entry': indicator_map1.get(key[3]),
         'type': indicator_map2.get(key[4]),
     }
@@ -57,16 +55,12 @@ def key_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'key_title': utils.force_list(
-            value.get('a')
+        'key_title': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'qualifying_information': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'qualifying_information': value.get('b'),
+        'linkage': value.get('6'),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
 
@@ -90,40 +84,36 @@ def uniform_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'authority_record_control_number': value.get('0'),
-        'version': utils.force_list(
-            value.get('s')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
@@ -148,27 +138,21 @@ def translation_of_title_by_cataloging_agency(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'title': utils.force_list(
-            value.get('a')
+        'title': value.get('a'),
+        'statement_of_responsibility': value.get('c'),
+        'remainder_of_title': value.get('b'),
+        'medium': value.get('h'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'statement_of_responsibility': utils.force_list(
-            value.get('c')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'remainder_of_title': utils.force_list(
-            value.get('b')
+        'linkage': value.get('6'),
+        'language_code_of_translated_title': value.get('y'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'medium': utils.force_list(
-            value.get('h')
-        ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'language_code_of_translated_title': utils.force_list(
-            value.get('y')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'title_added_entry': indicator_map1.get(key[3]),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
@@ -193,39 +177,33 @@ def collective_uniform_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
@@ -248,34 +226,26 @@ def title_statement(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'title': utils.force_list(
-            value.get('a')
+        'title': value.get('a'),
+        'statement_of_responsibility': value.get('c'),
+        'remainder_of_title': value.get('b'),
+        'bulk_dates': value.get('g'),
+        'inclusive_dates': value.get('f'),
+        'medium': value.get('h'),
+        'form': utils.force_list(
+            value.get('k')
         ),
-        'statement_of_responsibility': utils.force_list(
-            value.get('c')
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'remainder_of_title': utils.force_list(
-            value.get('b')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'bulk_dates': utils.force_list(
-            value.get('g')
+        'version': value.get('s'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'inclusive_dates': utils.force_list(
-            value.get('f')
-        ),
-        'medium': utils.force_list(
-            value.get('h')
-        ),
-        'form': value.get('k'),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'title_added_entry': indicator_map1.get(key[3]),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
@@ -303,33 +273,23 @@ def varying_form_of_title(self, key, value):
         "7": "Running title",
         "8": "Spine title"}
     return {
-        'title_proper_short_title': utils.force_list(
-            value.get('a')
+        'title_proper_short_title': value.get('a'),
+        'remainder_of_title': value.get('b'),
+        'miscellaneous_information': value.get('g'),
+        'date_or_sequential_designation': value.get('f'),
+        'display_text': value.get('i'),
+        'medium': value.get('h'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'remainder_of_title': utils.force_list(
-            value.get('b')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'date_or_sequential_designation': utils.force_list(
-            value.get('f')
-        ),
-        'display_text': utils.force_list(
-            value.get('i')
-        ),
-        'medium': utils.force_list(
-            value.get('h')
-        ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'note_added_entry_controller': indicator_map1.get(key[3]),
         'type_of_title': indicator_map2.get(key[4]),
     }
@@ -343,30 +303,22 @@ def former_title(self, key, value):
     indicator_map1 = {"0": "No added entry", "1": "Added entry"}
     indicator_map2 = {"0": "Display note", "1": "Do not display note"}
     return {
-        'title': utils.force_list(
-            value.get('a')
+        'title': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'remainder_of_title': value.get('b'),
+        'miscellaneous_information': value.get('g'),
+        'date_or_sequential_designation': value.get('f'),
+        'medium': value.get('h'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'remainder_of_title': utils.force_list(
-            value.get('b')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
-        ),
-        'date_or_sequential_designation': utils.force_list(
-            value.get('f')
-        ),
-        'medium': utils.force_list(
-            value.get('h')
-        ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'title_added_entry': indicator_map1.get(key[3]),
         'note_controller': indicator_map2.get(key[4]),
     }

--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -21,7 +21,8 @@ def abbreviated_title(self, key, value):
     """Abbreviated Title."""
     indicator_map1 = {"0": "No added entry", "1": "Added entry"}
     indicator_map2 = {
-        "#": "Abbreviated key title", "0": "Other abbreviated title"}
+        "#": "Abbreviated key title",
+        "0": "Other abbreviated title"}
     return {
         'abbreviated_title': utils.force_list(
             value.get('a')
@@ -39,12 +40,22 @@ def abbreviated_title(self, key, value):
     }
 
 
-@marc21.over('key_title', '^222.[0_]')
+@marc21.over('key_title', '^222.[_1032547698]')
 @utils.for_each_value
 @utils.filter_values
 def key_title(self, key, value):
     """Key Title."""
-    indicator_map2 = {"0": "No nonfiling characters"}
+    indicator_map2 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'key_title': utils.force_list(
             value.get('a')
@@ -60,12 +71,24 @@ def key_title(self, key, value):
     }
 
 
-@marc21.over('uniform_title', '^240[10_].')
+@marc21.over('uniform_title', '^240[10_][_1032547698]')
 @utils.filter_values
 def uniform_title(self, key, value):
     """Uniform Title."""
     indicator_map1 = {
-        "0": "Not printed or displayed", "1": "Printed or displayed"}
+        "0": "Not printed or displayed",
+        "1": "Printed or displayed"}
+    indicator_map2 = {
+        "0": "Number of nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'uniform_title': utils.force_list(
             value.get('a')
@@ -102,16 +125,28 @@ def uniform_title(self, key, value):
         ),
         'field_link_and_sequence_number': value.get('8'),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
+        'nonfiling_characters': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('translation_of_title_by_cataloging_agency', '^242[10_][0_]')
+@marc21.over(
+    'translation_of_title_by_cataloging_agency', '^242[10_][_1032547698]')
 @utils.for_each_value
 @utils.filter_values
 def translation_of_title_by_cataloging_agency(self, key, value):
     """Translation of Title by Cataloging Agency."""
     indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {"0": "No nonfiling characters"}
+    indicator_map2 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'title': utils.force_list(
             value.get('a')
@@ -139,12 +174,24 @@ def translation_of_title_by_cataloging_agency(self, key, value):
     }
 
 
-@marc21.over('collective_uniform_title', '^243[10_].')
+@marc21.over('collective_uniform_title', '^243[10_][_1032547698]')
 @utils.filter_values
 def collective_uniform_title(self, key, value):
     """Collective Uniform Title."""
     indicator_map1 = {
-        "0": "Not printed or displayed", "1": "Printed or displayed"}
+        "0": "Not printed or displayed",
+        "1": "Printed or displayed"}
+    indicator_map2 = {
+        "0": "Number of nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'uniform_title': utils.force_list(
             value.get('a')
@@ -180,15 +227,26 @@ def collective_uniform_title(self, key, value):
         ),
         'field_link_and_sequence_number': value.get('8'),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
+        'nonfiling_characters': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('title_statement', '^245[10_][0_]')
+@marc21.over('title_statement', '^245[10_][_1032547698]')
 @utils.filter_values
 def title_statement(self, key, value):
     """Title Statement."""
     indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {"0": "No nonfiling characters"}
+    indicator_map2 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'title': utils.force_list(
             value.get('a')

--- a/dojson/contrib/marc21/fields/bd25x28x.py
+++ b/dojson/contrib/marc21/fields/bd25x28x.py
@@ -20,19 +20,13 @@ from ..model import marc21
 def edition_statement(self, key, value):
     """Edition Statement."""
     return {
-        'edition_statement': utils.force_list(
-            value.get('a')
+        'edition_statement': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'remainder_of_edition_statement': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'remainder_of_edition_statement': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -41,13 +35,11 @@ def edition_statement(self, key, value):
 def musical_presentation_statement(self, key, value):
     """Musical Presentation Statement."""
     return {
-        'musical_presentation_statement': utils.force_list(
-            value.get('a')
+        'musical_presentation_statement': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -57,31 +49,17 @@ def musical_presentation_statement(self, key, value):
 def cartographic_mathematical_data(self, key, value):
     """Cartographic Mathematical Data."""
     return {
-        'statement_of_scale': utils.force_list(
-            value.get('a')
+        'statement_of_scale': value.get('a'),
+        'statement_of_coordinates': value.get('c'),
+        'statement_of_projection': value.get('b'),
+        'statement_of_equinox': value.get('e'),
+        'statement_of_zone': value.get('d'),
+        'exclusion_g_ring_coordinate_pairs': value.get('g'),
+        'outer_g_ring_coordinate_pairs': value.get('f'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'statement_of_coordinates': utils.force_list(
-            value.get('c')
-        ),
-        'statement_of_projection': utils.force_list(
-            value.get('b')
-        ),
-        'statement_of_equinox': utils.force_list(
-            value.get('e')
-        ),
-        'statement_of_zone': utils.force_list(
-            value.get('d')
-        ),
-        'exclusion_g_ring_coordinate_pairs': utils.force_list(
-            value.get('g')
-        ),
-        'outer_g_ring_coordinate_pairs': utils.force_list(
-            value.get('f')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -90,13 +68,11 @@ def cartographic_mathematical_data(self, key, value):
 def computer_file_characteristics(self, key, value):
     """Computer File Characteristics."""
     return {
-        'computer_file_characteristics': utils.force_list(
-            value.get('a')
+        'computer_file_characteristics': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -106,14 +82,14 @@ def computer_file_characteristics(self, key, value):
 def country_of_producing_entity(self, key, value):
     """Country of Producing Entity."""
     return {
-        'country_of_producing_entity': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': utils.force_list(
-            value.get('2')
+        'country_of_producing_entity': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
     }
 
 
@@ -123,16 +99,12 @@ def country_of_producing_entity(self, key, value):
 def philatelic_issue_data(self, key, value):
     """Philatelic Issue Data."""
     return {
-        'issuing_jurisdiction': utils.force_list(
-            value.get('a')
+        'issuing_jurisdiction': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'denomination': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'denomination': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -146,19 +118,29 @@ def publication_distribution_imprint(self, key, value):
         "2": "Intervening publisher",
         "3": "Current/latest publisher"}
     return {
-        'place_of_publication_distribution': value.get('a'),
-        'date_of_publication_distribution': value.get('c'),
-        'name_of_publisher_distributor': value.get('b'),
-        'place_of_manufacture': value.get('e'),
-        'date_of_manufacture': value.get('g'),
-        'manufacturer': value.get('f'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'place_of_publication_distribution': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'date_of_publication_distribution': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'name_of_publisher_distributor': utils.force_list(
+            value.get('b')
+        ),
+        'place_of_manufacture': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_manufacture': utils.force_list(
+            value.get('g')
+        ),
+        'manufacturer': utils.force_list(
+            value.get('f')
+        ),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'sequence_of_publishing_statements': indicator_map1.get(key[3]),
     }
 
@@ -168,15 +150,25 @@ def publication_distribution_imprint(self, key, value):
 def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
     """Imprint Statement for Films (Pre-AACR 1 Revised)."""
     return {
-        'producing_company': value.get('a'),
-        'releasing_company': value.get('b'),
-        'contractual_producer': value.get('e'),
-        'date_of_production_release': value.get('d'),
-        'place_of_production_release': value.get('f'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'producing_company': utils.force_list(
+            value.get('a')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'releasing_company': utils.force_list(
+            value.get('b')
+        ),
+        'contractual_producer': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_production_release': utils.force_list(
+            value.get('d')
+        ),
+        'place_of_production_release': utils.force_list(
+            value.get('f')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -185,25 +177,15 @@ def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
 def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
     """Imprint Statement for Sound Recordings (Pre-AACR 1)."""
     return {
-        'place_of_production_release': utils.force_list(
-            value.get('a')
+        'place_of_production_release': value.get('a'),
+        'date_of_production_release': value.get('c'),
+        'publisher_or_trade_name': value.get('b'),
+        'serial_identification': value.get('k'),
+        'matrix_and_or_take_number': value.get('l'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'date_of_production_release': utils.force_list(
-            value.get('c')
-        ),
-        'publisher_or_trade_name': utils.force_list(
-            value.get('b')
-        ),
-        'serial_identification': utils.force_list(
-            value.get('k')
-        ),
-        'matrix_and_or_take_number': utils.force_list(
-            value.get('l')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -212,13 +194,11 @@ def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
 def projected_publication_date(self, key, value):
     """Projected Publication Date."""
     return {
-        'projected_publication_date': utils.force_list(
-            value.get('a')
+        'projected_publication_date': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -240,16 +220,20 @@ def production_publication_distribution_manufacture_and_copyright_notice(
         "3": "Manufacture",
         "4": "Copyright notice date"}
     return {
-        'place_of_production_publication_distribution_manufacture': value.get('a'),
-        'date_of_production_publication_distribution_manufacture_or_copyright_notice': value.get('c'),
-        'name_of_producer_publisher_distributor_manufacturer': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'place_of_production_publication_distribution_manufacture': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'date_of_production_publication_distribution_manufacture_or_copyright_notice': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'name_of_producer_publisher_distributor_manufacturer': utils.force_list(
+            value.get('b')
+        ),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'sequence_of_statements': indicator_map1.get(key[3]),
         'function_of_entity': indicator_map2.get(key[4]),
     }
@@ -265,44 +249,50 @@ def address(self, key, value):
         "1": "Primary",
         "2": "Secondary"}
     return {
-        'address': value.get('a'),
-        'state_or_province': utils.force_list(
-            value.get('c')
+        'address': utils.force_list(
+            value.get('a')
         ),
-        'city': utils.force_list(
-            value.get('b')
+        'state_or_province': value.get('c'),
+        'city': value.get('b'),
+        'postal_code': value.get('e'),
+        'country': value.get('d'),
+        'attention_name': value.get('g'),
+        'terms_preceding_attention_name': value.get('f'),
+        'type_of_address': value.get('i'),
+        'attention_position': value.get('h'),
+        'telephone_number': utils.force_list(
+            value.get('k')
         ),
-        'postal_code': utils.force_list(
-            value.get('e')
+        'specialized_telephone_number': utils.force_list(
+            value.get('j')
         ),
-        'country': utils.force_list(
-            value.get('d')
+        'electronic_mail_address': utils.force_list(
+            value.get('m')
         ),
-        'attention_name': utils.force_list(
-            value.get('g')
+        'fax_number': utils.force_list(
+            value.get('l')
         ),
-        'terms_preceding_attention_name': utils.force_list(
-            value.get('f')
+        'tdd_or_tty_number': utils.force_list(
+            value.get('n')
         ),
-        'type_of_address': utils.force_list(
-            value.get('i')
+        'title_of_contact_person': utils.force_list(
+            value.get('q')
         ),
-        'attention_position': utils.force_list(
-            value.get('h')
+        'contact_person': utils.force_list(
+            value.get('p')
         ),
-        'telephone_number': value.get('k'),
-        'specialized_telephone_number': value.get('j'),
-        'electronic_mail_address': value.get('m'),
-        'fax_number': value.get('l'),
-        'tdd_or_tty_number': value.get('n'),
-        'title_of_contact_person': value.get('q'),
-        'contact_person': value.get('p'),
-        'hours': value.get('r'),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'hours': utils.force_list(
+            value.get('r')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'public_note': value.get('z'),
+        'relator_code': utils.force_list(
+            value.get('4')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
         'level': indicator_map1.get(key[3]),
     }

--- a/dojson/contrib/marc21/fields/bd25x28x.py
+++ b/dojson/contrib/marc21/fields/bd25x28x.py
@@ -223,15 +223,16 @@ def projected_publication_date(self, key, value):
 
 
 @marc21.over(
-    'production_publication_distribution_manufacture_and_copyright_notice',
-    '^264[_23][10324_]')
+    'production_publication_distribution_manufacture_and_copyright_notice', '^264[_23][10324_]')
 @utils.for_each_value
 @utils.filter_values
 def production_publication_distribution_manufacture_and_copyright_notice(
         self, key, value):
     """Production, Publication, Distribution, Manufacture, and Copyright Notice."""
-    indicator_map1 = {"#": "Not applicable/No information provided/Earliest",
-                      "2": "Intervening", "3": "Current/latest"}
+    indicator_map1 = {
+        "#": "Not applicable/No information provided/Earliest",
+        "2": "Intervening",
+        "3": "Current/latest"}
     indicator_map2 = {
         "0": "Production",
         "1": "Publication",
@@ -243,14 +244,14 @@ def production_publication_distribution_manufacture_and_copyright_notice(
         'date_of_production_publication_distribution_manufacture_or_copyright_notice': value.get('c'),
         'name_of_producer_publisher_distributor_manufacturer': value.get('b'),
         'materials_specified': utils.force_list(
-            value.get('3')),
+            value.get('3')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
-        'sequence_of_statements': indicator_map1.get(
-            key[3]),
-        'function_of_entity': indicator_map2.get(
-            key[4]),
+        'sequence_of_statements': indicator_map1.get(key[3]),
+        'function_of_entity': indicator_map2.get(key[4]),
     }
 
 
@@ -260,7 +261,9 @@ def production_publication_distribution_manufacture_and_copyright_notice(
 def address(self, key, value):
     """Address."""
     indicator_map1 = {
-        "#": "No level specified", "1": "Primary", "2": "Secondary"}
+        "#": "No level specified",
+        "1": "Primary",
+        "2": "Secondary"}
     return {
         'address': value.get('a'),
         'state_or_province': utils.force_list(

--- a/dojson/contrib/marc21/fields/bd3xx.py
+++ b/dojson/contrib/marc21/fields/bd3xx.py
@@ -20,23 +20,25 @@ from ..model import marc21
 def physical_description(self, key, value):
     """Physical Description."""
     return {
-        'extent': value.get('a'),
-        'dimensions': value.get('c'),
-        'other_physical_details': utils.force_list(
-            value.get('b')
+        'extent': utils.force_list(
+            value.get('a')
         ),
-        'accompanying_material': utils.force_list(
-            value.get('e')
+        'dimensions': utils.force_list(
+            value.get('c')
         ),
-        'size_of_unit': value.get('g'),
-        'type_of_unit': value.get('f'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'other_physical_details': value.get('b'),
+        'accompanying_material': value.get('e'),
+        'size_of_unit': utils.force_list(
+            value.get('g')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'type_of_unit': utils.force_list(
+            value.get('f')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -45,11 +47,13 @@ def physical_description(self, key, value):
 def playing_time(self, key, value):
     """Playing Time."""
     return {
-        'playing_time': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'playing_time': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -60,16 +64,12 @@ def hours(self, key, value):
     """Hours, Etc.."""
     indicator_map1 = {"#": "Hours", "8": "No display constant generated"}
     return {
-        'hours': utils.force_list(
-            value.get('a')
+        'hours': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'additional_information': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'additional_information': value.get('b'),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -79,16 +79,12 @@ def hours(self, key, value):
 def current_publication_frequency(self, key, value):
     """Current Publication Frequency."""
     return {
-        'current_publication_frequency': utils.force_list(
-            value.get('a')
+        'current_publication_frequency': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'date_of_current_publication_frequency': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'date_of_current_publication_frequency': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -98,16 +94,12 @@ def current_publication_frequency(self, key, value):
 def former_publication_frequency(self, key, value):
     """Former Publication Frequency."""
     return {
-        'former_publication_frequency': utils.force_list(
-            value.get('a')
+        'former_publication_frequency': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'dates_of_former_publication_frequency': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'dates_of_former_publication_frequency': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -117,18 +109,18 @@ def former_publication_frequency(self, key, value):
 def content_type(self, key, value):
     """Content Type."""
     return {
-        'content_type_term': value.get('a'),
-        'content_type_code': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'content_type_term': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'content_type_code': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -138,18 +130,18 @@ def content_type(self, key, value):
 def media_type(self, key, value):
     """Media Type."""
     return {
-        'media_type_term': value.get('a'),
-        'media_type_code': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'media_type_term': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'media_type_code': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -159,18 +151,18 @@ def media_type(self, key, value):
 def carrier_type(self, key, value):
     """Carrier Type."""
     return {
-        'carrier_type_term': value.get('a'),
-        'carrier_type_code': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'carrier_type_term': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'carrier_type_code': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -180,30 +172,54 @@ def carrier_type(self, key, value):
 def physical_medium(self, key, value):
     """Physical Medium."""
     return {
-        'material_base_and_configuration': value.get('a'),
-        'materials_applied_to_surface': value.get('c'),
-        'dimensions': value.get('b'),
-        'support': value.get('e'),
-        'information_recording_technique': value.get('d'),
-        'production_rate_ratio': value.get('f'),
-        'technical_specifications_of_medium': value.get('i'),
-        'location_within_medium': value.get('h'),
-        'layout': value.get('k'),
-        'generation': value.get('j'),
-        'book_format': value.get('m'),
-        'polarity': value.get('o'),
-        'font_size': value.get('n'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'material_base_and_configuration': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'materials_applied_to_surface': utils.force_list(
+            value.get('c')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'dimensions': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'support': utils.force_list(
+            value.get('e')
+        ),
+        'information_recording_technique': utils.force_list(
+            value.get('d')
+        ),
+        'production_rate_ratio': utils.force_list(
+            value.get('f')
+        ),
+        'technical_specifications_of_medium': utils.force_list(
+            value.get('i')
+        ),
+        'location_within_medium': utils.force_list(
+            value.get('h')
+        ),
+        'layout': utils.force_list(
+            value.get('k')
+        ),
+        'generation': utils.force_list(
+            value.get('j')
+        ),
+        'book_format': utils.force_list(
+            value.get('m')
+        ),
+        'polarity': utils.force_list(
+            value.get('o')
+        ),
+        'font_size': utils.force_list(
+            value.get('n')
+        ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -226,78 +242,38 @@ def geospatial_reference_data(self, key, value):
         "7": "Method specified in $2",
         "8": "Depth"}
     return {
-        'reference_method_used': utils.force_list(
-            value.get('2')
+        'reference_method_used': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'name': value.get('a'),
+        'latitude_resolution': value.get('c'),
+        'coordinate_units_or_distance_units': value.get('b'),
+        'standard_parallel_or_oblique_line_latitude': utils.force_list(
+            value.get('e')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'name': utils.force_list(
-            value.get('a')
+        'longitude_resolution': value.get('d'),
+        'longitude_of_central_meridian_or_projection_center': value.get('g'),
+        'oblique_line_longitude': utils.force_list(
+            value.get('f')
         ),
-        'latitude_resolution': utils.force_list(
-            value.get('c')
-        ),
-        'coordinate_units_or_distance_units': utils.force_list(
-            value.get('b')
-        ),
-        'standard_parallel_or_oblique_line_latitude': value.get('e'),
-        'longitude_resolution': utils.force_list(
-            value.get('d')
-        ),
-        'longitude_of_central_meridian_or_projection_center': utils.force_list(
-            value.get('g')
-        ),
-        'oblique_line_longitude': value.get('f'),
-        'false_easting': utils.force_list(
-            value.get('i')
-        ),
-        'latitude_of_projection_center_or_projection_origin': utils.force_list(
-            value.get('h')
-        ),
-        'scale_factor': utils.force_list(
-            value.get('k')
-        ),
-        'false_northing': utils.force_list(
-            value.get('j')
-        ),
-        'azimuthal_angle': utils.force_list(
-            value.get('m')
-        ),
-        'height_of_perspective_point_above_surface': utils.force_list(
-            value.get('l')
-        ),
-        'landsat_number_and_path_number': utils.force_list(
-            value.get('o')
-        ),
-        'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': utils.force_list(
-            value.get('n')
-        ),
-        'ellipsoid_name': utils.force_list(
-            value.get('q')
-        ),
-        'zone_identifier': utils.force_list(
-            value.get('p')
-        ),
-        'denominator_of_flattening_ratio': utils.force_list(
-            value.get('s')
-        ),
-        'semi_major_axis': utils.force_list(
-            value.get('r')
-        ),
-        'vertical_encoding_method': utils.force_list(
-            value.get('u')
-        ),
-        'vertical_resolution': utils.force_list(
-            value.get('t')
-        ),
-        'local_planar_or_local_georeference_information': utils.force_list(
-            value.get('w')
-        ),
-        'local_planar_local_or_other_projection_or_grid_description': utils.force_list(
-            value.get('v')
-        ),
+        'false_easting': value.get('i'),
+        'latitude_of_projection_center_or_projection_origin': value.get('h'),
+        'scale_factor': value.get('k'),
+        'false_northing': value.get('j'),
+        'azimuthal_angle': value.get('m'),
+        'height_of_perspective_point_above_surface': value.get('l'),
+        'landsat_number_and_path_number': value.get('o'),
+        'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': value.get('n'),
+        'ellipsoid_name': value.get('q'),
+        'zone_identifier': value.get('p'),
+        'denominator_of_flattening_ratio': value.get('s'),
+        'semi_major_axis': value.get('r'),
+        'vertical_encoding_method': value.get('u'),
+        'vertical_resolution': value.get('t'),
+        'local_planar_or_local_georeference_information': value.get('w'),
+        'local_planar_local_or_other_projection_or_grid_description': value.get('v'),
         'geospatial_reference_dimension': indicator_map1.get(key[3]),
         'geospatial_reference_method': indicator_map2.get(key[4]),
     }
@@ -309,37 +285,19 @@ def geospatial_reference_data(self, key, value):
 def planar_coordinate_data(self, key, value):
     """Planar Coordinate Data."""
     return {
-        'planar_coordinate_encoding_method': utils.force_list(
-            value.get('a')
+        'planar_coordinate_encoding_method': value.get('a'),
+        'abscissa_resolution': value.get('c'),
+        'planar_distance_units': value.get('b'),
+        'distance_resolution': value.get('e'),
+        'ordinate_resolution': value.get('d'),
+        'bearing_units': value.get('g'),
+        'bearing_resolution': value.get('f'),
+        'bearing_reference_meridian': value.get('i'),
+        'bearing_reference_direction': value.get('h'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'abscissa_resolution': utils.force_list(
-            value.get('c')
-        ),
-        'planar_distance_units': utils.force_list(
-            value.get('b')
-        ),
-        'distance_resolution': utils.force_list(
-            value.get('e')
-        ),
-        'ordinate_resolution': utils.force_list(
-            value.get('d')
-        ),
-        'bearing_units': utils.force_list(
-            value.get('g')
-        ),
-        'bearing_resolution': utils.force_list(
-            value.get('f')
-        ),
-        'bearing_reference_meridian': utils.force_list(
-            value.get('i')
-        ),
-        'bearing_reference_direction': utils.force_list(
-            value.get('h')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -349,25 +307,39 @@ def planar_coordinate_data(self, key, value):
 def sound_characteristics(self, key, value):
     """Sound Characteristics."""
     return {
-        'type_of_recording': value.get('a'),
-        'playing_speed': value.get('c'),
-        'recording_medium': value.get('b'),
-        'track_configuration': value.get('e'),
-        'groove_characteristic': value.get('d'),
-        'configuration_of_playback_channels': value.get('g'),
-        'tape_configuration': value.get('f'),
-        'special_playback_characteristics': value.get('h'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'type_of_recording': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'playing_speed': utils.force_list(
+            value.get('c')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'recording_medium': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'track_configuration': utils.force_list(
+            value.get('e')
+        ),
+        'groove_characteristic': utils.force_list(
+            value.get('d')
+        ),
+        'configuration_of_playback_channels': utils.force_list(
+            value.get('g')
+        ),
+        'tape_configuration': utils.force_list(
+            value.get('f')
+        ),
+        'special_playback_characteristics': utils.force_list(
+            value.get('h')
+        ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -377,19 +349,21 @@ def sound_characteristics(self, key, value):
 def projection_characteristics_of_moving_image(self, key, value):
     """Projection Characteristics of Moving Image."""
     return {
-        'presentation_format': value.get('a'),
-        'projection_speed': value.get('b'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'presentation_format': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'projection_speed': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -399,19 +373,21 @@ def projection_characteristics_of_moving_image(self, key, value):
 def video_characteristics(self, key, value):
     """Video Characteristics."""
     return {
-        'video_format': value.get('a'),
-        'broadcast_standard': value.get('b'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'video_format': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'broadcast_standard': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -421,23 +397,33 @@ def video_characteristics(self, key, value):
 def digital_file_characteristics(self, key, value):
     """Digital File Characteristics."""
     return {
-        'file_type': value.get('a'),
-        'file_size': value.get('c'),
-        'encoding_format': value.get('b'),
-        'regional_encoding': value.get('e'),
-        'resolution': value.get('d'),
-        'transmission_speed': value.get('f'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'file_type': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'file_size': utils.force_list(
+            value.get('c')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'encoding_format': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'regional_encoding': utils.force_list(
+            value.get('e')
+        ),
+        'resolution': utils.force_list(
+            value.get('d')
+        ),
+        'transmission_speed': utils.force_list(
+            value.get('f')
+        ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -447,18 +433,18 @@ def digital_file_characteristics(self, key, value):
 def organization_and_arrangement_of_materials(self, key, value):
     """Organization and Arrangement of Materials."""
     return {
-        'organization': value.get('a'),
-        'hierarchical_level': utils.force_list(
-            value.get('c')
+        'organization': utils.force_list(
+            value.get('a')
         ),
-        'arrangement': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'hierarchical_level': value.get('c'),
+        'arrangement': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -468,33 +454,23 @@ def organization_and_arrangement_of_materials(self, key, value):
 def digital_graphic_representation(self, key, value):
     """Digital Graphic Representation."""
     return {
-        'direct_reference_method': utils.force_list(
-            value.get('a')
+        'direct_reference_method': value.get('a'),
+        'object_count': utils.force_list(
+            value.get('c')
         ),
-        'object_count': value.get('c'),
-        'object_type': value.get('b'),
-        'column_count': utils.force_list(
-            value.get('e')
+        'object_type': utils.force_list(
+            value.get('b')
         ),
-        'row_count': utils.force_list(
-            value.get('d')
+        'column_count': value.get('e'),
+        'row_count': value.get('d'),
+        'vpf_topology_level': value.get('g'),
+        'vertical_count': value.get('f'),
+        'indirect_reference_description': value.get('i'),
+        'format_of_the_digital_image': value.get('q'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'vpf_topology_level': utils.force_list(
-            value.get('g')
-        ),
-        'vertical_count': utils.force_list(
-            value.get('f')
-        ),
-        'indirect_reference_description': utils.force_list(
-            value.get('i')
-        ),
-        'format_of_the_digital_image': utils.force_list(
-            value.get('q')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -512,31 +488,25 @@ def security_classification_control(self, key, value):
         "5": "Record",
         "8": "None of the above"}
     return {
-        'security_classification': utils.force_list(
-            value.get('a')
+        'security_classification': value.get('a'),
+        'external_dissemination_information': utils.force_list(
+            value.get('c')
         ),
-        'external_dissemination_information': value.get('c'),
-        'handling_instructions': value.get('b'),
-        'classification_system': utils.force_list(
-            value.get('e')
+        'handling_instructions': utils.force_list(
+            value.get('b')
         ),
-        'downgrading_or_declassification_event': utils.force_list(
-            value.get('d')
+        'classification_system': value.get('e'),
+        'downgrading_or_declassification_event': value.get('d'),
+        'downgrading_date': value.get('g'),
+        'country_of_origin_code': value.get('f'),
+        'declassification_date': value.get('h'),
+        'authorization': utils.force_list(
+            value.get('j')
         ),
-        'downgrading_date': utils.force_list(
-            value.get('g')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'country_of_origin_code': utils.force_list(
-            value.get('f')
-        ),
-        'declassification_date': utils.force_list(
-            value.get('h')
-        ),
-        'authorization': value.get('j'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'controlled_element': indicator_map1.get(key[3]),
     }
 
@@ -546,16 +516,20 @@ def security_classification_control(self, key, value):
 def originator_dissemination_control(self, key, value):
     """Originator Dissemination Control."""
     return {
-        'originator_control_term': utils.force_list(
-            value.get('a')
+        'originator_control_term': value.get('a'),
+        'authorized_recipients_of_material': utils.force_list(
+            value.get('c')
         ),
-        'authorized_recipients_of_material': value.get('c'),
-        'originating_agency': value.get('b'),
-        'other_restrictions': value.get('g'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'originating_agency': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'other_restrictions': utils.force_list(
+            value.get('g')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -567,16 +541,12 @@ def dates_of_publication_and_or_sequential_designation(self, key, value):
     """Dates of Publication and/or Sequential Designation."""
     indicator_map1 = {"0": "Formatted style", "1": "Unformatted note"}
     return {
-        'dates_of_publication_and_or_sequential_designation': utils.force_list(
-            value.get('a')
+        'dates_of_publication_and_or_sequential_designation': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'source_of_information': utils.force_list(
-            value.get('z')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'source_of_information': value.get('z'),
+        'linkage': value.get('6'),
         'format_of_date': indicator_map1.get(key[3]),
     }
 
@@ -592,59 +562,29 @@ def normalized_date_and_sequential_designation(self, key, value):
         "1": "Ending information"}
     indicator_map2 = {"#": "Not specified", "0": "Closed", "1": "Open"}
     return {
-        'first_level_of_enumeration': utils.force_list(
-            value.get('a')
+        'first_level_of_enumeration': value.get('a'),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
         ),
-        'nonpublic_note': value.get('x'),
-        'third_level_of_enumeration': utils.force_list(
-            value.get('c')
+        'third_level_of_enumeration': value.get('c'),
+        'second_level_of_enumeration': value.get('b'),
+        'fifth_level_of_enumeration': value.get('e'),
+        'fourth_level_of_enumeration': value.get('d'),
+        'alternative_numbering_scheme_first_level_of_enumeration': value.get('g'),
+        'sixth_level_of_enumeration': value.get('f'),
+        'first_level_of_chronology': value.get('i'),
+        'alternative_numbering_scheme_second_level_of_enumeration': value.get('h'),
+        'third_level_of_chronology': value.get('k'),
+        'second_level_of_chronology': value.get('j'),
+        'alternative_numbering_scheme_chronology': value.get('m'),
+        'fourth_level_of_chronology': value.get('l'),
+        'first_level_textual_designation': value.get('u'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': value.get('8'),
+        'public_note': utils.force_list(
+            value.get('z')
         ),
-        'second_level_of_enumeration': utils.force_list(
-            value.get('b')
-        ),
-        'fifth_level_of_enumeration': utils.force_list(
-            value.get('e')
-        ),
-        'fourth_level_of_enumeration': utils.force_list(
-            value.get('d')
-        ),
-        'alternative_numbering_scheme_first_level_of_enumeration': utils.force_list(
-            value.get('g')
-        ),
-        'sixth_level_of_enumeration': utils.force_list(
-            value.get('f')
-        ),
-        'first_level_of_chronology': utils.force_list(
-            value.get('i')
-        ),
-        'alternative_numbering_scheme_second_level_of_enumeration': utils.force_list(
-            value.get('h')
-        ),
-        'third_level_of_chronology': utils.force_list(
-            value.get('k')
-        ),
-        'second_level_of_chronology': utils.force_list(
-            value.get('j')
-        ),
-        'alternative_numbering_scheme_chronology': utils.force_list(
-            value.get('m')
-        ),
-        'fourth_level_of_chronology': utils.force_list(
-            value.get('l')
-        ),
-        'first_level_textual_designation': utils.force_list(
-            value.get('u')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'public_note': value.get('z'),
-        'first_level_of_chronology_issuance': utils.force_list(
-            value.get('v')
-        ),
+        'first_level_of_chronology_issuance': value.get('v'),
         'start_end_designator': indicator_map1.get(key[3]),
         'state_of_issuance': indicator_map2.get(key[4]),
     }
@@ -656,49 +596,23 @@ def normalized_date_and_sequential_designation(self, key, value):
 def trade_price(self, key, value):
     """Trade Price."""
     return {
-        'price_type_code': utils.force_list(
-            value.get('a')
+        'price_type_code': value.get('a'),
+        'currency_code': value.get('c'),
+        'price_amount': value.get('b'),
+        'price_note': value.get('e'),
+        'unit_of_pricing': value.get('d'),
+        'price_effective_until': value.get('g'),
+        'price_effective_from': value.get('f'),
+        'tax_rate_2': value.get('i'),
+        'tax_rate_1': value.get('h'),
+        'marc_country_code': value.get('k'),
+        'iso_country_code': value.get('j'),
+        'identification_of_pricing_entity': value.get('m'),
+        'source_of_price_type_code': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'currency_code': utils.force_list(
-            value.get('c')
-        ),
-        'price_amount': utils.force_list(
-            value.get('b')
-        ),
-        'price_note': utils.force_list(
-            value.get('e')
-        ),
-        'unit_of_pricing': utils.force_list(
-            value.get('d')
-        ),
-        'price_effective_until': utils.force_list(
-            value.get('g')
-        ),
-        'price_effective_from': utils.force_list(
-            value.get('f')
-        ),
-        'tax_rate_2': utils.force_list(
-            value.get('i')
-        ),
-        'tax_rate_1': utils.force_list(
-            value.get('h')
-        ),
-        'marc_country_code': utils.force_list(
-            value.get('k')
-        ),
-        'iso_country_code': utils.force_list(
-            value.get('j')
-        ),
-        'identification_of_pricing_entity': utils.force_list(
-            value.get('m')
-        ),
-        'source_of_price_type_code': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -708,43 +622,21 @@ def trade_price(self, key, value):
 def trade_availability_information(self, key, value):
     """Trade Availability Information."""
     return {
-        'publishers_compressed_title_identification': utils.force_list(
-            value.get('a')
+        'publishers_compressed_title_identification': value.get('a'),
+        'availability_status_code': value.get('c'),
+        'detailed_date_of_publication': value.get('b'),
+        'note': value.get('e'),
+        'expected_next_availability_date': value.get('d'),
+        'date_made_out_of_print': value.get('g'),
+        'publisher_s_discount_category': value.get('f'),
+        'marc_country_code': value.get('k'),
+        'iso_country_code': value.get('j'),
+        'identification_of_agency': value.get('m'),
+        'source_of_availability_status_code': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'availability_status_code': utils.force_list(
-            value.get('c')
-        ),
-        'detailed_date_of_publication': utils.force_list(
-            value.get('b')
-        ),
-        'note': utils.force_list(
-            value.get('e')
-        ),
-        'expected_next_availability_date': utils.force_list(
-            value.get('d')
-        ),
-        'date_made_out_of_print': utils.force_list(
-            value.get('g')
-        ),
-        'publisher_s_discount_category': utils.force_list(
-            value.get('f')
-        ),
-        'marc_country_code': utils.force_list(
-            value.get('k')
-        ),
-        'iso_country_code': utils.force_list(
-            value.get('j')
-        ),
-        'identification_of_agency': utils.force_list(
-            value.get('m')
-        ),
-        'source_of_availability_status_code': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -754,15 +646,17 @@ def trade_availability_information(self, key, value):
 def associated_language(self, key, value):
     """Associated Language."""
     return {
-        'language_code': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'source': utils.force_list(
-            value.get('2')
+        'language_code': utils.force_list(
+            value.get('a')
         ),
-        'language_term': value.get('l'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
+        'source': value.get('2'),
+        'language_term': utils.force_list(
+            value.get('l')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -772,15 +666,17 @@ def associated_language(self, key, value):
 def form_of_work(self, key, value):
     """Form of Work."""
     return {
-        'form_of_work': value.get('a'),
-        'record_control_number': value.get('0'),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'form_of_work': utils.force_list(
+            value.get('a')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'record_control_number': utils.force_list(
+            value.get('0')
         ),
+        'source_of_term': value.get('2'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -792,17 +688,23 @@ def other_distinguishing_characteristics_of_work_or_expression(
         self, key, value):
     """Other Distinguishing Characteristics of Work or Expression."""
     return {
-        'other_distinguishing_characteristic': value.get('a'),
-        'source_of_information': value.get('v'),
-        'record_control_number': value.get('0'),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'other_distinguishing_characteristic': utils.force_list(
+            value.get('a')
         ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'source_of_information': utils.force_list(
+            value.get('v')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_term': value.get('2'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -820,21 +722,35 @@ def medium_of_performance(self, key, value):
         "0": "Not intended for access",
         "1": "Intended for access"}
     return {
-        'medium_of_performance': value.get('a'),
-        'soloist': value.get('b'),
-        'doubling_instrument': value.get('d'),
-        'alternative_medium_of_performance': value.get('p'),
-        'note': value.get('v'),
-        'number_of_performers_of_the_same_medium': value.get('n'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'total_number_of_performers': value.get('s'),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'medium_of_performance': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'soloist': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'doubling_instrument': utils.force_list(
+            value.get('d')
+        ),
+        'alternative_medium_of_performance': utils.force_list(
+            value.get('p')
+        ),
+        'note': utils.force_list(
+            value.get('v')
+        ),
+        'number_of_performers_of_the_same_medium': utils.force_list(
+            value.get('n')
+        ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'total_number_of_performers': utils.force_list(
+            value.get('s')
+        ),
+        'source_of_term': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'display_constant_controller': indicator_map1.get(key[3]),
         'access_control': indicator_map2.get(key[4]),
     }
@@ -846,22 +762,22 @@ def medium_of_performance(self, key, value):
 def numeric_designation_of_musical_work(self, key, value):
     """Numeric Designation of Musical Work."""
     return {
-        'serial_number': value.get('a'),
-        'thematic_index_number': value.get('c'),
-        'opus_number': value.get('b'),
-        'publisher_associated_with_opus_number': utils.force_list(
-            value.get('e')
+        'serial_number': utils.force_list(
+            value.get('a')
         ),
-        'thematic_index_code': utils.force_list(
-            value.get('d')
+        'thematic_index_number': utils.force_list(
+            value.get('c')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'opus_number': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'publisher_associated_with_opus_number': value.get('e'),
+        'thematic_index_code': value.get('d'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -874,13 +790,11 @@ def key(self, key, value):
         "0": "Original key ",
         "1": "Transposed key "}
     return {
-        'key': utils.force_list(
-            value.get('a')
+        'key': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'key_type': indicator_map1.get(key[3]),
     }
 
@@ -891,25 +805,23 @@ def key(self, key, value):
 def audience_characteristics(self, key, value):
     """Audience Characteristics."""
     return {
-        'audience_term': value.get('a'),
-        'audience_code': value.get('b'),
-        'demographic_group_term': utils.force_list(
-            value.get('m')
+        'audience_term': utils.force_list(
+            value.get('a')
         ),
-        'demographic_group_code': utils.force_list(
-            value.get('n')
+        'audience_code': utils.force_list(
+            value.get('b')
         ),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'demographic_group_term': value.get('m'),
+        'demographic_group_code': value.get('n'),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -919,23 +831,21 @@ def audience_characteristics(self, key, value):
 def creator_contributor_characteristics(self, key, value):
     """Creator/Contributor Characteristics."""
     return {
-        'creator_contributor_term': value.get('a'),
-        'creator_contributor_code': value.get('b'),
-        'demographic_group_term': utils.force_list(
-            value.get('m')
+        'creator_contributor_term': utils.force_list(
+            value.get('a')
         ),
-        'demographic_group_code': utils.force_list(
-            value.get('n')
+        'creator_contributor_code': utils.force_list(
+            value.get('b')
         ),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'demographic_group_term': value.get('m'),
+        'demographic_group_code': value.get('n'),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'source': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }

--- a/dojson/contrib/marc21/fields/bd3xx.py
+++ b/dojson/contrib/marc21/fields/bd3xx.py
@@ -213,9 +213,18 @@ def physical_medium(self, key, value):
 def geospatial_reference_data(self, key, value):
     """Geospatial Reference Data."""
     indicator_map1 = {
-        "0": "Horizontal coordinate system", "1": "Vertical coordinate system"}
-    indicator_map2 = {"0": "Geographic", "1": "Map projection", "2": "Grid coordinate system", "3": "Local planar",
-                      "4": "Local", "5": "Geodetic model", "6": "Altitude", "7": "Method specified in $2", "8": "Depth"}
+        "0": "Horizontal coordinate system",
+        "1": "Vertical coordinate system"}
+    indicator_map2 = {
+        "0": "Geographic",
+        "1": "Map projection",
+        "2": "Grid coordinate system",
+        "3": "Local planar",
+        "4": "Local",
+        "5": "Geodetic model",
+        "6": "Altitude",
+        "7": "Method specified in $2",
+        "8": "Depth"}
     return {
         'reference_method_used': utils.force_list(
             value.get('2')
@@ -494,8 +503,14 @@ def digital_graphic_representation(self, key, value):
 @utils.filter_values
 def security_classification_control(self, key, value):
     """Security Classification Control."""
-    indicator_map1 = {"0": "Document", "1": "Title", "2": "Abstract", "3":
-                      "Contents note", "4": "Author", "5": "Record", "8": "None of the above"}
+    indicator_map1 = {
+        "0": "Document",
+        "1": "Title",
+        "2": "Abstract",
+        "3": "Contents note",
+        "4": "Author",
+        "5": "Record",
+        "8": "None of the above"}
     return {
         'security_classification': utils.force_list(
             value.get('a')
@@ -571,8 +586,10 @@ def dates_of_publication_and_or_sequential_designation(self, key, value):
 @utils.filter_values
 def normalized_date_and_sequential_designation(self, key, value):
     """Normalized Date and Sequential Designation."""
-    indicator_map1 = {"#": "No information provided",
-                      "0": "Starting information", "1": "Ending information"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "Starting information",
+        "1": "Ending information"}
     indicator_map2 = {"#": "Not specified", "0": "Closed", "1": "Open"}
     return {
         'first_level_of_enumeration': utils.force_list(
@@ -794,10 +811,14 @@ def other_distinguishing_characteristics_of_work_or_expression(
 @utils.filter_values
 def medium_of_performance(self, key, value):
     """Medium of Performance."""
-    indicator_map1 = {"#": "No information provided", "0":
-                      "Medium of performance", "1": "Partial medium of performance"}
-    indicator_map2 = {"#": "No information provided",
-                      "0": "Not intended for access", "1": "Intended for access"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "Medium of performance",
+        "1": "Partial medium of performance"}
+    indicator_map2 = {
+        "#": "No information provided",
+        "0": "Not intended for access",
+        "1": "Intended for access"}
     return {
         'medium_of_performance': value.get('a'),
         'soloist': value.get('b'),
@@ -848,8 +869,10 @@ def numeric_designation_of_musical_work(self, key, value):
 @utils.filter_values
 def key(self, key, value):
     """Key."""
-    indicator_map1 = {"#": "Relationship to original unknown ",
-                      "0": "Original key ", "1": "Transposed key "}
+    indicator_map1 = {
+        "#": "Relationship to original unknown ",
+        "0": "Original key ",
+        "1": "Transposed key "}
     return {
         'key': utils.force_list(
             value.get('a')

--- a/dojson/contrib/marc21/fields/bd4xx.py
+++ b/dojson/contrib/marc21/fields/bd4xx.py
@@ -24,46 +24,38 @@ def series_statement_added_entry_personal_name(self, key, value):
         "0": "Main entry not represented by pronoun",
         "1": "Main entry represented by pronoun"}
     return {
-        'personal_name': utils.force_list(
-            value.get('a')
+        'personal_name': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'titles_and_other_words_associated_with_a_name': utils.force_list(
+            value.get('c')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'numeration': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'titles_and_other_words_associated_with_a_name': value.get('c'),
-        'numeration': utils.force_list(
-            value.get('b')
+        'dates_associated_with_a_name': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'relator_term': value.get('e'),
-        'dates_associated_with_a_name': utils.force_list(
-            value.get('d')
+        'volume_sequential_designation': value.get('v'),
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'form_subheading': value.get('k'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
-        ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
+        'title_of_a_work': value.get('t'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
@@ -82,44 +74,40 @@ def series_statement_added_entry_corporate_name(self, key, value):
         "0": "Main entry not represented by pronoun",
         "1": "Main entry represented by pronoun"}
     return {
-        'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'subordinate_unit': value.get('b'),
-        'relator_term': value.get('e'),
-        'date_of_meeting_or_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'volume_sequential_designation': value.get('v'),
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'form_subheading': value.get('k'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'affiliation': utils.force_list(
-            value.get('u')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
+        'title_of_a_work': value.get('t'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
@@ -138,48 +126,36 @@ def series_statement_added_entry_meeting_name(self, key, value):
         "0": "Main entry not represented by pronoun",
         "1": "Main entry represented by pronoun"}
     return {
-        'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'date_of_meeting': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'volume_sequential_designation': value.get('v'),
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'subordinate_unit': value.get('e'),
-        'date_of_meeting': utils.force_list(
-            value.get('d')
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'affiliation': value.get('u'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'form_subheading': value.get('k'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
-        ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')
-        ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
+        'title_of_a_work': value.get('t'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
@@ -202,23 +178,25 @@ def series_statement_added_entry_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'title': utils.force_list(
-            value.get('a')
+        'title': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'volume_sequential_designation': value.get('v'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'authority_record_control_number': value.get('0'),
-        'bibliographic_record_control_number': value.get('w'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }
 
@@ -230,18 +208,20 @@ def series_statement(self, key, value):
     """Series Statement."""
     indicator_map1 = {"0": "Series not traced", "1": "Series traced"}
     return {
-        'series_statement': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'series_statement': utils.force_list(
+            value.get('a')
         ),
-        'library_of_congress_call_number': utils.force_list(
-            value.get('l')
+        'international_standard_serial_number': utils.force_list(
+            value.get('x')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'linkage': value.get('6'),
+        'library_of_congress_call_number': value.get('l'),
+        'materials_specified': value.get('3'),
+        'volume_sequential_designation': utils.force_list(
+            value.get('v')
         ),
-        'volume_sequential_designation': value.get('v'),
-        'field_link_and_sequence_number': value.get('8'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'series_tracing_policy': indicator_map1.get(key[3]),
     }

--- a/dojson/contrib/marc21/fields/bd4xx.py
+++ b/dojson/contrib/marc21/fields/bd4xx.py
@@ -20,8 +20,9 @@ from ..model import marc21
 def series_statement_added_entry_personal_name(self, key, value):
     """Series Statement/Added Entry-Personal Name."""
     indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
-    indicator_map2 = {"0": "Main entry not represented by pronoun",
-                      "1": "Main entry represented by pronoun"}
+    indicator_map2 = {
+        "0": "Main entry not represented by pronoun",
+        "1": "Main entry represented by pronoun"}
     return {
         'personal_name': utils.force_list(
             value.get('a')
@@ -77,41 +78,50 @@ def series_statement_added_entry_corporate_name(self, key, value):
         "0": "Inverted name",
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
-    indicator_map2 = {"0": "Main entry not represented by pronoun",
-                      "1": "Main entry represented by pronoun"}
+    indicator_map2 = {
+        "0": "Main entry not represented by pronoun",
+        "1": "Main entry represented by pronoun"}
     return {
         'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'international_standard_serial_number': utils.force_list(
-            value.get('x')),
+            value.get('x')
+        ),
         'location_of_meeting': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'subordinate_unit': value.get('b'),
         'relator_term': value.get('e'),
         'date_of_meeting_or_treaty_signing': value.get('d'),
         'miscellaneous_information': utils.force_list(
-            value.get('g')),
+            value.get('g')
+        ),
         'date_of_a_work': utils.force_list(
-            value.get('f')),
+            value.get('f')
+        ),
         'form_subheading': value.get('k'),
         'volume_sequential_designation': utils.force_list(
-            value.get('v')),
+            value.get('v')
+        ),
         'language_of_a_work': utils.force_list(
-            value.get('l')),
+            value.get('l')
+        ),
         'number_of_part_section_meeting': value.get('n'),
         'name_of_part_section_of_a_work': value.get('p'),
         'affiliation': utils.force_list(
-            value.get('u')),
+            value.get('u')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'title_of_a_work': utils.force_list(
-            value.get('t')),
-        'type_of_corporate_name_entry_element': indicator_map1.get(
-            key[3]),
-        'pronoun_represents_main_entry': indicator_map2.get(
-            key[4]),
+            value.get('t')
+        ),
+        'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
+        'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
 
 
@@ -124,52 +134,73 @@ def series_statement_added_entry_meeting_name(self, key, value):
         "0": "Inverted name",
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
-    indicator_map2 = {"0": "Main entry not represented by pronoun",
-                      "1": "Main entry represented by pronoun"}
+    indicator_map2 = {
+        "0": "Main entry not represented by pronoun",
+        "1": "Main entry represented by pronoun"}
     return {
         'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'international_standard_serial_number': utils.force_list(
-            value.get('x')),
+            value.get('x')
+        ),
         'location_of_meeting': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'subordinate_unit': value.get('e'),
         'date_of_meeting': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'miscellaneous_information': utils.force_list(
-            value.get('g')),
+            value.get('g')
+        ),
         'date_of_a_work': utils.force_list(
-            value.get('f')),
+            value.get('f')
+        ),
         'form_subheading': value.get('k'),
         'volume_sequential_designation': utils.force_list(
-            value.get('v')),
+            value.get('v')
+        ),
         'language_of_a_work': utils.force_list(
-            value.get('l')),
+            value.get('l')
+        ),
         'number_of_part_section_meeting': value.get('n'),
         'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')),
+            value.get('q')
+        ),
         'name_of_part_section_of_a_work': value.get('p'),
         'affiliation': utils.force_list(
-            value.get('u')),
+            value.get('u')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'title_of_a_work': utils.force_list(
-            value.get('t')),
-        'type_of_meeting_name_entry_element': indicator_map1.get(
-            key[3]),
-        'pronoun_represents_main_entry': indicator_map2.get(
-            key[4]),
+            value.get('t')
+        ),
+        'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
+        'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('series_statement_added_entry_title', '^440.[0_]')
+@marc21.over('series_statement_added_entry_title', '^440.[_1032547698]')
 @utils.for_each_value
 @utils.filter_values
 def series_statement_added_entry_title(self, key, value):
     """Series Statement/Added Entry-Title."""
-    indicator_map2 = {"0": "No nonfiling characters"}
+    indicator_map2 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'title': utils.force_list(
             value.get('a')

--- a/dojson/contrib/marc21/fields/bd5xx.py
+++ b/dojson/contrib/marc21/fields/bd5xx.py
@@ -20,19 +20,13 @@ from ..model import marc21
 def general_note(self, key, value):
     """General Note."""
     return {
-        'general_note': utils.force_list(
-            value.get('a')
+        'general_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
     }
 
 
@@ -42,16 +36,12 @@ def general_note(self, key, value):
 def with_note(self, key, value):
     """With Note."""
     return {
-        'with_note': utils.force_list(
-            value.get('a')
+        'with_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
     }
 
 
@@ -61,24 +51,20 @@ def with_note(self, key, value):
 def dissertation_note(self, key, value):
     """Dissertation Note."""
     return {
-        'dissertation_note': utils.force_list(
-            value.get('a')
+        'dissertation_note': value.get('a'),
+        'name_of_granting_institution': value.get('c'),
+        'degree_type': value.get('b'),
+        'year_degree_granted': value.get('d'),
+        'miscellaneous_information': utils.force_list(
+            value.get('g')
         ),
-        'name_of_granting_institution': utils.force_list(
-            value.get('c')
+        'dissertation_identifier': utils.force_list(
+            value.get('o')
         ),
-        'degree_type': utils.force_list(
-            value.get('b')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'year_degree_granted': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
-        'dissertation_identifier': value.get('o'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -88,16 +74,12 @@ def dissertation_note(self, key, value):
 def bibliography_note(self, key, value):
     """Bibliography, Etc. Note."""
     return {
-        'bibliography_note': utils.force_list(
-            value.get('a')
+        'bibliography_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'number_of_references': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'number_of_references': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -113,17 +95,23 @@ def formatted_contents_note(self, key, value):
         "8": "No display constant generated"}
     indicator_map2 = {"#": "Basic", "0": "Enhanced"}
     return {
-        'formatted_contents_note': utils.force_list(
-            value.get('a')
+        'formatted_contents_note': value.get('a'),
+        'miscellaneous_information': utils.force_list(
+            value.get('g')
         ),
-        'miscellaneous_information': value.get('g'),
-        'statement_of_responsibility': value.get('r'),
-        'uniform_resource_identifier': value.get('u'),
-        'title': value.get('t'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'statement_of_responsibility': utils.force_list(
+            value.get('r')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
+        'title': utils.force_list(
+            value.get('t')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'display_constant_controller': indicator_map1.get(key[3]),
         'level_of_content_designation': indicator_map2.get(key[4]),
     }
@@ -139,28 +127,32 @@ def restrictions_on_access_note(self, key, value):
         "0": "No restrictions",
         "1": "Restrictions apply"}
     return {
-        'terms_governing_access': utils.force_list(
-            value.get('a')
+        'terms_governing_access': value.get('a'),
+        'physical_access_provisions': utils.force_list(
+            value.get('c')
         ),
-        'physical_access_provisions': value.get('c'),
-        'jurisdiction': value.get('b'),
-        'authorization': value.get('e'),
-        'authorized_users': value.get('d'),
-        'standardized_terminology_for_access_restriction': value.get('f'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'jurisdiction': utils.force_list(
+            value.get('b')
         ),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'authorization': utils.force_list(
+            value.get('e')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'authorized_users': utils.force_list(
+            value.get('d')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'standardized_terminology_for_access_restriction': utils.force_list(
+            value.get('f')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_resource_identifier': value.get('u'),
+        'materials_specified': value.get('3'),
+        'source_of_term': value.get('2'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'restriction': indicator_map1.get(key[3]),
     }
 
@@ -170,16 +162,12 @@ def restrictions_on_access_note(self, key, value):
 def scale_note_for_graphic_material(self, key, value):
     """Scale Note for Graphic Material."""
     return {
-        'representative_fraction_of_scale_note': utils.force_list(
-            value.get('a')
+        'representative_fraction_of_scale_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'remainder_of_scale_note': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'remainder_of_scale_note': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -189,13 +177,11 @@ def scale_note_for_graphic_material(self, key, value):
 def creation_production_credits_note(self, key, value):
     """Creation/Production Credits Note."""
     return {
-        'creation_production_credits_note': utils.force_list(
-            value.get('a')
+        'creation_production_credits_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -211,26 +197,18 @@ def citation_references_note(self, key, value):
         "3": "Location in source not given",
         "4": "Location in source given"}
     return {
-        'name_of_source': utils.force_list(
-            value.get('a')
+        'name_of_source': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'location_within_source': value.get('c'),
+        'coverage_of_source': value.get('b'),
+        'materials_specified': value.get('3'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'location_within_source': utils.force_list(
-            value.get('c')
-        ),
-        'coverage_of_source': utils.force_list(
-            value.get('b')
-        ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'coverage_location_in_source': indicator_map1.get(key[3]),
     }
 
@@ -242,13 +220,11 @@ def participant_or_performer_note(self, key, value):
     """Participant or Performer Note."""
     indicator_map1 = {"0": "No display constant generated", "1": "Cast"}
     return {
-        'participant_or_performer_note': utils.force_list(
-            value.get('a')
+        'participant_or_performer_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -259,16 +235,12 @@ def participant_or_performer_note(self, key, value):
 def type_of_report_and_period_covered_note(self, key, value):
     """Type of Report and Period Covered Note."""
     return {
-        'type_of_report': utils.force_list(
-            value.get('a')
+        'type_of_report': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'period_covered': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'period_covered': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -277,36 +249,40 @@ def type_of_report_and_period_covered_note(self, key, value):
 def data_quality_note(self, key, value):
     """Data Quality Note."""
     return {
-        'attribute_accuracy_report': utils.force_list(
-            value.get('a')
+        'attribute_accuracy_report': value.get('a'),
+        'attribute_accuracy_explanation': utils.force_list(
+            value.get('c')
         ),
-        'attribute_accuracy_explanation': value.get('c'),
-        'attribute_accuracy_value': value.get('b'),
-        'completeness_report': utils.force_list(
-            value.get('e')
+        'attribute_accuracy_value': utils.force_list(
+            value.get('b')
         ),
-        'logical_consistency_report': utils.force_list(
-            value.get('d')
+        'completeness_report': value.get('e'),
+        'logical_consistency_report': value.get('d'),
+        'horizontal_position_accuracy_value': utils.force_list(
+            value.get('g')
         ),
-        'horizontal_position_accuracy_value': value.get('g'),
-        'horizontal_position_accuracy_report': utils.force_list(
-            value.get('f')
+        'horizontal_position_accuracy_report': value.get('f'),
+        'vertical_positional_accuracy_report': value.get('i'),
+        'horizontal_position_accuracy_explanation': utils.force_list(
+            value.get('h')
         ),
-        'vertical_positional_accuracy_report': utils.force_list(
-            value.get('i')
+        'vertical_positional_accuracy_explanation': utils.force_list(
+            value.get('k')
         ),
-        'horizontal_position_accuracy_explanation': value.get('h'),
-        'vertical_positional_accuracy_explanation': value.get('k'),
-        'vertical_positional_accuracy_value': value.get('j'),
-        'cloud_cover': utils.force_list(
-            value.get('m')
+        'vertical_positional_accuracy_value': utils.force_list(
+            value.get('j')
         ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'cloud_cover': value.get('m'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'display_note': value.get('z'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'display_note': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -316,13 +292,11 @@ def data_quality_note(self, key, value):
 def numbering_peculiarities_note(self, key, value):
     """Numbering Peculiarities Note."""
     return {
-        'numbering_peculiarities_note': utils.force_list(
-            value.get('a')
+        'numbering_peculiarities_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -335,13 +309,11 @@ def type_of_computer_file_or_data_note(self, key, value):
         "#": "Type of file",
         "8": "No display constant generated"}
     return {
-        'type_of_computer_file_or_data_note': utils.force_list(
-            value.get('a')
+        'type_of_computer_file_or_data_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -352,21 +324,27 @@ def type_of_computer_file_or_data_note(self, key, value):
 def date_time_and_place_of_an_event_note(self, key, value):
     """Date/Time and Place of an Event Note."""
     return {
-        'date_time_and_place_of_an_event_note': utils.force_list(
-            value.get('a')
+        'date_time_and_place_of_an_event_note': value.get('a'),
+        'date_of_event': utils.force_list(
+            value.get('d')
         ),
-        'date_of_event': value.get('d'),
-        'place_of_event': value.get('p'),
-        'other_event_information': value.get('o'),
-        'record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'place_of_event': utils.force_list(
+            value.get('p')
         ),
-        'source_of_term': value.get('2'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'other_event_information': utils.force_list(
+            value.get('o')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source_of_term': utils.force_list(
+            value.get('2')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -384,26 +362,18 @@ def summary(self, key, value):
         "4": "Content advice",
         "8": "No display constant generated"}
     return {
-        'summary': utils.force_list(
-            value.get('a')
+        'summary': value.get('a'),
+        'assigning_source': value.get('c'),
+        'expansion_of_summary_note': value.get('b'),
+        'materials_specified': value.get('3'),
+        'source': value.get('2'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'assigning_source': utils.force_list(
-            value.get('c')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'expansion_of_summary_note': utils.force_list(
-            value.get('b')
-        ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'source': utils.force_list(
-            value.get('2')
-        ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -422,17 +392,15 @@ def target_audience_note(self, key, value):
         "4": "Motivation/interest level",
         "8": "No display constant generated"}
     return {
-        'target_audience_note': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'target_audience_note': utils.force_list(
+            value.get('a')
         ),
-        'source': utils.force_list(
-            value.get('b')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'source': value.get('b'),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -446,13 +414,11 @@ def geographic_coverage_note(self, key, value):
         "#": "Geographic coverage",
         "8": "No display constant generated"}
     return {
-        'geographic_coverage_note': utils.force_list(
-            value.get('a')
+        'geographic_coverage_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -464,19 +430,13 @@ def preferred_citation_of_described_materials_note(self, key, value):
     """Preferred Citation of Described Materials Note."""
     indicator_map1 = {"#": "Cite as", "8": "No display constant generated"}
     return {
-        'preferred_citation_of_described_materials_note': utils.force_list(
-            value.get('a')
+        'preferred_citation_of_described_materials_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'source_of_schema_used': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'source_of_schema_used': value.get('2'),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -487,13 +447,11 @@ def preferred_citation_of_described_materials_note(self, key, value):
 def supplement_note(self, key, value):
     """Supplement Note."""
     return {
-        'supplement_note': utils.force_list(
-            value.get('a')
+        'supplement_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -506,30 +464,22 @@ def study_program_information_note(self, key, value):
         "0": "Reading program",
         "8": "No display constant generated"}
     return {
-        'program_name': utils.force_list(
-            value.get('a')
+        'program_name': value.get('a'),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
         ),
-        'nonpublic_note': value.get('x'),
-        'reading_level': utils.force_list(
-            value.get('c')
+        'reading_level': value.get('c'),
+        'interest_level': value.get('b'),
+        'title_point_value': value.get('d'),
+        'display_text': value.get('i'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'interest_level': utils.force_list(
-            value.get('b')
+        'public_note': utils.force_list(
+            value.get('z')
         ),
-        'title_point_value': utils.force_list(
-            value.get('d')
-        ),
-        'display_text': utils.force_list(
-            value.get('i')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'public_note': value.get('z'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -540,26 +490,18 @@ def study_program_information_note(self, key, value):
 def additional_physical_form_available_note(self, key, value):
     """Additional Physical Form Available Note."""
     return {
-        'additional_physical_form_available_note': utils.force_list(
-            value.get('a')
+        'additional_physical_form_available_note': value.get('a'),
+        'availability_conditions': value.get('c'),
+        'availability_source': value.get('b'),
+        'order_number': value.get('d'),
+        'materials_specified': value.get('3'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'availability_conditions': utils.force_list(
-            value.get('c')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'availability_source': utils.force_list(
-            value.get('b')
-        ),
-        'order_number': utils.force_list(
-            value.get('d')
-        ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -569,33 +511,31 @@ def additional_physical_form_available_note(self, key, value):
 def reproduction_note(self, key, value):
     """Reproduction Note."""
     return {
-        'type_of_reproduction': utils.force_list(
-            value.get('a')
+        'type_of_reproduction': value.get('a'),
+        'agency_responsible_for_reproduction': utils.force_list(
+            value.get('c')
         ),
-        'agency_responsible_for_reproduction': value.get('c'),
-        'place_of_reproduction': value.get('b'),
-        'physical_description_of_reproduction': utils.force_list(
-            value.get('e')
+        'place_of_reproduction': utils.force_list(
+            value.get('b')
         ),
-        'date_of_reproduction': utils.force_list(
-            value.get('d')
+        'physical_description_of_reproduction': value.get('e'),
+        'date_of_reproduction': value.get('d'),
+        'series_statement_of_reproduction': utils.force_list(
+            value.get('f')
         ),
-        'series_statement_of_reproduction': value.get('f'),
-        'dates_and_or_sequential_designation_of_issues_reproduced': value.get('m'),
-        'note_about_reproduction': value.get('n'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'dates_and_or_sequential_designation_of_issues_reproduced': utils.force_list(
+            value.get('m')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'note_about_reproduction': utils.force_list(
+            value.get('n')
         ),
-        'fixed_length_data_elements_of_reproduction': utils.force_list(
-            value.get('7')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'fixed_length_data_elements_of_reproduction': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -605,43 +545,37 @@ def reproduction_note(self, key, value):
 def original_version_note(self, key, value):
     """Original Version Note."""
     return {
-        'main_entry_of_original': utils.force_list(
-            value.get('a')
+        'main_entry_of_original': value.get('a'),
+        'international_standard_serial_number': utils.force_list(
+            value.get('x')
         ),
-        'international_standard_serial_number': value.get('x'),
-        'publication_distribution_of_original': utils.force_list(
-            value.get('c')
+        'publication_distribution_of_original': value.get('c'),
+        'edition_statement_of_original': value.get('b'),
+        'physical_description_of_original': value.get('e'),
+        'series_statement_of_original': utils.force_list(
+            value.get('f')
         ),
-        'edition_statement_of_original': utils.force_list(
-            value.get('b')
+        'key_title_of_original': utils.force_list(
+            value.get('k')
         ),
-        'physical_description_of_original': utils.force_list(
-            value.get('e')
+        'material_specific_details': value.get('m'),
+        'location_of_original': value.get('l'),
+        'other_resource_identifier': utils.force_list(
+            value.get('o')
         ),
-        'series_statement_of_original': value.get('f'),
-        'key_title_of_original': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'note_about_original': utils.force_list(
+            value.get('n')
         ),
-        'location_of_original': utils.force_list(
-            value.get('l')
+        'introductory_phrase': value.get('p'),
+        'materials_specified': value.get('3'),
+        'title_statement_of_original': value.get('t'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'other_resource_identifier': value.get('o'),
-        'note_about_original': value.get('n'),
-        'introductory_phrase': utils.force_list(
-            value.get('p')
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'title_statement_of_original': utils.force_list(
-            value.get('t')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'international_standard_book_number': value.get('z'),
     }
 
 
@@ -652,22 +586,22 @@ def location_of_originals_duplicates_note(self, key, value):
     """Location of Originals/Duplicates Note."""
     indicator_map1 = {"1": "Holder of originals", "2": "Holder of duplicates"}
     return {
-        'custodian': utils.force_list(
-            value.get('a')
+        'custodian': value.get('a'),
+        'country': utils.force_list(
+            value.get('c')
         ),
-        'country': value.get('c'),
-        'postal_address': value.get('b'),
-        'telecommunications_address': value.get('d'),
-        'repository_location_code': utils.force_list(
-            value.get('g')
+        'postal_address': utils.force_list(
+            value.get('b')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'telecommunications_address': utils.force_list(
+            value.get('d')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'repository_location_code': value.get('g'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
         'custodial_role': indicator_map1.get(key[3]),
     }
 
@@ -678,20 +612,32 @@ def location_of_originals_duplicates_note(self, key, value):
 def funding_information_note(self, key, value):
     """Funding Information Note."""
     return {
-        'text_of_note': utils.force_list(
-            value.get('a')
+        'text_of_note': value.get('a'),
+        'grant_number': utils.force_list(
+            value.get('c')
         ),
-        'grant_number': value.get('c'),
-        'contract_number': value.get('b'),
-        'program_element_number': value.get('e'),
-        'undifferentiated_number': value.get('d'),
-        'task_number': value.get('g'),
-        'project_number': value.get('f'),
-        'work_unit_number': value.get('h'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'contract_number': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'program_element_number': utils.force_list(
+            value.get('e')
+        ),
+        'undifferentiated_number': utils.force_list(
+            value.get('d')
+        ),
+        'task_number': utils.force_list(
+            value.get('g')
+        ),
+        'project_number': utils.force_list(
+            value.get('f')
+        ),
+        'work_unit_number': utils.force_list(
+            value.get('h')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -701,21 +647,19 @@ def funding_information_note(self, key, value):
 def system_details_note(self, key, value):
     """System Details Note."""
     return {
-        'system_details_note': utils.force_list(
-            value.get('a')
+        'system_details_note': value.get('a'),
+        'display_text': value.get('i'),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'display_text': utils.force_list(
-            value.get('i')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_resource_identifier': value.get('u'),
     }
 
 
@@ -725,29 +669,19 @@ def system_details_note(self, key, value):
 def terms_governing_use_and_reproduction_note(self, key, value):
     """Terms Governing Use and Reproduction Note."""
     return {
-        'terms_governing_use_and_reproduction': utils.force_list(
-            value.get('a')
+        'terms_governing_use_and_reproduction': value.get('a'),
+        'authorization': value.get('c'),
+        'jurisdiction': value.get('b'),
+        'authorized_users': value.get('d'),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'authorization': utils.force_list(
-            value.get('c')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'jurisdiction': utils.force_list(
-            value.get('b')
-        ),
-        'authorized_users': utils.force_list(
-            value.get('d')
-        ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_resource_identifier': value.get('u'),
     }
 
 
@@ -761,39 +695,25 @@ def immediate_source_of_acquisition_note(self, key, value):
         "0": "Private",
         "1": "Not private"}
     return {
-        'source_of_acquisition': utils.force_list(
-            value.get('a')
+        'source_of_acquisition': value.get('a'),
+        'method_of_acquisition': value.get('c'),
+        'address': value.get('b'),
+        'accession_number': value.get('e'),
+        'date_of_acquisition': value.get('d'),
+        'owner': value.get('f'),
+        'purchase_price': value.get('h'),
+        'type_of_unit': utils.force_list(
+            value.get('o')
         ),
-        'method_of_acquisition': utils.force_list(
-            value.get('c')
+        'extent': utils.force_list(
+            value.get('n')
         ),
-        'address': utils.force_list(
-            value.get('b')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'accession_number': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_acquisition': utils.force_list(
-            value.get('d')
-        ),
-        'owner': utils.force_list(
-            value.get('f')
-        ),
-        'purchase_price': utils.force_list(
-            value.get('h')
-        ),
-        'type_of_unit': value.get('o'),
-        'extent': value.get('n'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'privacy': indicator_map1.get(key[3]),
     }
 
@@ -808,57 +728,47 @@ def information_relating_to_copyright_status(self, key, value):
         "0": "Private",
         "1": "Not private"}
     return {
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'personal_creator': value.get('a'),
+        'corporate_creator': value.get('c'),
+        'personal_creator_death_date': value.get('b'),
+        'copyright_holder_contact_information': utils.force_list(
+            value.get('e')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'personal_creator': utils.force_list(
-            value.get('a')
+        'copyright_holder': utils.force_list(
+            value.get('d')
         ),
-        'corporate_creator': utils.force_list(
-            value.get('c')
+        'copyright_date': value.get('g'),
+        'copyright_statement': utils.force_list(
+            value.get('f')
         ),
-        'personal_creator_death_date': utils.force_list(
-            value.get('b')
+        'publication_date': value.get('i'),
+        'copyright_renewal_date': utils.force_list(
+            value.get('h')
         ),
-        'copyright_holder_contact_information': value.get('e'),
-        'copyright_holder': value.get('d'),
-        'copyright_date': utils.force_list(
-            value.get('g')
+        'publisher': utils.force_list(
+            value.get('k')
         ),
-        'copyright_statement': value.get('f'),
-        'publication_date': utils.force_list(
-            value.get('i')
+        'creation_date': value.get('j'),
+        'publication_status': value.get('m'),
+        'copyright_status': value.get('l'),
+        'research_date': value.get('o'),
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'copyright_renewal_date': value.get('h'),
-        'publisher': value.get('k'),
-        'creation_date': utils.force_list(
-            value.get('j')
+        'supplying_agency': value.get('q'),
+        'country_of_publication_or_creation': utils.force_list(
+            value.get('p')
         ),
-        'publication_status': utils.force_list(
-            value.get('m')
+        'source_of_information': value.get('s'),
+        'jurisdiction_of_copyright_assessment': value.get('r'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'copyright_status': utils.force_list(
-            value.get('l')
-        ),
-        'research_date': utils.force_list(
-            value.get('o')
-        ),
-        'note': value.get('n'),
-        'supplying_agency': utils.force_list(
-            value.get('q')
-        ),
-        'country_of_publication_or_creation': value.get('p'),
-        'source_of_information': utils.force_list(
-            value.get('s')
-        ),
-        'jurisdiction_of_copyright_assessment': utils.force_list(
-            value.get('r')
-        ),
-        'uniform_resource_identifier': value.get('u'),
         'privacy': indicator_map1.get(key[3]),
     }
 
@@ -873,19 +783,29 @@ def location_of_other_archival_materials_note(self, key, value):
         "0": "Associated materials",
         "1": "Related materials"}
     return {
-        'custodian': value.get('a'),
-        'country': value.get('c'),
-        'address': value.get('b'),
-        'provenance': value.get('e'),
-        'title': value.get('d'),
-        'note': value.get('n'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'custodian': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'country': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'address': utils.force_list(
+            value.get('b')
+        ),
+        'provenance': utils.force_list(
+            value.get('e')
+        ),
+        'title': utils.force_list(
+            value.get('d')
+        ),
+        'note': utils.force_list(
+            value.get('n')
+        ),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'relationship': indicator_map1.get(key[3]),
     }
 
@@ -900,17 +820,15 @@ def biographical_or_historical_data(self, key, value):
         "0": "Biographical sketch",
         "1": "Administrative history"}
     return {
-        'biographical_or_historical_data': utils.force_list(
-            value.get('a')
+        'biographical_or_historical_data': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'expansion': utils.force_list(
-            value.get('b')
+        'expansion': value.get('b'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'type_of_data': indicator_map1.get(key[3]),
     }
 
@@ -921,17 +839,15 @@ def biographical_or_historical_data(self, key, value):
 def language_note(self, key, value):
     """Language Note."""
     return {
-        'language_note': utils.force_list(
-            value.get('a')
+        'language_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'information_code_or_alphabet': utils.force_list(
+            value.get('b')
         ),
-        'information_code_or_alphabet': value.get('b'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -941,13 +857,11 @@ def language_note(self, key, value):
 def former_title_complexity_note(self, key, value):
     """Former Title Complexity Note."""
     return {
-        'former_title_complexity_note': utils.force_list(
-            value.get('a')
+        'former_title_complexity_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -957,13 +871,11 @@ def former_title_complexity_note(self, key, value):
 def issuing_body_note(self, key, value):
     """Issuing Body Note."""
     return {
-        'issuing_body_note': utils.force_list(
-            value.get('a')
+        'issuing_body_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -973,52 +885,40 @@ def issuing_body_note(self, key, value):
 def entity_and_attribute_information_note(self, key, value):
     """Entity and Attribute Information Note."""
     return {
-        'entity_type_label': utils.force_list(
-            value.get('a')
+        'entity_type_label': value.get('a'),
+        'attribute_label': value.get('c'),
+        'entity_type_definition_and_source': value.get('b'),
+        'enumerated_domain_value': utils.force_list(
+            value.get('e')
         ),
-        'attribute_label': utils.force_list(
-            value.get('c')
+        'attribute_definition_and_source': value.get('d'),
+        'range_domain_minimum_and_maximum': value.get('g'),
+        'enumerated_domain_value_definition_and_source': utils.force_list(
+            value.get('f')
         ),
-        'entity_type_definition_and_source': utils.force_list(
-            value.get('b')
+        'unrepresentable_domain': value.get('i'),
+        'codeset_name_and_source': value.get('h'),
+        'beginning_and_ending_date_of_attribute_values': value.get('k'),
+        'attribute_units_of_measurement_and_resolution': value.get('j'),
+        'attribute_value_accuracy_explanation': value.get('m'),
+        'attribute_value_accuracy': value.get('l'),
+        'entity_and_attribute_overview': utils.force_list(
+            value.get('o')
         ),
-        'enumerated_domain_value': value.get('e'),
-        'attribute_definition_and_source': utils.force_list(
-            value.get('d')
+        'attribute_measurement_frequency': value.get('n'),
+        'entity_and_attribute_detail_citation': utils.force_list(
+            value.get('p')
         ),
-        'range_domain_minimum_and_maximum': utils.force_list(
-            value.get('g')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'enumerated_domain_value_definition_and_source': value.get('f'),
-        'unrepresentable_domain': utils.force_list(
-            value.get('i')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'codeset_name_and_source': utils.force_list(
-            value.get('h')
+        'display_note': utils.force_list(
+            value.get('z')
         ),
-        'beginning_and_ending_date_of_attribute_values': utils.force_list(
-            value.get('k')
-        ),
-        'attribute_units_of_measurement_and_resolution': utils.force_list(
-            value.get('j')
-        ),
-        'attribute_value_accuracy_explanation': utils.force_list(
-            value.get('m')
-        ),
-        'attribute_value_accuracy': utils.force_list(
-            value.get('l')
-        ),
-        'entity_and_attribute_overview': value.get('o'),
-        'attribute_measurement_frequency': utils.force_list(
-            value.get('n')
-        ),
-        'entity_and_attribute_detail_citation': value.get('p'),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'display_note': value.get('z'),
     }
 
 
@@ -1032,24 +932,20 @@ def cumulative_index_finding_aids_note(self, key, value):
         "0": "Finding aids",
         "8": "No display constant generated"}
     return {
-        'cumulative_index_finding_aids_note': utils.force_list(
-            value.get('a')
+        'cumulative_index_finding_aids_note': value.get('a'),
+        'degree_of_control': value.get('c'),
+        'availability_source': utils.force_list(
+            value.get('b')
         ),
-        'degree_of_control': utils.force_list(
-            value.get('c')
+        'bibliographic_reference': value.get('d'),
+        'materials_specified': value.get('3'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'availability_source': value.get('b'),
-        'bibliographic_reference': utils.force_list(
-            value.get('d')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'uniform_resource_identifier': value.get('u'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1063,14 +959,14 @@ def information_about_documentation_note(self, key, value):
         "#": "Documentation",
         "8": "No display constant generated"}
     return {
-        'information_about_documentation_note': utils.force_list(
-            value.get('a')
+        'information_about_documentation_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'international_standard_book_number': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1085,20 +981,16 @@ def ownership_and_custodial_history(self, key, value):
         "0": "Private",
         "1": "Not private"}
     return {
-        'history': utils.force_list(
-            value.get('a')
+        'history': value.get('a'),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_resource_identifier': value.get('u'),
         'privacy': indicator_map1.get(key[3]),
     }
 
@@ -1109,21 +1001,27 @@ def ownership_and_custodial_history(self, key, value):
 def copy_and_version_identification_note(self, key, value):
     """Copy and Version Identification Note."""
     return {
-        'identifying_markings': value.get('a'),
-        'version_identification': value.get('c'),
-        'copy_identification': value.get('b'),
-        'number_of_copies': value.get('e'),
-        'presentation_format': value.get('d'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'identifying_markings': utils.force_list(
+            value.get('a')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'version_identification': utils.force_list(
+            value.get('c')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'copy_identification': utils.force_list(
+            value.get('b')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'number_of_copies': utils.force_list(
+            value.get('e')
+        ),
+        'presentation_format': utils.force_list(
+            value.get('d')
+        ),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -1133,20 +1031,16 @@ def copy_and_version_identification_note(self, key, value):
 def binding_information(self, key, value):
     """Binding Information."""
     return {
-        'binding_note': utils.force_list(
-            value.get('a')
+        'binding_note': value.get('a'),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_resource_identifier': value.get('u'),
     }
 
 
@@ -1160,20 +1054,24 @@ def case_file_characteristics_note(self, key, value):
         "0": "Case file characteristics",
         "8": "No display constant generated"}
     return {
-        'number_of_cases_variables': utils.force_list(
-            value.get('a')
+        'number_of_cases_variables': value.get('a'),
+        'unit_of_analysis': utils.force_list(
+            value.get('c')
         ),
-        'unit_of_analysis': value.get('c'),
-        'name_of_variable': value.get('b'),
-        'filing_scheme_or_code': value.get('e'),
-        'universe_of_data': value.get('d'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'name_of_variable': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'filing_scheme_or_code': utils.force_list(
+            value.get('e')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'universe_of_data': utils.force_list(
+            value.get('d')
+        ),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1185,13 +1083,11 @@ def methodology_note(self, key, value):
     """Methodology Note."""
     indicator_map1 = {"#": "Methodology", "8": "No display constant generated"}
     return {
-        'methodology_note': utils.force_list(
-            value.get('a')
+        'methodology_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1202,13 +1098,11 @@ def methodology_note(self, key, value):
 def linking_entry_complexity_note(self, key, value):
     """Linking Entry Complexity Note."""
     return {
-        'linking_entry_complexity_note': utils.force_list(
-            value.get('a')
+        'linking_entry_complexity_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -1221,17 +1115,15 @@ def publications_about_described_materials_note(self, key, value):
         "#": "Publications",
         "8": "No display constant generated"}
     return {
-        'publications_about_described_materials_note': utils.force_list(
-            value.get('a')
+        'publications_about_described_materials_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'international_standard_book_number': value.get('z'),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1246,37 +1138,59 @@ def action_note(self, key, value):
         "0": "Private",
         "1": "Not private"}
     return {
-        'action': utils.force_list(
-            value.get('a')
+        'action': value.get('a'),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
         ),
-        'nonpublic_note': value.get('x'),
-        'time_date_of_action': value.get('c'),
-        'action_identification': value.get('b'),
-        'contingency_for_action': value.get('e'),
-        'action_interval': value.get('d'),
-        'authorization': value.get('f'),
-        'method_of_action': value.get('i'),
-        'jurisdiction': value.get('h'),
-        'action_agent': value.get('k'),
-        'site_of_action': value.get('j'),
-        'status': value.get('l'),
-        'type_of_unit': value.get('o'),
-        'extent': value.get('n'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'time_date_of_action': utils.force_list(
+            value.get('c')
         ),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'action_identification': utils.force_list(
+            value.get('b')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'contingency_for_action': utils.force_list(
+            value.get('e')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'action_interval': utils.force_list(
+            value.get('d')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'public_note': value.get('z'),
-        'uniform_resource_identifier': value.get('u'),
+        'authorization': utils.force_list(
+            value.get('f')
+        ),
+        'method_of_action': utils.force_list(
+            value.get('i')
+        ),
+        'jurisdiction': utils.force_list(
+            value.get('h')
+        ),
+        'action_agent': utils.force_list(
+            value.get('k')
+        ),
+        'site_of_action': utils.force_list(
+            value.get('j')
+        ),
+        'status': utils.force_list(
+            value.get('l')
+        ),
+        'type_of_unit': utils.force_list(
+            value.get('o')
+        ),
+        'extent': utils.force_list(
+            value.get('n')
+        ),
+        'materials_specified': value.get('3'),
+        'source_of_term': value.get('2'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'privacy': indicator_map1.get(key[3]),
     }
 
@@ -1287,18 +1201,18 @@ def action_note(self, key, value):
 def accumulation_and_frequency_of_use_note(self, key, value):
     """Accumulation and Frequency of Use Note."""
     return {
-        'accumulation': value.get('a'),
-        'frequency_of_use': value.get('b'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'accumulation': utils.force_list(
+            value.get('a')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'frequency_of_use': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -1308,19 +1222,13 @@ def accumulation_and_frequency_of_use_note(self, key, value):
 def exhibitions_note(self, key, value):
     """Exhibitions Note."""
     return {
-        'exhibitions_note': utils.force_list(
-            value.get('a')
+        'exhibitions_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
     }
 
 
@@ -1331,16 +1239,12 @@ def awards_note(self, key, value):
     """Awards Note."""
     indicator_map1 = {"#": "Awards", "8": "No display constant generated"}
     return {
-        'awards_note': utils.force_list(
-            value.get('a')
+        'awards_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'materials_specified': utils.force_list(
-            value.get('3')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
@@ -1351,14 +1255,10 @@ def awards_note(self, key, value):
 def source_of_description_note(self, key, value):
     """Source of Description Note."""
     return {
-        'source_of_description_note': utils.force_list(
-            value.get('a')
+        'source_of_description_note': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
     }

--- a/dojson/contrib/marc21/fields/bd5xx.py
+++ b/dojson/contrib/marc21/fields/bd5xx.py
@@ -134,8 +134,10 @@ def formatted_contents_note(self, key, value):
 @utils.filter_values
 def restrictions_on_access_note(self, key, value):
     """Restrictions on Access Note."""
-    indicator_map1 = {"#": "No information provided",
-                      "0": "No restrictions", "1": "Restrictions apply"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "No restrictions",
+        "1": "Restrictions apply"}
     return {
         'terms_governing_access': utils.force_list(
             value.get('a')
@@ -330,7 +332,8 @@ def numbering_peculiarities_note(self, key, value):
 def type_of_computer_file_or_data_note(self, key, value):
     """Type of Computer File or Data Note."""
     indicator_map1 = {
-        "#": "Type of file", "8": "No display constant generated"}
+        "#": "Type of file",
+        "8": "No display constant generated"}
     return {
         'type_of_computer_file_or_data_note': utils.force_list(
             value.get('a')
@@ -440,7 +443,8 @@ def target_audience_note(self, key, value):
 def geographic_coverage_note(self, key, value):
     """Geographic Coverage Note."""
     indicator_map1 = {
-        "#": "Geographic coverage", "8": "No display constant generated"}
+        "#": "Geographic coverage",
+        "8": "No display constant generated"}
     return {
         'geographic_coverage_note': utils.force_list(
             value.get('a')
@@ -499,7 +503,8 @@ def supplement_note(self, key, value):
 def study_program_information_note(self, key, value):
     """Study Program Information Note."""
     indicator_map1 = {
-        "0": "Reading program", "8": "No display constant generated"}
+        "0": "Reading program",
+        "8": "No display constant generated"}
     return {
         'program_name': utils.force_list(
             value.get('a')
@@ -565,24 +570,31 @@ def reproduction_note(self, key, value):
     """Reproduction Note."""
     return {
         'type_of_reproduction': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'agency_responsible_for_reproduction': value.get('c'),
         'place_of_reproduction': value.get('b'),
         'physical_description_of_reproduction': utils.force_list(
-            value.get('e')),
+            value.get('e')
+        ),
         'date_of_reproduction': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'series_statement_of_reproduction': value.get('f'),
         'dates_and_or_sequential_designation_of_issues_reproduced': value.get('m'),
         'note_about_reproduction': value.get('n'),
         'materials_specified': utils.force_list(
-            value.get('3')),
+            value.get('3')
+        ),
         'institution_to_which_field_applies': utils.force_list(
-            value.get('5')),
+            value.get('5')
+        ),
         'fixed_length_data_elements_of_reproduction': utils.force_list(
-            value.get('7')),
+            value.get('7')
+        ),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
     }
 
@@ -745,7 +757,9 @@ def terms_governing_use_and_reproduction_note(self, key, value):
 def immediate_source_of_acquisition_note(self, key, value):
     """Immediate Source of Acquisition Note."""
     indicator_map1 = {
-        "#": "No information provided", "0": "Private", "1": "Not private"}
+        "#": "No information provided",
+        "0": "Private",
+        "1": "Not private"}
     return {
         'source_of_acquisition': utils.force_list(
             value.get('a')
@@ -790,7 +804,9 @@ def immediate_source_of_acquisition_note(self, key, value):
 def information_relating_to_copyright_status(self, key, value):
     """Information Relating to Copyright Status."""
     indicator_map1 = {
-        "#": "No information provided", "0": "Private", "1": "Not private"}
+        "#": "No information provided",
+        "0": "Private",
+        "1": "Not private"}
     return {
         'materials_specified': utils.force_list(
             value.get('3')
@@ -852,8 +868,10 @@ def information_relating_to_copyright_status(self, key, value):
 @utils.filter_values
 def location_of_other_archival_materials_note(self, key, value):
     """Location of Other Archival Materials Note."""
-    indicator_map1 = {"#": "No information provided",
-                      "0": "Associated materials", "1": "Related materials"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "Associated materials",
+        "1": "Related materials"}
     return {
         'custodian': value.get('a'),
         'country': value.get('c'),
@@ -1042,7 +1060,8 @@ def cumulative_index_finding_aids_note(self, key, value):
 def information_about_documentation_note(self, key, value):
     """Information About Documentation Note."""
     indicator_map1 = {
-        "#": "Documentation", "8": "No display constant generated"}
+        "#": "Documentation",
+        "8": "No display constant generated"}
     return {
         'information_about_documentation_note': utils.force_list(
             value.get('a')
@@ -1062,7 +1081,9 @@ def information_about_documentation_note(self, key, value):
 def ownership_and_custodial_history(self, key, value):
     """Ownership and Custodial History."""
     indicator_map1 = {
-        "#": "No information provided", "0": "Private", "1": "Not private"}
+        "#": "No information provided",
+        "0": "Private",
+        "1": "Not private"}
     return {
         'history': utils.force_list(
             value.get('a')
@@ -1197,7 +1218,8 @@ def linking_entry_complexity_note(self, key, value):
 def publications_about_described_materials_note(self, key, value):
     """Publications About Described Materials Note."""
     indicator_map1 = {
-        "#": "Publications", "8": "No display constant generated"}
+        "#": "Publications",
+        "8": "No display constant generated"}
     return {
         'publications_about_described_materials_note': utils.force_list(
             value.get('a')
@@ -1220,7 +1242,9 @@ def publications_about_described_materials_note(self, key, value):
 def action_note(self, key, value):
     """Action Note."""
     indicator_map1 = {
-        "#": "No information provided", "0": "Private", "1": "Not private"}
+        "#": "No information provided",
+        "0": "Private",
+        "1": "Not private"}
     return {
         'action': utils.force_list(
             value.get('a')

--- a/dojson/contrib/marc21/fields/bd6xx.py
+++ b/dojson/contrib/marc21/fields/bd6xx.py
@@ -118,50 +118,62 @@ def subject_added_entry_corporate_name(self, key, value):
     return {
         'authority_record_control_number': value.get('0'),
         'materials_specified': utils.force_list(
-            value.get('3')),
+            value.get('3')
+        ),
         'source_of_heading_or_term': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
         'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'location_of_meeting': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'subordinate_unit': value.get('b'),
         'relator_term': value.get('e'),
         'date_of_meeting_or_treaty_signing': value.get('d'),
         'miscellaneous_information': utils.force_list(
-            value.get('g')),
+            value.get('g')
+        ),
         'date_of_a_work': utils.force_list(
-            value.get('f')),
+            value.get('f')
+        ),
         'medium': utils.force_list(
-            value.get('h')),
+            value.get('h')
+        ),
         'form_subheading': value.get('k'),
         'medium_of_performance_for_music': value.get('m'),
         'language_of_a_work': utils.force_list(
-            value.get('l')),
+            value.get('l')
+        ),
         'arranged_statement_for_music': utils.force_list(
-            value.get('o')),
+            value.get('o')
+        ),
         'number_of_part_section_meeting': value.get('n'),
         'name_of_part_section_of_a_work': value.get('p'),
         'version': utils.force_list(
-            value.get('s')),
+            value.get('s')
+        ),
         'key_for_music': utils.force_list(
-            value.get('r')),
+            value.get('r')
+        ),
         'affiliation': utils.force_list(
-            value.get('u')),
+            value.get('u')
+        ),
         'title_of_a_work': utils.force_list(
-            value.get('t')),
+            value.get('t')
+        ),
         'form_subdivision': value.get('v'),
         'chronological_subdivision': value.get('y'),
         'general_subdivision': value.get('x'),
         'geographic_subdivision': value.get('z'),
-        'type_of_corporate_name_entry_element': indicator_map1.get(
-            key[3]),
-        'thesaurus': indicator_map2.get(
-            key[4]),
+        'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
+        'thesaurus': indicator_map2.get(key[4]),
     }
 
 
@@ -243,11 +255,23 @@ def subject_added_entry_meeting_name(self, key, value):
     }
 
 
-@marc21.over('subject_added_entry_uniform_title', '^630.[_10325476]')
+@marc21.over(
+    'subject_added_entry_uniform_title', '^630[_1032547698][_10325476]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_uniform_title(self, key, value):
     """Subject Added Entry-Uniform Title."""
+    indicator_map1 = {
+        "0": "Number of nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     indicator_map2 = {
         "0": "Library of Congress Subject Headings",
         "1": "LC subject headings for children\u0027s literature",
@@ -307,6 +331,7 @@ def subject_added_entry_uniform_title(self, key, value):
         'chronological_subdivision': value.get('y'),
         'general_subdivision': value.get('x'),
         'geographic_subdivision': value.get('z'),
+        'nonfiling_characters': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
@@ -358,8 +383,11 @@ def subject_added_entry_chronological_term(self, key, value):
 @utils.filter_values
 def subject_added_entry_topical_term(self, key, value):
     """Subject Added Entry-Topical Term."""
-    indicator_map1 = {"#": "No information provided", "0":
-                      "No level specified", "1": "Primary", "2": "Secondary"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "No level specified",
+        "1": "Primary",
+        "2": "Secondary"}
     indicator_map2 = {
         "0": "Library of Congress Subject Headings",
         "1": "LC subject headings for children\u0027s literature",
@@ -371,31 +399,36 @@ def subject_added_entry_topical_term(self, key, value):
         "7": "Source specified in subfield $2"}
     return {
         'topical_term_or_geographic_name_entry_element': utils.force_list(
-            value.get('a')),
+            value.get('a')
+        ),
         'general_subdivision': value.get('x'),
         'location_of_event': utils.force_list(
-            value.get('c')),
+            value.get('c')
+        ),
         'topical_term_following_geographic_name_entry_element': utils.force_list(
-            value.get('b')),
+            value.get('b')
+        ),
         'relator_term': value.get('e'),
         'active_dates': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'form_subdivision': value.get('v'),
         'authority_record_control_number': value.get('0'),
         'materials_specified': utils.force_list(
-            value.get('3')),
+            value.get('3')
+        ),
         'source_of_heading_or_term': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'chronological_subdivision': value.get('y'),
         'field_link_and_sequence_number': value.get('8'),
         'geographic_subdivision': value.get('z'),
-        'level_of_subject': indicator_map1.get(
-            key[3]),
-        'thesaurus': indicator_map2.get(
-            key[4]),
+        'level_of_subject': indicator_map1.get(key[3]),
+        'thesaurus': indicator_map2.get(key[4]),
     }
 
 
@@ -443,8 +476,11 @@ def subject_added_entry_geographic_name(self, key, value):
 @utils.filter_values
 def index_term_uncontrolled(self, key, value):
     """Index Term-Uncontrolled."""
-    indicator_map1 = {"#": "No information provided", "0":
-                      "No level specified", "1": "Primary", "2": "Secondary"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "No level specified",
+        "1": "Primary",
+        "2": "Secondary"}
     indicator_map2 = {
         "#": "No information provided",
         "0": "Topical term",
@@ -470,8 +506,11 @@ def index_term_uncontrolled(self, key, value):
 @utils.filter_values
 def subject_added_entry_faceted_topical_terms(self, key, value):
     """Subject Added Entry-Faceted Topical Terms."""
-    indicator_map1 = {"#": "No information provided", "0":
-                      "No level specified", "1": "Primary", "2": "Secondary"}
+    indicator_map1 = {
+        "#": "No information provided",
+        "0": "No level specified",
+        "1": "Primary",
+        "2": "Secondary"}
     return {
         'focus_term': value.get('a'),
         'facet_hierarchy_designation': value.get('c'),
@@ -632,18 +671,22 @@ def subject_added_entry_hierarchical_place_name(self, key, value):
         'country_or_larger_entity': value.get('a'),
         'intermediate_political_jurisdiction': value.get('c'),
         'first_order_political_jurisdiction': utils.force_list(
-            value.get('b')),
+            value.get('b')
+        ),
         'relator_term': value.get('e'),
         'city': utils.force_list(
-            value.get('d')),
+            value.get('d')
+        ),
         'other_nonjurisdictional_geographic_region_and_feature': value.get('g'),
         'city_subsection': value.get('f'),
         'extraterrestrial_area': value.get('h'),
         'authority_record_control_number': value.get('0'),
         'source_of_heading_or_term': utils.force_list(
-            value.get('2')),
+            value.get('2')
+        ),
         'relator_code': value.get('4'),
         'linkage': utils.force_list(
-            value.get('6')),
+            value.get('6')
+        ),
         'field_link_and_sequence_number': value.get('8'),
     }

--- a/dojson/contrib/marc21/fields/bd6xx.py
+++ b/dojson/contrib/marc21/fields/bd6xx.py
@@ -30,68 +30,64 @@ def subject_added_entry_personal_name(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'personal_name': utils.force_list(
-            value.get('a')
+        'personal_name': value.get('a'),
+        'titles_and_other_words_associated_with_a_name': utils.force_list(
+            value.get('c')
         ),
-        'titles_and_other_words_associated_with_a_name': value.get('c'),
-        'numeration': utils.force_list(
-            value.get('b')
+        'numeration': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_term': value.get('e'),
-        'dates_associated_with_a_name': utils.force_list(
-            value.get('d')
+        'dates_associated_with_a_name': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'attribution_qualifier': utils.force_list(
+            value.get('j')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'form_subheading': value.get('k'),
-        'attribution_qualifier': value.get('j'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'fuller_form_of_name': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'fuller_form_of_name': utils.force_list(
-            value.get('q')
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'form_subdivision': value.get('v'),
-        'chronological_subdivision': value.get('y'),
-        'general_subdivision': value.get('x'),
-        'geographic_subdivision': value.get('z'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -116,62 +112,62 @@ def subject_added_entry_corporate_name(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'subordinate_unit': value.get('b'),
-        'relator_term': value.get('e'),
-        'date_of_meeting_or_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'affiliation': utils.force_list(
-            value.get('u')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
-        'form_subdivision': value.get('v'),
-        'chronological_subdivision': value.get('y'),
-        'general_subdivision': value.get('x'),
-        'geographic_subdivision': value.get('z'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -196,60 +192,56 @@ def subject_added_entry_meeting_name(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'date_of_meeting': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'subordinate_unit': value.get('e'),
-        'date_of_meeting': utils.force_list(
-            value.get('d')
+        'relator_term': utils.force_list(
+            value.get('j')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'version': value.get('s'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'form_subheading': value.get('k'),
-        'relator_term': value.get('j'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'form_subdivision': value.get('v'),
-        'chronological_subdivision': value.get('y'),
-        'general_subdivision': value.get('x'),
-        'geographic_subdivision': value.get('z'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -282,55 +274,57 @@ def subject_added_entry_uniform_title(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_term': value.get('e'),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'title_of_a_work': value.get('t'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'form_subdivision': value.get('v'),
-        'chronological_subdivision': value.get('y'),
-        'general_subdivision': value.get('x'),
-        'geographic_subdivision': value.get('z'),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'nonfiling_characters': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -355,24 +349,28 @@ def subject_added_entry_chronological_term(self, key, value):
         "6": "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re",
         "7": "Source specified in subfield $2"}
     return {
-        'chronological_term': utils.force_list(
-            value.get('a')
+        'chronological_term': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'type_of_date_or_time_period': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -398,35 +396,37 @@ def subject_added_entry_topical_term(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'topical_term_or_geographic_name_entry_element': utils.force_list(
-            value.get('a')
+        'topical_term_or_geographic_name_entry_element': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'location_of_event': utils.force_list(
-            value.get('c')
+        'location_of_event': value.get('c'),
+        'topical_term_following_geographic_name_entry_element': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'topical_term_following_geographic_name_entry_element': utils.force_list(
-            value.get('b')
+        'active_dates': value.get('d'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'relator_term': value.get('e'),
-        'active_dates': utils.force_list(
-            value.get('d')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'level_of_subject': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -447,26 +447,34 @@ def subject_added_entry_geographic_name(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'geographic_name': utils.force_list(
-            value.get('a')
+        'geographic_name': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'relator_term': value.get('e'),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
+        ),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
@@ -491,11 +499,13 @@ def index_term_uncontrolled(self, key, value):
         "5": "Geographic name",
         "6": "Genre/form term"}
     return {
-        'uncontrolled_term': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'uncontrolled_term': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'linkage': value.get('6'),
         'level_of_index_term': indicator_map1.get(key[3]),
         'type_of_term_or_name': indicator_map2.get(key[4]),
     }
@@ -512,25 +522,39 @@ def subject_added_entry_faceted_topical_terms(self, key, value):
         "1": "Primary",
         "2": "Secondary"}
     return {
-        'focus_term': value.get('a'),
-        'facet_hierarchy_designation': value.get('c'),
-        'non_focus_term': value.get('b'),
-        'relator_term': value.get('e'),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'focus_term': utils.force_list(
+            value.get('a')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'facet_hierarchy_designation': utils.force_list(
+            value.get('c')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'non_focus_term': utils.force_list(
+            value.get('b')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'relator_term': utils.force_list(
+            value.get('e')
+        ),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
+        ),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'level_of_subject': indicator_map1.get(key[3]),
     }
 
@@ -551,29 +575,35 @@ def index_term_genre_form(self, key, value):
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
     return {
-        'genre_form_data_or_focus_term': utils.force_list(
-            value.get('a')
+        'genre_form_data_or_focus_term': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'facet_hierarchy_designation': value.get('c'),
-        'non_focus_term': value.get('b'),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'facet_hierarchy_designation': utils.force_list(
+            value.get('c')
         ),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'non_focus_term': utils.force_list(
+            value.get('b')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'materials_specified': value.get('3'),
+        'source_of_term': value.get('2'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'type_of_heading': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
@@ -585,27 +615,29 @@ def index_term_genre_form(self, key, value):
 def index_term_occupation(self, key, value):
     """Index Term-Occupation."""
     return {
-        'occupation': utils.force_list(
-            value.get('a')
+        'occupation': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'form': utils.force_list(
-            value.get('k')
+        'form': value.get('k'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_term': value.get('2'),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -615,24 +647,28 @@ def index_term_occupation(self, key, value):
 def index_term_function(self, key, value):
     """Index Term-Function."""
     return {
-        'function': utils.force_list(
-            value.get('a')
+        'function': value.get('a'),
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'general_subdivision': value.get('x'),
-        'form_subdivision': value.get('v'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'form_subdivision': utils.force_list(
+            value.get('v')
         ),
-        'source_of_term': utils.force_list(
-            value.get('2')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'materials_specified': value.get('3'),
+        'source_of_term': value.get('2'),
+        'linkage': value.get('6'),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
         ),
-        'chronological_subdivision': value.get('y'),
-        'field_link_and_sequence_number': value.get('8'),
-        'geographic_subdivision': value.get('z'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
     }
 
 
@@ -642,23 +678,17 @@ def index_term_function(self, key, value):
 def index_term_curriculum_objective(self, key, value):
     """Index Term-Curriculum Objective."""
     return {
-        'main_curriculum_objective': utils.force_list(
-            value.get('a')
+        'main_curriculum_objective': value.get('a'),
+        'curriculum_code': value.get('c'),
+        'subordinate_curriculum_objective': utils.force_list(
+            value.get('b')
         ),
-        'curriculum_code': utils.force_list(
-            value.get('c')
+        'correlation_factor': value.get('d'),
+        'source_of_term_or_code': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'subordinate_curriculum_objective': value.get('b'),
-        'correlation_factor': utils.force_list(
-            value.get('d')
-        ),
-        'source_of_term_or_code': utils.force_list(
-            value.get('2')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -668,25 +698,35 @@ def index_term_curriculum_objective(self, key, value):
 def subject_added_entry_hierarchical_place_name(self, key, value):
     """Subject Added Entry-Hierarchical Place Name."""
     return {
-        'country_or_larger_entity': value.get('a'),
-        'intermediate_political_jurisdiction': value.get('c'),
-        'first_order_political_jurisdiction': utils.force_list(
-            value.get('b')
+        'country_or_larger_entity': utils.force_list(
+            value.get('a')
         ),
-        'relator_term': value.get('e'),
-        'city': utils.force_list(
-            value.get('d')
+        'intermediate_political_jurisdiction': utils.force_list(
+            value.get('c')
         ),
-        'other_nonjurisdictional_geographic_region_and_feature': value.get('g'),
-        'city_subsection': value.get('f'),
-        'extraterrestrial_area': value.get('h'),
-        'authority_record_control_number': value.get('0'),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'first_order_political_jurisdiction': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'city': value.get('d'),
+        'other_nonjurisdictional_geographic_region_and_feature': utils.force_list(
+            value.get('g')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'city_subsection': utils.force_list(
+            value.get('f')
+        ),
+        'extraterrestrial_area': utils.force_list(
+            value.get('h')
+        ),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
+        ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }

--- a/dojson/contrib/marc21/fields/bd70x75x.py
+++ b/dojson/contrib/marc21/fields/bd70x75x.py
@@ -22,68 +22,56 @@ def added_entry_personal_name(self, key, value):
     indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'personal_name': utils.force_list(
-            value.get('a')
+        'personal_name': value.get('a'),
+        'titles_and_other_words_associated_with_a_name': utils.force_list(
+            value.get('c')
         ),
-        'titles_and_other_words_associated_with_a_name': value.get('c'),
-        'numeration': utils.force_list(
-            value.get('b')
+        'numeration': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_term': value.get('e'),
-        'dates_associated_with_a_name': utils.force_list(
-            value.get('d')
+        'dates_associated_with_a_name': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'attribution_qualifier': utils.force_list(
+            value.get('j')
         ),
-        'relationship_information': value.get('i'),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'attribution_qualifier': value.get('j'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'fuller_form_of_name': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'fuller_form_of_name': utils.force_list(
-            value.get('q')
-        ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -100,62 +88,54 @@ def added_entry_corporate_name(self, key, value):
         "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'subordinate_unit': value.get('b'),
-        'relator_term': value.get('e'),
-        'date_of_meeting_or_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'relationship_information': value.get('i'),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -172,60 +152,48 @@ def added_entry_meeting_name(self, key, value):
         "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': value.get('5'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'date_of_meeting': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'subordinate_unit': value.get('e'),
-        'date_of_meeting': utils.force_list(
-            value.get('d')
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'relator_term': utils.force_list(
+            value.get('j')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'relationship_information': value.get('i'),
-        'medium': utils.force_list(
-            value.get('h')
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'form_subheading': value.get('k'),
-        'relator_term': value.get('j'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
-        ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')
-        ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'version': value.get('s'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -238,15 +206,17 @@ def added_entry_uncontrolled_name(self, key, value):
     """Added Entry-Uncontrolled Name."""
     indicator_map1 = {"#": "Not specified", "1": "Personal", "2": "Other"}
     return {
-        'name': utils.force_list(
-            value.get('a')
+        'name': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'relator_term': value.get('e'),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
+        'relator_code': utils.force_list(
+            value.get('4')
+        ),
+        'linkage': value.get('6'),
         'type_of_name': indicator_map1.get(key[3]),
     }
 
@@ -269,53 +239,43 @@ def added_entry_uniform_title(self, key, value):
         "9": "Number of nonfiling characters"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'relationship_information': value.get('i'),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'key_for_music': value.get('r'),
+        'institution_to_which_field_applies': value.get('5'),
+        'title_of_a_work': value.get('t'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
+        'version': value.get('s'),
         'nonfiling_characters': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -340,21 +300,19 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
         "9": "Number of nonfiling characters"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
-        'uncontrolled_related_analytical_title': utils.force_list(
-            value.get('a')
+        'uncontrolled_related_analytical_title': value.get('a'),
+        'medium': value.get('h'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'institution_to_which_field_applies': utils.force_list(
-            value.get('5')
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'nonfiling_characters': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -366,22 +324,22 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
 def added_entry_geographic_name(self, key, value):
     """Added Entry-Geographic Name."""
     return {
-        'geographic_name': utils.force_list(
-            value.get('a')
+        'geographic_name': value.get('a'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'relator_term': value.get('e'),
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'materials_specified': value.get('3'),
+        'source_of_heading_or_term': value.get('2'),
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'relator_code': value.get('4'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
     }
 
 
@@ -391,25 +349,31 @@ def added_entry_geographic_name(self, key, value):
 def added_entry_hierarchical_place_name(self, key, value):
     """Added Entry-Hierarchical Place Name."""
     return {
-        'country_or_larger_entity': value.get('a'),
-        'intermediate_political_jurisdiction': value.get('c'),
-        'first_order_political_jurisdiction': utils.force_list(
-            value.get('b')
+        'country_or_larger_entity': utils.force_list(
+            value.get('a')
         ),
-        'city': utils.force_list(
-            value.get('d')
+        'intermediate_political_jurisdiction': utils.force_list(
+            value.get('c')
         ),
-        'other_nonjurisdictional_geographic_region_and_feature': value.get('g'),
-        'city_subsection': value.get('f'),
-        'extraterrestrial_area': value.get('h'),
-        'authority_record_control_number': value.get('0'),
-        'source_of_heading_or_term': utils.force_list(
-            value.get('2')
+        'first_order_political_jurisdiction': value.get('b'),
+        'city': value.get('d'),
+        'other_nonjurisdictional_geographic_region_and_feature': utils.force_list(
+            value.get('g')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'city_subsection': utils.force_list(
+            value.get('f')
         ),
-        'field_link_and_sequence_number': value.get('8'),
+        'extraterrestrial_area': utils.force_list(
+            value.get('h')
+        ),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_heading_or_term': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -419,19 +383,13 @@ def added_entry_hierarchical_place_name(self, key, value):
 def system_details_access_to_computer_files(self, key, value):
     """System Details Access to Computer Files."""
     return {
-        'make_and_model_of_machine': utils.force_list(
-            value.get('a')
+        'make_and_model_of_machine': value.get('a'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'operating_system': utils.force_list(
-            value.get('c')
-        ),
-        'programming_language': utils.force_list(
-            value.get('b')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
+        'operating_system': value.get('c'),
+        'programming_language': value.get('b'),
+        'linkage': value.get('6'),
     }
 
 
@@ -441,17 +399,27 @@ def system_details_access_to_computer_files(self, key, value):
 def added_entry_taxonomic_identification(self, key, value):
     """Added Entry-Taxonomic Identification."""
     return {
-        'taxonomic_name': value.get('a'),
-        'non_public_note': value.get('x'),
-        'taxonomic_category': value.get('c'),
-        'common_or_alternative_name': value.get('d'),
-        'authority_record_control_number': value.get('0'),
-        'source_of_taxonomic_identification': utils.force_list(
-            value.get('2')
+        'taxonomic_name': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'non_public_note': utils.force_list(
+            value.get('x')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'public_note': value.get('z'),
+        'taxonomic_category': utils.force_list(
+            value.get('c')
+        ),
+        'common_or_alternative_name': utils.force_list(
+            value.get('d')
+        ),
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_taxonomic_identification': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
     }

--- a/dojson/contrib/marc21/fields/bd70x75x.py
+++ b/dojson/contrib/marc21/fields/bd70x75x.py
@@ -95,7 +95,9 @@ def added_entry_personal_name(self, key, value):
 def added_entry_corporate_name(self, key, value):
     """Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name", "1": "Jurisdiction name", "2": "Name in direct order"}
+        "0": "Inverted name",
+        "1": "Jurisdiction name",
+        "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
         'authority_record_control_number': value.get('0'),
@@ -165,7 +167,9 @@ def added_entry_corporate_name(self, key, value):
 def added_entry_meeting_name(self, key, value):
     """Added Entry-Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name", "1": "Jurisdiction name", "2": "Name in direct order"}
+        "0": "Inverted name",
+        "1": "Jurisdiction name",
+        "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
         'authority_record_control_number': value.get('0'),
@@ -247,11 +251,22 @@ def added_entry_uncontrolled_name(self, key, value):
     }
 
 
-@marc21.over('added_entry_uniform_title', '^730.[_2]')
+@marc21.over('added_entry_uniform_title', '^730[_1032547698][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uniform_title(self, key, value):
     """Added Entry-Uniform Title."""
+    indicator_map1 = {
+        "0": "Number of nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
         'uniform_title': utils.force_list(
@@ -301,17 +316,28 @@ def added_entry_uniform_title(self, key, value):
         'version': utils.force_list(
             value.get('s')
         ),
+        'nonfiling_characters': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
 
 @marc21.over(
-    'added_entry_uncontrolled_related_analytical_title', '^740[0_][_2]')
+    'added_entry_uncontrolled_related_analytical_title', '^740[_1032547698][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uncontrolled_related_analytical_title(self, key, value):
     """Added Entry-Uncontrolled Related/Analytical Title."""
-    indicator_map1 = {"0": "No nonfiling characters"}
+    indicator_map1 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     return {
         'uncontrolled_related_analytical_title': utils.force_list(

--- a/dojson/contrib/marc21/fields/bd76x78x.py
+++ b/dojson/contrib/marc21/fields/bd76x78x.py
@@ -77,7 +77,8 @@ def subseries_entry(self, key, value):
     """Subseries Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Has subseries", "8": "No display constant generated"}
+        "#": "Has subseries",
+        "8": "No display constant generated"}
     return {
         'main_entry_heading': utils.force_list(
             value.get('a')
@@ -134,7 +135,8 @@ def original_language_entry(self, key, value):
     """Original Language Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Translation of", "8": "No display constant generated"}
+        "#": "Translation of",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -197,7 +199,8 @@ def translation_entry(self, key, value):
     """Translation Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Translated as", "8": "No display constant generated"}
+        "#": "Translated as",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -260,7 +263,8 @@ def supplement_special_issue_entry(self, key, value):
     """Supplement/Special Issue Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Has supplement", "8": "No display constant generated"}
+        "#": "Has supplement",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -456,7 +460,8 @@ def constituent_unit_entry(self, key, value):
     """Constituent Unit Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Constituent unit", "8": "No display constant generated"}
+        "#": "Constituent unit",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -519,7 +524,8 @@ def other_edition_entry(self, key, value):
     """Other Edition Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Other edition available", "8": "No display constant generated"}
+        "#": "Other edition available",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -588,7 +594,8 @@ def additional_physical_form_entry(self, key, value):
     """Additional Physical Form Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Available in another form", "8": "No display constant generated"}
+        "#": "Available in another form",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(
@@ -920,7 +927,8 @@ def other_relationship_entry(self, key, value):
     """Other Relationship Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
-        "#": "Related item", "8": "No display constant generated"}
+        "#": "Related item",
+        "8": "No display constant generated"}
     return {
         'relationship_code': value.get('4'),
         'control_subfield': utils.force_list(

--- a/dojson/contrib/marc21/fields/bd76x78x.py
+++ b/dojson/contrib/marc21/fields/bd76x78x.py
@@ -22,49 +22,39 @@ def main_series_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Main series", "8": "No display constant generated"}
     return {
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'physical_description': value.get('h'),
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'uniform_title': value.get('s'),
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'coden_designation': value.get('y'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'record_control_number': value.get('w'),
-        'uniform_title': utils.force_list(
-            value.get('s')
-        ),
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title': utils.force_list(
-            value.get('t')
-        ),
+        'title': value.get('t'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -80,49 +70,39 @@ def subseries_entry(self, key, value):
         "#": "Has subseries",
         "8": "No display constant generated"}
     return {
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'physical_description': value.get('h'),
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'uniform_title': value.get('s'),
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'coden_designation': value.get('y'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'record_control_number': value.get('w'),
-        'uniform_title': utils.force_list(
-            value.get('s')
-        ),
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title': utils.force_list(
-            value.get('t')
-        ),
+        'title': value.get('t'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -138,55 +118,49 @@ def original_language_entry(self, key, value):
         "#": "Translation of",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -202,55 +176,49 @@ def translation_entry(self, key, value):
         "#": "Translated as",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -266,55 +234,49 @@ def supplement_special_issue_entry(self, key, value):
         "#": "Has supplement",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -331,55 +293,49 @@ def supplement_parent_entry(self, key, value):
         "0": "Parent",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -393,61 +349,51 @@ def host_item_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "In", "8": "No display constant generated"}
     return {
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'enumeration_and_first_page': value.get('q'),
+        'abbreviated_title': value.get('p'),
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'enumeration_and_first_page': utils.force_list(
-            value.get('q')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'abbreviated_title': utils.force_list(
-            value.get('p')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'uniform_title': utils.force_list(
-            value.get('s')
-        ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
-        ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -463,55 +409,49 @@ def constituent_unit_entry(self, key, value):
         "#": "Constituent unit",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -527,61 +467,51 @@ def other_edition_entry(self, key, value):
         "#": "Other edition available",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'language_code': value.get('e'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'country_code': value.get('f'),
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'language_code': utils.force_list(
-            value.get('e')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'related_parts': value.get('g'),
-        'country_code': utils.force_list(
-            value.get('f')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
-        ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
-        ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -597,55 +527,49 @@ def additional_physical_form_entry(self, key, value):
         "#": "Available in another form",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -659,50 +583,42 @@ def issued_with_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Issued with", "8": "No display constant generated"}
     return {
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'international_standard_serial_number': value.get('x'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'record_control_number': value.get('w'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'coden_designation': value.get('y'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
-        ),
-        'linkage': utils.force_list(
-            value.get('6')
-        ),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
-        'title': utils.force_list(
-            value.get('t')
-        ),
+        'title': value.get('t'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -724,55 +640,49 @@ def preceding_entry(self, key, value):
         "6": "Absorbed in part",
         "7": "Separated from"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'type_of_relationship': indicator_map2.get(key[4]),
     }
@@ -795,55 +705,49 @@ def succeeding_entry(self, key, value):
         "7": "Merged with ... to form ...",
         "8": "Changed back to"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'type_of_relationship': indicator_map2.get(key[4]),
     }
@@ -857,64 +761,52 @@ def data_source_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Data source", "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'period_of_content': value.get('j'),
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'period_of_content': utils.force_list(
-            value.get('j')
+        'abbreviated_title': value.get('p'),
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'abbreviated_title': utils.force_list(
-            value.get('p')
+        'source_contribution': value.get('v'),
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'uniform_title': utils.force_list(
-            value.get('s')
-        ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
-        ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'source_contribution': utils.force_list(
-            value.get('v')
-        ),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
@@ -930,55 +822,49 @@ def other_relationship_entry(self, key, value):
         "#": "Related item",
         "8": "No display constant generated"}
     return {
-        'relationship_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'relationship_code': utils.force_list(
+            value.get('4')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'main_entry_heading': utils.force_list(
-            value.get('a')
+        'main_entry_heading': value.get('a'),
+        'qualifying_information': value.get('c'),
+        'edition': value.get('b'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(
+            value.get('g')
         ),
-        'qualifying_information': utils.force_list(
-            value.get('c')
+        'relationship_information': utils.force_list(
+            value.get('i')
         ),
-        'edition': utils.force_list(
-            value.get('b')
+        'physical_description': value.get('h'),
+        'series_data_for_related_item': utils.force_list(
+            value.get('k')
         ),
-        'place_publisher_and_date_of_publication': utils.force_list(
-            value.get('d')
+        'material_specific_details': value.get('m'),
+        'other_item_identifier': utils.force_list(
+            value.get('o')
         ),
-        'related_parts': value.get('g'),
-        'relationship_information': value.get('i'),
-        'physical_description': utils.force_list(
-            value.get('h')
+        'note': utils.force_list(
+            value.get('n')
         ),
-        'series_data_for_related_item': value.get('k'),
-        'material_specific_details': utils.force_list(
-            value.get('m')
+        'uniform_title': value.get('s'),
+        'report_number': utils.force_list(
+            value.get('r')
         ),
-        'other_item_identifier': value.get('o'),
-        'note': value.get('n'),
-        'uniform_title': utils.force_list(
-            value.get('s')
+        'standard_technical_report_number': value.get('u'),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'report_number': value.get('r'),
-        'standard_technical_report_number': utils.force_list(
-            value.get('u')
+        'coden_designation': value.get('y'),
+        'international_standard_serial_number': value.get('x'),
+        'international_standard_book_number': utils.force_list(
+            value.get('z')
         ),
-        'title': utils.force_list(
-            value.get('t')
-        ),
-        'record_control_number': value.get('w'),
-        'coden_designation': utils.force_list(
-            value.get('y')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'international_standard_book_number': value.get('z'),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }

--- a/dojson/contrib/marc21/fields/bd80x83x.py
+++ b/dojson/contrib/marc21/fields/bd80x83x.py
@@ -21,72 +21,60 @@ def series_added_entry_personal_name(self, key, value):
     """Series Added Entry-Personal Name."""
     indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'relator_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'personal_name': utils.force_list(
-            value.get('a')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'titles_and_other_words_associated_with_a_name': value.get('c'),
-        'numeration': utils.force_list(
-            value.get('b')
+        'personal_name': value.get('a'),
+        'titles_and_other_words_associated_with_a_name': utils.force_list(
+            value.get('c')
         ),
-        'relator_term': value.get('e'),
-        'dates_associated_with_a_name': utils.force_list(
-            value.get('d')
+        'numeration': value.get('b'),
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'dates_associated_with_a_name': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'attribution_qualifier': utils.force_list(
+            value.get('j')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'form_subheading': value.get('k'),
-        'attribution_qualifier': value.get('j'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'fuller_form_of_name': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'fuller_form_of_name': utils.force_list(
-            value.get('q')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'bibliographic_record_control_number': value.get('w'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -101,66 +89,58 @@ def series_added_entry_corporate_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'relator_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'corporate_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
         ),
-        'subordinate_unit': value.get('b'),
-        'relator_term': value.get('e'),
-        'date_of_meeting_or_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'relator_term': utils.force_list(
+            value.get('e')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'key_for_music': utils.force_list(
-            value.get('r')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'bibliographic_record_control_number': value.get('w'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -175,64 +155,52 @@ def series_added_entry_meeting_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'relator_code': value.get('4'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'relator_code': utils.force_list(
+            value.get('4')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'meeting_name_or_jurisdiction_name_as_entry_element': utils.force_list(
-            value.get('a')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'location_of_meeting': utils.force_list(
-            value.get('c')
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
         ),
-        'subordinate_unit': value.get('e'),
-        'date_of_meeting': utils.force_list(
-            value.get('d')
+        'date_of_meeting': value.get('d'),
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'relator_term': utils.force_list(
+            value.get('j')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'form_subheading': value.get('k'),
-        'relator_term': value.get('j'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'version': value.get('s'),
+        'affiliation': value.get('u'),
+        'title_of_a_work': value.get('t'),
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'number_of_part_section_meeting': value.get('n'),
-        'name_of_meeting_following_jurisdiction_name_entry_element': utils.force_list(
-            value.get('q')
-        ),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'affiliation': utils.force_list(
-            value.get('u')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'bibliographic_record_control_number': value.get('w'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
     }
 
@@ -254,56 +222,46 @@ def series_added_entry_uniform_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'authority_record_control_number': value.get('0'),
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'authority_record_control_number': utils.force_list(
+            value.get('0')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'control_subfield': utils.force_list(
-            value.get('7')
+        'materials_specified': value.get('3'),
+        'institution_to_which_field_applies': utils.force_list(
+            value.get('5')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'control_subfield': value.get('7'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'uniform_title': utils.force_list(
-            value.get('a')
+        'uniform_title': value.get('a'),
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
         ),
-        'date_of_treaty_signing': value.get('d'),
-        'miscellaneous_information': utils.force_list(
-            value.get('g')
+        'miscellaneous_information': value.get('g'),
+        'date_of_a_work': value.get('f'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
         ),
-        'date_of_a_work': utils.force_list(
-            value.get('f')
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
         ),
-        'medium': utils.force_list(
-            value.get('h')
+        'language_of_a_work': value.get('l'),
+        'arranged_statement_for_music': value.get('o'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
         ),
-        'form_subheading': value.get('k'),
-        'medium_of_performance_for_music': value.get('m'),
-        'language_of_a_work': utils.force_list(
-            value.get('l')
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
         ),
-        'arranged_statement_for_music': utils.force_list(
-            value.get('o')
+        'version': value.get('s'),
+        'key_for_music': value.get('r'),
+        'title_of_a_work': value.get('t'),
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'number_of_part_section_of_a_work': value.get('n'),
-        'name_of_part_section_of_a_work': value.get('p'),
-        'version': utils.force_list(
-            value.get('s')
-        ),
-        'key_for_music': utils.force_list(
-            value.get('r')
-        ),
-        'title_of_a_work': utils.force_list(
-            value.get('t')
-        ),
-        'bibliographic_record_control_number': value.get('w'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'nonfiling_characters': indicator_map2.get(key[4]),
     }

--- a/dojson/contrib/marc21/fields/bd80x83x.py
+++ b/dojson/contrib/marc21/fields/bd80x83x.py
@@ -97,7 +97,9 @@ def series_added_entry_personal_name(self, key, value):
 def series_added_entry_corporate_name(self, key, value):
     """Series Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name", "1": "Jurisdiction name", "2": "Name in direct order"}
+        "0": "Inverted name",
+        "1": "Jurisdiction name",
+        "2": "Name in direct order"}
     return {
         'authority_record_control_number': value.get('0'),
         'materials_specified': utils.force_list(
@@ -169,7 +171,9 @@ def series_added_entry_corporate_name(self, key, value):
 def series_added_entry_meeting_name(self, key, value):
     """Series Added Entry-Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name", "1": "Jurisdiction name", "2": "Name in direct order"}
+        "0": "Inverted name",
+        "1": "Jurisdiction name",
+        "2": "Name in direct order"}
     return {
         'authority_record_control_number': value.get('0'),
         'materials_specified': utils.force_list(
@@ -233,12 +237,22 @@ def series_added_entry_meeting_name(self, key, value):
     }
 
 
-@marc21.over('series_added_entry_uniform_title', '^830.[0_]')
+@marc21.over('series_added_entry_uniform_title', '^830.[_1032547698]')
 @utils.for_each_value
 @utils.filter_values
 def series_added_entry_uniform_title(self, key, value):
     """Series Added Entry-Uniform Title."""
-    indicator_map2 = {"0": "No nonfiling characters"}
+    indicator_map2 = {
+        "0": "No nonfiling characters",
+        "1": "Number of nonfiling characters",
+        "2": "Number of nonfiling characters",
+        "3": "Number of nonfiling characters",
+        "4": "Number of nonfiling characters",
+        "5": "Number of nonfiling characters",
+        "6": "Number of nonfiling characters",
+        "7": "Number of nonfiling characters",
+        "8": "Number of nonfiling characters",
+        "9": "Number of nonfiling characters"}
     return {
         'authority_record_control_number': value.get('0'),
         'materials_specified': utils.force_list(

--- a/dojson/contrib/marc21/fields/bd84188x.py
+++ b/dojson/contrib/marc21/fields/bd84188x.py
@@ -20,8 +20,12 @@ from ..model import marc21
 def holding_institution(self, key, value):
     """Holding Institution."""
     return {
-        'holding_institution': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
+        'holding_institution': utils.force_list(
+            value.get('a')
+        ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
@@ -47,55 +51,57 @@ def location(self, key, value):
         "1": "Primary enumeration",
         "2": "Alternative enumeration"}
     return {
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'source_of_classification_or_shelving_scheme': value.get('2'),
+        'linkage': value.get('6'),
+        'sequence_number': value.get('8'),
+        'location': value.get('a'),
+        'shelving_location': utils.force_list(
+            value.get('c')
         ),
-        'source_of_classification_or_shelving_scheme': utils.force_list(
-            value.get('2')
+        'sublocation_or_collection': utils.force_list(
+            value.get('b')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'address': utils.force_list(
+            value.get('e')
         ),
-        'sequence_number': utils.force_list(
-            value.get('8')
+        'former_shelving_location': utils.force_list(
+            value.get('d')
         ),
-        'location': utils.force_list(
-            value.get('a')
+        'non_coded_location_qualifier': utils.force_list(
+            value.get('g')
         ),
-        'shelving_location': value.get('c'),
-        'sublocation_or_collection': value.get('b'),
-        'address': value.get('e'),
-        'former_shelving_location': value.get('d'),
-        'non_coded_location_qualifier': value.get('g'),
-        'coded_location_qualifier': value.get('f'),
-        'item_part': value.get('i'),
-        'classification_part': utils.force_list(
-            value.get('h')
+        'coded_location_qualifier': utils.force_list(
+            value.get('f')
         ),
-        'call_number_prefix': value.get('k'),
-        'shelving_control_number': utils.force_list(
-            value.get('j')
+        'item_part': utils.force_list(
+            value.get('i')
         ),
-        'call_number_suffix': value.get('m'),
-        'shelving_form_of_title': utils.force_list(
-            value.get('l')
+        'classification_part': value.get('h'),
+        'call_number_prefix': utils.force_list(
+            value.get('k')
         ),
-        'country_code': utils.force_list(
-            value.get('n')
+        'shelving_control_number': value.get('j'),
+        'call_number_suffix': utils.force_list(
+            value.get('m')
         ),
-        'piece_physical_condition': utils.force_list(
-            value.get('q')
+        'shelving_form_of_title': value.get('l'),
+        'country_code': value.get('n'),
+        'piece_physical_condition': value.get('q'),
+        'piece_designation': value.get('p'),
+        'copyright_article_fee_code': utils.force_list(
+            value.get('s')
         ),
-        'piece_designation': utils.force_list(
-            value.get('p')
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'copyright_article_fee_code': value.get('s'),
-        'uniform_resource_identifier': value.get('u'),
-        'copy_number': utils.force_list(
-            value.get('t')
+        'copy_number': value.get('t'),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
         ),
-        'nonpublic_note': value.get('x'),
-        'public_note': value.get('z'),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
         'shelving_scheme': indicator_map1.get(key[3]),
         'shelving_order': indicator_map2.get(key[4]),
     }
@@ -113,58 +119,66 @@ def electronic_location_and_access(self, key, value):
         "2": "Related resource",
         "8": "No display constant generated"}
     return {
-        'materials_specified': utils.force_list(
-            value.get('3')
+        'materials_specified': value.get('3'),
+        'access_method': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'access_method': utils.force_list(
-            value.get('2')
+        'host_name': utils.force_list(
+            value.get('a')
         ),
-        'linkage': utils.force_list(
-            value.get('6')
+        'compression_information': utils.force_list(
+            value.get('c')
         ),
-        'field_link_and_sequence_number': value.get('8'),
-        'host_name': value.get('a'),
-        'compression_information': value.get('c'),
-        'access_number': value.get('b'),
-        'path': value.get('d'),
-        'electronic_name': value.get('f'),
-        'instruction': value.get('i'),
-        'processor_of_request': utils.force_list(
-            value.get('h')
+        'access_number': utils.force_list(
+            value.get('b')
         ),
-        'password': utils.force_list(
-            value.get('k')
+        'path': utils.force_list(
+            value.get('d')
         ),
-        'bits_per_second': utils.force_list(
-            value.get('j')
+        'electronic_name': utils.force_list(
+            value.get('f')
         ),
-        'contact_for_access_assistance': value.get('m'),
-        'logon': utils.force_list(
-            value.get('l')
+        'instruction': utils.force_list(
+            value.get('i')
         ),
-        'operating_system': utils.force_list(
-            value.get('o')
+        'processor_of_request': value.get('h'),
+        'password': value.get('k'),
+        'bits_per_second': value.get('j'),
+        'contact_for_access_assistance': utils.force_list(
+            value.get('m')
         ),
-        'name_of_location_of_host': utils.force_list(
-            value.get('n')
+        'logon': value.get('l'),
+        'operating_system': value.get('o'),
+        'name_of_location_of_host': value.get('n'),
+        'electronic_format_type': value.get('q'),
+        'port': value.get('p'),
+        'file_size': utils.force_list(
+            value.get('s')
         ),
-        'electronic_format_type': utils.force_list(
-            value.get('q')
+        'settings': value.get('r'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
-        'port': utils.force_list(
-            value.get('p')
+        'terminal_emulation': utils.force_list(
+            value.get('t')
         ),
-        'file_size': value.get('s'),
-        'settings': utils.force_list(
-            value.get('r')
+        'record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'uniform_resource_identifier': value.get('u'),
-        'terminal_emulation': value.get('t'),
-        'record_control_number': value.get('w'),
-        'hours_access_method_available': value.get('v'),
-        'link_text': value.get('y'),
-        'nonpublic_note': value.get('x'),
-        'public_note': value.get('z'),
+        'hours_access_method_available': utils.force_list(
+            value.get('v')
+        ),
+        'link_text': utils.force_list(
+            value.get('y')
+        ),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
+        ),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
         'relationship': indicator_map2.get(key[4]),
     }
 
@@ -174,13 +188,19 @@ def electronic_location_and_access(self, key, value):
 def replacement_record_information(self, key, value):
     """Replacement Record Information."""
     return {
-        'replacement_title': value.get('a'),
-        'field_link_and_sequence_number': value.get('8'),
-        'explanatory_text': value.get('i'),
-        'replacement_bibliographic_record_control_number': value.get('w'),
-        'linkage': utils.force_list(
-            value.get('6')
+        'replacement_title': utils.force_list(
+            value.get('a')
         ),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'explanatory_text': utils.force_list(
+            value.get('i')
+        ),
+        'replacement_bibliographic_record_control_number': utils.force_list(
+            value.get('w')
+        ),
+        'linkage': value.get('6'),
     }
 
 
@@ -194,27 +214,21 @@ def machine_generated_metadata_provenance(self, key, value):
         "0": "Fully machine-generated",
         "1": "Partially machine-generated"}
     return {
-        'generation_process': utils.force_list(
-            value.get('a')
+        'generation_process': value.get('a'),
+        'confidence_value': value.get('c'),
+        'generation_date': value.get('d'),
+        'generation_agency': value.get('q'),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
-        'confidence_value': utils.force_list(
-            value.get('c')
+        'uniform_resource_identifier': value.get('u'),
+        'bibliographic_record_control_number': utils.force_list(
+            value.get('w')
         ),
-        'generation_date': utils.force_list(
-            value.get('d')
+        'validity_end_date': value.get('x'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
         ),
-        'generation_agency': utils.force_list(
-            value.get('q')
-        ),
-        'authority_record_control_number_or_standard_number': value.get('0'),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
-        'bibliographic_record_control_number': value.get('w'),
-        'validity_end_date': utils.force_list(
-            value.get('x')
-        ),
-        'field_link_and_sequence_number': value.get('8'),
         'method_of_machine_assignment': indicator_map1.get(key[3]),
     }
 
@@ -225,10 +239,6 @@ def machine_generated_metadata_provenance(self, key, value):
 def non_marc_information_field(self, key, value):
     """Non-MARC Information Field."""
     return {
-        'content_of_non_marc_field': utils.force_list(
-            value.get('a')
-        ),
-        'source_of_data': utils.force_list(
-            value.get('2')
-        ),
+        'content_of_non_marc_field': value.get('a'),
+        'source_of_data': value.get('2'),
     }

--- a/dojson/contrib/marc21/schemas/bd01x09x.json
+++ b/dojson/contrib/marc21/schemas/bd01x09x.json
@@ -5,19 +5,25 @@
             "description": "Library of Congress Control Number",
             "properties": {
                 "lc_control_number": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
-                    "type": "string"
-                },
                 "nucmc_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "canceled_invalid_lc_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -28,40 +34,40 @@
                 "type": "object",
                 "properties": {
                     "number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "type_of_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "status": {
-                        "type": "string"
-                    },
-                    "date": {
-                        "type": "string"
-                    },
-                    "party_to_document": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "date": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "party_to_document": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -73,28 +79,34 @@
                 "type": "object",
                 "properties": {
                     "national_bibliography_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "qualifying_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "canceled_invalid_national_bibliography_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -109,22 +121,22 @@
                         "enum": ["Source specified in subfield $2", "Library and Archives Canada"]
                     },
                     "record_control_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "source": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "canceled_invalid_control_number": {
+                    "source": {
                         "type": "string"
+                    },
+                    "canceled_invalid_control_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -139,43 +151,37 @@
                         "enum": ["Copyright or legal deposit number", "No display constant generated"]
                     },
                     "copyright_or_legal_deposit_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "assigning_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "display_text": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "canceled_invalid_copyright_or_legal_deposit_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -184,16 +190,19 @@
             "description": "Copyright Article-Fee Code",
             "properties": {
                 "copyright_article_fee_code_nr": {
-                    "type": "string"
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -204,31 +213,31 @@
                 "type": "object",
                 "properties": {
                     "international_standard_book_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "terms_of_availability": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
                     },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "canceled_invalid_isbn": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -243,40 +252,40 @@
                         "enum": ["Continuing resource not of international interest", "Continuing resource of international interest", "No level specified"]
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "canceled_issn_l": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "issn_l": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "incorrect_issn": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "incorrect_issn": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "canceled_issn": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -294,43 +303,37 @@
                         "enum": ["No difference", "Difference", "No information provided"]
                     },
                     "standard_number_or_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "terms_of_availability": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "additional_codes_following_the_standard_number_or_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_number_or_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "canceled_invalid_standard_number_or_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -342,10 +345,16 @@
                 "type": "object",
                 "properties": {
                     "overseas_acquisition_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -357,49 +366,40 @@
                 "type": "object",
                 "properties": {
                     "first_and_second_groups_of_characters": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "third_and_fourth_groups_of_characters": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "unparsed_fingerprint": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_volume_or_part": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -411,25 +411,28 @@
                 "type": "object",
                 "properties": {
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "canceled_invalid_number": {
-                        "type": "string"
-                    },
-                    "qualifying_information": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "canceled_invalid_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "qualifying_information": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -447,28 +450,25 @@
                         "enum": ["Note, no added entry", "Note, added entry", "No note, no added entry", "No note, added entry"]
                     },
                     "publisher_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "qualifying_information": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "qualifying_information": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -480,22 +480,22 @@
                 "type": "object",
                 "properties": {
                     "coden": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "canceled_invalid_coden": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "canceled_invalid_coden": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -507,100 +507,88 @@
                 "type": "object",
                 "properties": {
                     "number_of_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_excerpt": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_movement": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "role": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "caption_or_heading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "clef": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "voice_instrument": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "time_signature": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "key_signature": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "musical_notation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coded_validity_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "system_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "text_incipit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "link_text": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "key_or_mode": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "key_or_mode": {
+                        "type": "string"
                     }
                 }
             }
@@ -612,25 +600,19 @@
                 "type": "object",
                 "properties": {
                     "postal_registration_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "source_agency_assigning_number": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "source_agency_assigning_number": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -648,37 +630,52 @@
                         "enum": ["Broadcast ", "Capture ", "No information provided ", "Finding "]
                     },
                     "formatted_date_time": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_classification_subarea_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_classification_area_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "place_of_event": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -696,127 +693,97 @@
                         "enum": ["Not applicable", "Exclusion ring", "Outer ring"]
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "category_of_scale": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "constant_ratio_linear_vertical_scale": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "constant_ratio_linear_horizontal_scale": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coordinates_easternmost_longitude": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coordinates_westernmost_longitude": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coordinates_southernmost_latitude": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coordinates_northernmost_latitude": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "angular_scale": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "declination_southern_limit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "declination_northern_limit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "right_ascension_eastern_limit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "right_ascension_western_limit": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "equinox": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "g_ring_latitude": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "distance_from_earth": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "g_ring_longitude": {
                         "type": "string"
                     },
-                    "ending_date": {
+                    "g_ring_longitude": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "ending_date": {
+                        "type": "string"
                     },
                     "beginning_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_extraterrestrial_body": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -828,22 +795,22 @@
                 "type": "object",
                 "properties": {
                     "system_control_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "canceled_invalid_control_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "canceled_invalid_control_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -852,25 +819,19 @@
             "description": "Original Study Number for Computer Data Files",
             "properties": {
                 "original_study_number": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "source_agency_assigning_number": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
+                "source_agency_assigning_number": {
+                    "type": "string"
+                },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 }
             }
         },
@@ -881,37 +842,43 @@
                 "type": "object",
                 "properties": {
                     "stock_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "terms_of_availability": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_stock_number_acquisition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "additional_format_characteristics": {
-                        "type": "string"
-                    },
-                    "form_of_issue": {
-                        "type": "string"
-                    },
-                    "note": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "form_of_issue": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "note": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -920,19 +887,16 @@
             "description": "Record Content Licensor",
             "properties": {
                 "record_content_licensor": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "linkage": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -940,37 +904,34 @@
             "description": "Cataloging Source",
             "properties": {
                 "original_cataloging_agency": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "transcribing_agency": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "language_of_cataloging": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "description_conventions": {
-                    "type": "string"
-                },
-                "modifying_agency": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "modifying_agency": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
                     "type": "string"
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -984,52 +945,82 @@
                         "enum": ["Item is or includes a translation", "Item not a translation/does not include a\n                  \t\t\t\t\t\ttranslation", "No information provided"]
                     },
                     "language_code_of_text_sound_track_or_separate_title": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_summary_or_abstract": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_librettos": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_sung_or_spoken_text": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_accompanying_material_other_than_librettos": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_table_of_contents": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_original": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_intermediate_translations": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_subtitles_or_captions": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_original_accompanying_materials_other_than_librettos": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_code_of_original_libretto": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1038,7 +1029,10 @@
             "description": "Authentication Code",
             "properties": {
                 "authentication_code": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -1046,28 +1040,43 @@
             "description": "Geographic Area Code",
             "properties": {
                 "geographic_area_code": {
-                    "type": "string"
-                },
-                "iso_code": {
-                    "type": "string"
-                },
-                "local_gac_code": {
-                    "type": "string"
-                },
-                "authority_record_control_number_or_standard_number": {
-                    "type": "string"
-                },
-                "source_of_local_code": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "iso_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "local_gac_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "authority_record_control_number_or_standard_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source_of_local_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
                     "type": "string"
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -1075,25 +1084,37 @@
             "description": "Country of Publishing/Producing Entity Code",
             "properties": {
                 "marc_country_code": {
-                    "type": "string"
-                },
-                "iso_country_code": {
-                    "type": "string"
-                },
-                "local_subentity_code": {
-                    "type": "string"
-                },
-                "source_of_local_subentity_code": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "iso_country_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "local_subentity_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "source_of_local_subentity_code": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
                     "type": "string"
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -1104,22 +1125,31 @@
                     "enum": ["Subfield $b or $c not present", "Range of dates/times", "Single date/time", "Multiple single dates/times"]
                 },
                 "time_period_code": {
-                    "type": "string"
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
-                },
-                "formatted_pre_9999_bc_time_period": {
-                    "type": "string"
-                },
-                "formatted_9999_bc_through_ce_time_period": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "formatted_pre_9999_bc_time_period": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "formatted_9999_bc_through_ce_time_period": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -1130,91 +1160,52 @@
                 "type": "object",
                 "properties": {
                     "type_of_date_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_1_ce_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_1_bc_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_2_ce_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_2_bc_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "beginning_or_single_date_created": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_resource_modified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "beginning_of_date_valid": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "ending_date_created": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "single_or_starting_date_for_aggregated_content": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "end_of_date_valid": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "ending_date_for_aggregated_content": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1226,16 +1217,19 @@
                 "type": "object",
                 "properties": {
                     "form_of_musical_composition_code": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "source_of_code": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_code": {
+                        "type": "string"
                     }
                 }
             }
@@ -1247,19 +1241,25 @@
                 "type": "object",
                 "properties": {
                     "performer_or_ensemble": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "source_of_code": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "soloist": {
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_code": {
                         "type": "string"
+                    },
+                    "soloist": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1277,28 +1277,25 @@
                         "enum": ["Assigned by agency other than LC", "Assigned by LC"]
                     },
                     "classification_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -1310,25 +1307,19 @@
                 "type": "object",
                 "properties": {
                     "classification_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "copy_information": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "copy_information": {
+                        "type": "string"
+                    },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -1340,31 +1331,31 @@
                 "type": "object",
                 "properties": {
                     "geographic_classification_area_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "geographic_classification_subarea_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "populated_place_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "code_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1382,31 +1373,22 @@
                         "enum": ["Other class number assigned by LAC", "Incomplete LC class number assigned by the contributing library", "Incomplete LC class number assigned by LAC", "LC-based call number assigned by LAC", "Other call number assigned by LAC", "Complete LC class number assigned by LAC", "LC-based call number assigned by the contributing library", "Other class number assigned by the contributing library", "Other call number assigned by the contributing library", "Complete LC class number assigned by the contributing library"]
                     },
                     "classification_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "source_of_call_class_number": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "source_of_call_class_number": {
+                        "type": "string"
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -1424,16 +1406,19 @@
                         "enum": ["Assigned by agency other than NLM", "Assigned by NLM"]
                     },
                     "classification_number_r": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "item_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "item_number": {
+                        "type": "string"
                     }
                 }
             }
@@ -1445,22 +1430,22 @@
                 "type": "object",
                 "properties": {
                     "classification_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "copy_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -1469,19 +1454,16 @@
             "description": "Character Sets Present",
             "properties": {
                 "primary_g0_character_set": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "alternate_g0_or_g1_character_set": {
                     "type": "string"
                 },
-                "primary_g1_character_set": {
+                "alternate_g0_or_g1_character_set": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "primary_g1_character_set": {
+                    "type": "string"
                 }
             }
         },
@@ -1495,16 +1477,19 @@
                         "enum": ["Item is not in NAL", "Item is in NAL"]
                     },
                     "classification_number": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number_r": {
-                        "type": "string"
-                    },
-                    "item_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number_r": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "item_number": {
+                        "type": "string"
                     }
                 }
             }
@@ -1516,19 +1501,25 @@
                 "type": "object",
                 "properties": {
                     "classification_number": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "copy_information": {
-                        "type": "string"
-                    },
-                    "item_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "copy_information": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "item_number": {
+                        "type": "string"
                     }
                 }
             }
@@ -1540,28 +1531,25 @@
                 "type": "object",
                 "properties": {
                     "subject_category_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "subject_category_code_subdivision": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "subject_category_code_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1573,16 +1561,19 @@
                 "type": "object",
                 "properties": {
                     "gpo_item_number": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "canceled_invalid_gpo_item_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1597,34 +1588,28 @@
                         "enum": ["Full", "No information provided", "Abridged"]
                     },
                     "universal_decimal_classification_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition_identifier": {
+                        "type": "string"
+                    },
+                    "common_auxiliary_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "common_auxiliary_subdivision": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1642,40 +1627,31 @@
                         "enum": ["Assigned by agency other than LC", "No information provided", "Assigned by LC"]
                     },
                     "classification_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "standard_or_optional_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "assigning_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1690,43 +1666,46 @@
                         "enum": ["Full edition", "Abridged edition", "Other edition specified in subfield $2"]
                     },
                     "classification_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "classification_number_ending_number_of_span": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_or_optional_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "assigning_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "table_sequence_number_for_internal_subarrangement_or_add_table": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "table_sequence_number_for_internal_subarrangement_or_add_table": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "table_identification": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1738,34 +1717,28 @@
                 "type": "object",
                 "properties": {
                     "classification_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "item_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "assigning_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1777,49 +1750,85 @@
                 "type": "object",
                 "properties": {
                     "number_where_instructions_are_found_single_number_or_beginning_number_of_span": {
-                        "type": "string"
-                    },
-                    "classification_number_ending_number_of_span": {
-                        "type": "string"
-                    },
-                    "base_number": {
-                        "type": "string"
-                    },
-                    "facet_designator": {
-                        "type": "string"
-                    },
-                    "number_in_internal_subarrangement_or_add_table_where_instructions_are_found": {
-                        "type": "string"
-                    },
-                    "digits_added_from_classification_number_in_schedule_or_external_table": {
-                        "type": "string"
-                    },
-                    "root_number": {
-                        "type": "string"
-                    },
-                    "number_being_analyzed": {
-                        "type": "string"
-                    },
-                    "digits_added_from_internal_subarrangement_or_add_table": {
-                        "type": "string"
-                    },
-                    "table_identification_internal_subarrangement_or_add_table": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "table_sequence_number_for_internal_subarrangement_or_add_table": {
+                    "classification_number_ending_number_of_span": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "base_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "facet_designator": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "number_in_internal_subarrangement_or_add_table_where_instructions_are_found": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "digits_added_from_classification_number_in_schedule_or_external_table": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "root_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "number_being_analyzed": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "digits_added_from_internal_subarrangement_or_add_table": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "table_identification_internal_subarrangement_or_add_table": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "table_sequence_number_for_internal_subarrangement_or_add_table": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "table_identification": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1831,28 +1840,25 @@
                 "type": "object",
                 "properties": {
                     "classification_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "number_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "canceled_invalid_classification_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "canceled_invalid_classification_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1864,22 +1870,22 @@
                 "type": "object",
                 "properties": {
                     "report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "canceled_invalid_report_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "canceled_invalid_report_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd01x09x.json
+++ b/dojson/contrib/marc21/schemas/bd01x09x.json
@@ -106,7 +106,7 @@
                 "type": "object",
                 "properties": {
                     "national_bibliographic_agency": {
-                        "enum": ["Library and Archives Canada", "Source specified in subfield $2"]
+                        "enum": ["Source specified in subfield $2", "Library and Archives Canada"]
                     },
                     "record_control_number": {
                         "type": "array",
@@ -136,7 +136,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Copyright or legal deposit number"]
+                        "enum": ["Copyright or legal deposit number", "No display constant generated"]
                     },
                     "copyright_or_legal_deposit_number": {
                         "type": "string"
@@ -288,10 +288,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_standard_number_or_code": {
-                        "enum": ["Universal Product Code", "International Standard Recording Code", "International Article Number", "International Standard Music Number", "Serial Item and Contribution Identifier", "Source specified in subfield $2", "Unspecified type of standard number or code"]
+                        "enum": ["International Standard Music Number", "Source specified in subfield $2", "International Standard Recording Code", "International Article Number", "Unspecified type of standard number or code", "Serial Item and Contribution Identifier", "Universal Product Code"]
                     },
                     "difference_indicator": {
-                        "enum": ["Difference", "No difference", "No information provided"]
+                        "enum": ["No difference", "Difference", "No information provided"]
                     },
                     "standard_number_or_code": {
                         "type": "array",
@@ -441,10 +441,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_publisher_number": {
-                        "enum": ["Matrix number", "Issue number", "Other music number", "Plate number", "Other publisher number", "Videorecording number"]
+                        "enum": ["Other music number", "Other publisher number", "Videorecording number", "Matrix number", "Issue number", "Plate number"]
                     },
                     "note_added_entry_controller": {
-                        "enum": ["Note, added entry", "No note, no added entry", "No note, added entry", "Note, no added entry"]
+                        "enum": ["Note, no added entry", "Note, added entry", "No note, no added entry", "No note, added entry"]
                     },
                     "publisher_number": {
                         "type": "array",
@@ -642,7 +642,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_date_in_subfield_a": {
-                        "enum": ["Multiple single dates ", "Single date ", "No date information ", "Range of dates "]
+                        "enum": ["No date information ", "Range of dates ", "Multiple single dates ", "Single date "]
                     },
                     "type_of_event": {
                         "enum": ["Broadcast ", "Capture ", "No information provided ", "Finding "]
@@ -690,10 +690,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_scale": {
-                        "enum": ["Single scale", "Scale indeterminable/No scale recorded", "Range of scales"]
+                        "enum": ["Range of scales", "Single scale", "Scale indeterminable/No scale recorded"]
                     },
                     "type_of_ring": {
-                        "enum": ["Exclusion ring", "Outer ring", "Not applicable"]
+                        "enum": ["Not applicable", "Exclusion ring", "Outer ring"]
                     },
                     "authority_record_control_number_or_standard_number": {
                         "type": "string"
@@ -1101,7 +1101,7 @@
             "description": "Time Period of Content",
             "properties": {
                 "type_of_time_period_in_subfield_b_or_c": {
-                    "enum": ["Multiple single dates/times", "Single date/time", "Subfield $b or $c not present", "Range of dates/times"]
+                    "enum": ["Subfield $b or $c not present", "Range of dates/times", "Single date/time", "Multiple single dates/times"]
                 },
                 "time_period_code": {
                     "type": "string"
@@ -1271,10 +1271,10 @@
                 "type": "object",
                 "properties": {
                     "existence_in_lc_collection": {
-                        "enum": ["Item is not in LC", "Item is in LC", "No information provided"]
+                        "enum": ["Item is not in LC", "No information provided", "Item is in LC"]
                     },
                     "source_of_call_number": {
-                        "enum": ["Assigned by LC", "Assigned by agency other than LC"]
+                        "enum": ["Assigned by agency other than LC", "Assigned by LC"]
                     },
                     "classification_number": {
                         "type": "string"
@@ -1376,10 +1376,10 @@
                 "type": "object",
                 "properties": {
                     "existence_in_lac_collection": {
-                        "enum": ["Work not held by LAC", "Work held by LAC", "Information not provided"]
+                        "enum": ["Information not provided", "Work held by LAC", "Work not held by LAC"]
                     },
                     "type_completeness_source_of_class_call_number": {
-                        "enum": ["Complete LC class number assigned by LAC", "LC-based call number assigned by LAC", "LC-based call number assigned by the contributing library", "Incomplete LC class number assigned by LAC", "Incomplete LC class number assigned by the contributing library", "Complete LC class number assigned by the contributing library", "Other class number assigned by LAC", "Other call number assigned by LAC", "Other class number assigned by the contributing library", "Other call number assigned by the contributing library"]
+                        "enum": ["Other class number assigned by LAC", "Incomplete LC class number assigned by the contributing library", "Incomplete LC class number assigned by LAC", "LC-based call number assigned by LAC", "Other call number assigned by LAC", "Complete LC class number assigned by LAC", "LC-based call number assigned by the contributing library", "Other class number assigned by the contributing library", "Other call number assigned by the contributing library", "Complete LC class number assigned by the contributing library"]
                     },
                     "classification_number": {
                         "type": "array",
@@ -1418,10 +1418,10 @@
                 "type": "object",
                 "properties": {
                     "existence_in_nlm_collection": {
-                        "enum": ["Item is not in NLM", "Item is in NLM", "No information provided"]
+                        "enum": ["Item is not in NLM", "No information provided", "Item is in NLM"]
                     },
                     "source_of_call_number": {
-                        "enum": ["Assigned by NLM", "Assigned by agency other than NLM"]
+                        "enum": ["Assigned by agency other than NLM", "Assigned by NLM"]
                     },
                     "classification_number_r": {
                         "type": "string"
@@ -1594,7 +1594,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_edition": {
-                        "enum": ["Abridged", "Full", "No information provided"]
+                        "enum": ["Full", "No information provided", "Abridged"]
                     },
                     "universal_decimal_classification_number": {
                         "type": "array",
@@ -1636,10 +1636,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_edition": {
-                        "enum": ["Abridged edition", "Full edition", "Other edition specified in subfield $2"]
+                        "enum": ["Full edition", "Abridged edition", "Other edition specified in subfield $2"]
                     },
                     "source_of_classification_number": {
-                        "enum": ["Assigned by LC", "No information provided", "Assigned by agency other than LC"]
+                        "enum": ["Assigned by agency other than LC", "No information provided", "Assigned by LC"]
                     },
                     "classification_number": {
                         "type": "string"
@@ -1687,7 +1687,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_edition": {
-                        "enum": ["Abridged edition", "Full edition", "Other edition specified in subfield $2"]
+                        "enum": ["Full edition", "Abridged edition", "Other edition specified in subfield $2"]
                     },
                     "classification_number": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd1xx.json
+++ b/dojson/contrib/marc21/schemas/bd1xx.json
@@ -8,91 +8,88 @@
                     "enum": ["Family name", "Surname", "Forename"]
                 },
                 "personal_name": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "titles_and_words_associated_with_a_name": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "numeration": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "relator_term": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "dates_associated_with_a_name": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "attribution_qualifier": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "number_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "fuller_form_of_name": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "authority_record_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "affiliation": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "relator_code": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "title_of_a_work": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "title_of_a_work": {
+                    "type": "string"
                 }
             }
         },
@@ -103,79 +100,82 @@
                     "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                 },
                 "corporate_name_or_jurisdiction_name_as_entry_element": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "location_of_meeting": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "subordinate_unit": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "relator_term": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "date_of_meeting_or_treaty_signing": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "number_of_part_section_meeting": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "authority_record_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "affiliation": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "relator_code": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number_r": {
                     "type": "string"
                 },
-                "title_of_a_work": {
+                "field_link_and_sequence_number_r": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "title_of_a_work": {
+                    "type": "string"
                 }
             }
         },
@@ -186,88 +186,82 @@
                     "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                 },
                 "meeting_name_or_jurisdiction_name_as_entry_element": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "location_of_meeting": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "subordinate_unit": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "date_of_meeting": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "relator_term": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "number_of_part_section_meeting": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name_of_meeting_following_jurisdiction_name_entry_element": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "authority_record_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "affiliation": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "relator_code": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "title_of_a_work": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "title_of_a_work": {
+                    "type": "string"
                 }
             }
         },
@@ -278,85 +272,76 @@
                     "enum": ["Number of nonfiling characters"]
                 },
                 "uniform_title": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "date_of_treaty_signing": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "medium": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "medium_of_performance_for_music": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "arranged_statement_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "number_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "authority_record_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "version": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "key_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "title_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "linkage": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
                 }
             }
         }

--- a/dojson/contrib/marc21/schemas/bd1xx.json
+++ b/dojson/contrib/marc21/schemas/bd1xx.json
@@ -5,7 +5,7 @@
             "description": "Main Entry-Personal Name",
             "properties": {
                 "type_of_personal_name_entry_element": {
-                    "enum": ["Surname", "Forename", "Family name"]
+                    "enum": ["Family name", "Surname", "Forename"]
                 },
                 "personal_name": {
                     "type": "array",
@@ -100,7 +100,7 @@
             "description": "Main Entry-Corporate Name",
             "properties": {
                 "type_of_corporate_name_entry_element": {
-                    "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                    "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                 },
                 "corporate_name_or_jurisdiction_name_as_entry_element": {
                     "type": "array",
@@ -183,7 +183,7 @@
             "description": "Main Entry-Meeting Name",
             "properties": {
                 "type_of_meeting_name_entry_element": {
-                    "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                    "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                 },
                 "meeting_name_or_jurisdiction_name_as_entry_element": {
                     "type": "array",
@@ -274,6 +274,9 @@
         "main_entry_uniform_title": {
             "description": "Main Entry-Uniform Title",
             "properties": {
+                "nonfiling_characters": {
+                    "enum": ["Number of nonfiling characters"]
+                },
                 "uniform_title": {
                     "type": "array",
                     "items": {

--- a/dojson/contrib/marc21/schemas/bd20x24x.json
+++ b/dojson/contrib/marc21/schemas/bd20x24x.json
@@ -47,7 +47,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters"]
+                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "key_title": {
                         "type": "array",
@@ -78,6 +78,9 @@
             "properties": {
                 "uniform_title_printed_or_displayed": {
                     "enum": ["Printed or displayed", "Not printed or displayed"]
+                },
+                "nonfiling_characters": {
+                    "enum": ["Number of nonfiling characters"]
                 },
                 "uniform_title": {
                     "type": "array",
@@ -166,7 +169,7 @@
                         "enum": ["Added entry", "No added entry"]
                     },
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters"]
+                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "title": {
                         "type": "array",
@@ -221,6 +224,9 @@
             "properties": {
                 "uniform_title_printed_or_displayed": {
                     "enum": ["Printed or displayed", "Not printed or displayed"]
+                },
+                "nonfiling_characters": {
+                    "enum": ["Number of nonfiling characters"]
                 },
                 "uniform_title": {
                     "type": "array",
@@ -303,7 +309,7 @@
                     "enum": ["Added entry", "No added entry"]
                 },
                 "nonfiling_characters": {
-                    "enum": ["No nonfiling characters"]
+                    "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                 },
                 "title": {
                     "type": "array",
@@ -374,10 +380,10 @@
                 "type": "object",
                 "properties": {
                     "note_added_entry_controller": {
-                        "enum": ["Note, added entry", "Note, no added entry", "No note, added entry", "No note, no added entry"]
+                        "enum": ["Note, added entry", "No note, no added entry", "No note, added entry", "Note, no added entry"]
                     },
                     "type_of_title": {
-                        "enum": ["No type specified", "Parallel title", "Portion of title", "Other title", "Distinctive title", "Added title page title", "Cover title", "Running title", "Caption title", "Spine title"]
+                        "enum": ["Portion of title", "Added title page title", "Other title", "Caption title", "No type specified", "Cover title", "Parallel title", "Running title", "Spine title", "Distinctive title"]
                     },
                     "title_proper_short_title": {
                         "type": "array",

--- a/dojson/contrib/marc21/schemas/bd20x24x.json
+++ b/dojson/contrib/marc21/schemas/bd20x24x.json
@@ -14,28 +14,25 @@
                         "enum": ["Other abbreviated title", "Abbreviated key title"]
                     },
                     "abbreviated_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -50,25 +47,19 @@
                         "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "key_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "qualifying_information": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "qualifying_information": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -83,79 +74,73 @@
                     "enum": ["Number of nonfiling characters"]
                 },
                 "uniform_title": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "date_of_treaty_signing": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "medium": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "medium_of_performance_for_music": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "arranged_statement_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "number_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "authority_record_control_number": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "version": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "key_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "linkage": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
                 }
             }
         },
@@ -172,49 +157,40 @@
                         "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "statement_of_responsibility": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "remainder_of_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "language_code_of_translated_title": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -229,76 +205,67 @@
                     "enum": ["Number of nonfiling characters"]
                 },
                 "uniform_title": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_treaty_signing": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "miscellaneous_information": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "medium": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form_subheading": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "medium_of_performance_for_music": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "language_of_a_work": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "arranged_statement_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "number_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "version": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "key_for_music": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "linkage": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
                 }
             }
         },
@@ -312,64 +279,52 @@
                     "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                 },
                 "title": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "statement_of_responsibility": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "remainder_of_title": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "bulk_dates": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "inclusive_dates": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "medium": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "form": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "number_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "name_of_part_section_of_a_work": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "version": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "linkage": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
                 }
             }
         },
@@ -386,61 +341,46 @@
                         "enum": ["Portion of title", "Added title page title", "Other title", "Caption title", "No type specified", "Cover title", "Parallel title", "Running title", "Spine title", "Distinctive title"]
                     },
                     "title_proper_short_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "remainder_of_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_or_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "display_text": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -458,55 +398,43 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "remainder_of_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_or_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
-                    },
-                    "name_of_part_section_of_a_work": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "name_of_part_section_of_a_work": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd25x28x.json
+++ b/dojson/contrib/marc21/schemas/bd25x28x.json
@@ -201,7 +201,7 @@
                 "type": "object",
                 "properties": {
                     "sequence_of_publishing_statements": {
-                        "enum": ["Not applicable/No information provided/Earliest available publisher", "Intervening publisher", "Current/latest publisher"]
+                        "enum": ["Intervening publisher", "Current/latest publisher", "Not applicable/No information provided/Earliest available publisher"]
                     },
                     "place_of_publication_distribution": {
                         "type": "string"
@@ -339,10 +339,10 @@
                 "type": "object",
                 "properties": {
                     "sequence_of_statements": {
-                        "enum": ["Not applicable/No information provided/Earliest", "Intervening", "Current/latest"]
+                        "enum": ["Intervening", "Current/latest", "Not applicable/No information provided/Earliest"]
                     },
                     "function_of_entity": {
-                        "enum": ["Publication", "Production", "Manufacture", "Distribution", "Copyright notice date"]
+                        "enum": ["Manufacture", "Distribution", "Production", "Publication", "Copyright notice date"]
                     },
                     "place_of_production_publication_distribution_manufacture": {
                         "type": "string"
@@ -378,7 +378,7 @@
                 "type": "object",
                 "properties": {
                     "level": {
-                        "enum": ["Primary", "No level specified", "Secondary"]
+                        "enum": ["No level specified", "Primary", "Secondary"]
                     },
                     "address": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd25x28x.json
+++ b/dojson/contrib/marc21/schemas/bd25x28x.json
@@ -8,31 +8,22 @@
                 "type": "object",
                 "properties": {
                     "edition_statement": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "materials_specified": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "materials_specified": {
+                        "type": "string"
                     },
                     "remainder_of_edition_statement": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -41,19 +32,16 @@
             "description": "Musical Presentation Statement",
             "properties": {
                 "musical_presentation_statement": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "linkage": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -64,55 +52,34 @@
                 "type": "object",
                 "properties": {
                     "statement_of_scale": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "statement_of_coordinates": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "statement_of_projection": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "statement_of_equinox": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "statement_of_zone": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "exclusion_g_ring_coordinate_pairs": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "outer_g_ring_coordinate_pairs": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -121,19 +88,16 @@
             "description": "Computer File Characteristics",
             "properties": {
                 "computer_file_characteristics": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "linkage": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -144,22 +108,22 @@
                 "type": "object",
                 "properties": {
                     "country_of_producing_entity": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -171,25 +135,19 @@
                 "type": "object",
                 "properties": {
                     "issuing_jurisdiction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "denomination": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "denomination": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -204,37 +162,52 @@
                         "enum": ["Intervening publisher", "Current/latest publisher", "Not applicable/No information provided/Earliest available publisher"]
                     },
                     "place_of_publication_distribution": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_publication_distribution": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_publisher_distributor": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "place_of_manufacture": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_manufacture": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "manufacturer": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -243,28 +216,43 @@
             "description": "Imprint Statement for Films (Pre-AACR 1 Revised)",
             "properties": {
                 "producing_company": {
-                    "type": "string"
-                },
-                "releasing_company": {
-                    "type": "string"
-                },
-                "contractual_producer": {
-                    "type": "string"
-                },
-                "date_of_production_release": {
-                    "type": "string"
-                },
-                "place_of_production_release": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "releasing_company": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "contractual_producer": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "date_of_production_release": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "place_of_production_release": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
                     "type": "string"
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -272,43 +260,28 @@
             "description": "Imprint Statement for Sound Recordings (Pre-AACR 1)",
             "properties": {
                 "place_of_production_release": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "date_of_production_release": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "publisher_or_trade_name": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "serial_identification": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "matrix_and_or_take_number": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "linkage": {
+                    "type": "string"
+                },
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
                 }
             }
         },
@@ -316,19 +289,16 @@
             "description": "Projected Publication Date",
             "properties": {
                 "projected_publication_date": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "linkage": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -345,28 +315,34 @@
                         "enum": ["Manufacture", "Distribution", "Production", "Publication", "Copyright notice date"]
                     },
                     "place_of_production_publication_distribution_manufacture": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_production_publication_distribution_manufacture_or_copyright_notice": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_producer_publisher_distributor_manufacturer": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -381,94 +357,103 @@
                         "enum": ["No level specified", "Primary", "Secondary"]
                     },
                     "address": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "state_or_province": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "city": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "postal_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attention_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "terms_preceding_attention_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "type_of_address": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attention_position": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "telephone_number": {
-                        "type": "string"
-                    },
-                    "specialized_telephone_number": {
-                        "type": "string"
-                    },
-                    "electronic_mail_address": {
-                        "type": "string"
-                    },
-                    "fax_number": {
-                        "type": "string"
-                    },
-                    "tdd_or_tty_number": {
-                        "type": "string"
-                    },
-                    "title_of_contact_person": {
-                        "type": "string"
-                    },
-                    "contact_person": {
-                        "type": "string"
-                    },
-                    "hours": {
-                        "type": "string"
-                    },
-                    "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "specialized_telephone_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "electronic_mail_address": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "fax_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "tdd_or_tty_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "title_of_contact_person": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "contact_person": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "hours": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "relator_code": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
                     },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd3xx.json
+++ b/dojson/contrib/marc21/schemas/bd3xx.json
@@ -73,7 +73,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Hours"]
+                        "enum": ["Hours", "No display constant generated"]
                     },
                     "hours": {
                         "type": "array",
@@ -345,7 +345,7 @@
                         "enum": ["Vertical coordinate system", "Horizontal coordinate system"]
                     },
                     "geospatial_reference_method": {
-                        "enum": ["Map projection", "Geographic", "Local planar", "Grid coordinate system", "Geodetic model", "Local", "Method specified in $2", "Altitude", "Depth"]
+                        "enum": ["Map projection", "Method specified in $2", "Altitude", "Depth", "Geodetic model", "Geographic", "Local", "Local planar", "Grid coordinate system"]
                     },
                     "reference_method_used": {
                         "type": "array",
@@ -864,7 +864,7 @@
                 "type": "object",
                 "properties": {
                     "controlled_element": {
-                        "enum": ["Title", "Document", "Contents note", "Abstract", "Record", "Author", "None of the above"]
+                        "enum": ["Contents note", "Author", "Abstract", "Title", "Record", "Document", "None of the above"]
                     },
                     "security_classification": {
                         "type": "array",
@@ -995,7 +995,7 @@
                         "enum": ["Ending information", "Starting information", "No information provided"]
                     },
                     "state_of_issuance": {
-                        "enum": ["Open", "Closed", "Not specified"]
+                        "enum": ["Not specified", "Open", "Closed"]
                     },
                     "first_level_of_enumeration": {
                         "type": "array",
@@ -1391,10 +1391,10 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Partial medium of performance", "Medium of performance", "No information provided"]
+                        "enum": ["No information provided", "Partial medium of performance", "Medium of performance"]
                     },
                     "access_control": {
-                        "enum": ["Intended for access", "Not intended for access", "No information provided"]
+                        "enum": ["No information provided", "Intended for access", "Not intended for access"]
                     },
                     "medium_of_performance": {
                         "type": "string"
@@ -1487,7 +1487,7 @@
             "description": "Key",
             "properties": {
                 "key_type": {
-                    "enum": ["Transposed key ", "Original key ", "Relationship to original unknown "]
+                    "enum": ["Original key ", "Transposed key ", "Relationship to original unknown "]
                 },
                 "key": {
                     "type": "array",

--- a/dojson/contrib/marc21/schemas/bd3xx.json
+++ b/dojson/contrib/marc21/schemas/bd3xx.json
@@ -8,43 +8,46 @@
                 "type": "object",
                 "properties": {
                     "extent": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dimensions": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "other_physical_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "accompanying_material": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "size_of_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "type_of_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -53,16 +56,19 @@
             "description": "Playing Time",
             "properties": {
                 "playing_time": {
-                    "type": "string"
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -76,25 +82,19 @@
                         "enum": ["Hours", "No display constant generated"]
                     },
                     "hours": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "additional_information": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "additional_information": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -103,25 +103,19 @@
             "description": "Current Publication Frequency",
             "properties": {
                 "current_publication_frequency": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "date_of_current_publication_frequency": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
+                "date_of_current_publication_frequency": {
+                    "type": "string"
+                },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 }
             }
         },
@@ -132,25 +126,19 @@
                 "type": "object",
                 "properties": {
                     "former_publication_frequency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "dates_of_former_publication_frequency": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "dates_of_former_publication_frequency": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -162,31 +150,31 @@
                 "type": "object",
                 "properties": {
                     "content_type_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "content_type_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -198,31 +186,31 @@
                 "type": "object",
                 "properties": {
                     "media_type_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "media_type_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -234,31 +222,31 @@
                 "type": "object",
                 "properties": {
                     "carrier_type_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "carrier_type_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -270,67 +258,103 @@
                 "type": "object",
                 "properties": {
                     "material_base_and_configuration": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_applied_to_surface": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dimensions": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "support": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "information_recording_technique": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "production_rate_ratio": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "technical_specifications_of_medium": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "location_within_medium": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "layout": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "generation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "book_format": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "polarity": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "font_size": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -348,151 +372,91 @@
                         "enum": ["Map projection", "Method specified in $2", "Altitude", "Depth", "Geodetic model", "Geographic", "Local", "Local planar", "Grid coordinate system"]
                     },
                     "reference_method_used": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "latitude_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coordinate_units_or_distance_units": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "standard_parallel_or_oblique_line_latitude": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "longitude_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "longitude_of_central_meridian_or_projection_center": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "oblique_line_longitude": {
                         "type": "string"
                     },
-                    "false_easting": {
+                    "longitude_of_central_meridian_or_projection_center": {
+                        "type": "string"
+                    },
+                    "oblique_line_longitude": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "false_easting": {
+                        "type": "string"
                     },
                     "latitude_of_projection_center_or_projection_origin": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "scale_factor": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "false_northing": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "azimuthal_angle": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "height_of_perspective_point_above_surface": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "landsat_number_and_path_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "ellipsoid_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "zone_identifier": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "denominator_of_flattening_ratio": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "semi_major_axis": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "vertical_encoding_method": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "vertical_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "local_planar_or_local_georeference_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "local_planar_local_or_other_projection_or_grid_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -504,67 +468,40 @@
                 "type": "object",
                 "properties": {
                     "planar_coordinate_encoding_method": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "abscissa_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "planar_distance_units": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "distance_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "ordinate_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bearing_units": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bearing_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bearing_reference_meridian": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bearing_reference_direction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -576,52 +513,73 @@
                 "type": "object",
                 "properties": {
                     "type_of_recording": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "playing_speed": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "recording_medium": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "track_configuration": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "groove_characteristic": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "configuration_of_playback_channels": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "tape_configuration": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "special_playback_characteristics": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -633,34 +591,37 @@
                 "type": "object",
                 "properties": {
                     "presentation_format": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "projection_speed": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -672,34 +633,37 @@
                 "type": "object",
                 "properties": {
                     "video_format": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "broadcast_standard": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -711,46 +675,61 @@
                 "type": "object",
                 "properties": {
                     "file_type": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "file_size": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "encoding_format": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "regional_encoding": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "resolution": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "transmission_speed": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -762,31 +741,31 @@
                 "type": "object",
                 "properties": {
                     "organization": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "hierarchical_level": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arrangement": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -798,61 +777,46 @@
                 "type": "object",
                 "properties": {
                     "direct_reference_method": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "object_count": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "object_type": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "column_count": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "row_count": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "vpf_topology_level": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "vertical_count": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "indirect_reference_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "format_of_the_digital_image": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -867,58 +831,49 @@
                         "enum": ["Contents note", "Author", "Abstract", "Title", "Record", "Document", "None of the above"]
                     },
                     "security_classification": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "external_dissemination_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "handling_instructions": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "classification_system": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "downgrading_or_declassification_event": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "downgrading_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country_of_origin_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "declassification_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authorization": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -927,28 +882,34 @@
             "description": "Originator Dissemination Control",
             "properties": {
                 "originator_control_term": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "authorized_recipients_of_material": {
-                    "type": "string"
-                },
-                "originating_agency": {
-                    "type": "string"
-                },
-                "other_restrictions": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "originating_agency": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "other_restrictions": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
                     "type": "string"
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -962,25 +923,19 @@
                         "enum": ["Unformatted note", "Formatted style"]
                     },
                     "dates_of_publication_and_or_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "source_of_information": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "source_of_information": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -998,112 +953,67 @@
                         "enum": ["Not specified", "Open", "Closed"]
                     },
                     "first_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "nonpublic_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "third_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "second_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "fifth_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "fourth_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "alternative_numbering_scheme_first_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "sixth_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "first_level_of_chronology": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "alternative_numbering_scheme_second_level_of_enumeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "third_level_of_chronology": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "second_level_of_chronology": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "alternative_numbering_scheme_chronology": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "fourth_level_of_chronology": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "first_level_textual_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "public_note": {
                         "type": "string"
                     },
-                    "first_level_of_chronology_issuance": {
+                    "second_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "fifth_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "fourth_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "alternative_numbering_scheme_first_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "sixth_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "first_level_of_chronology": {
+                        "type": "string"
+                    },
+                    "alternative_numbering_scheme_second_level_of_enumeration": {
+                        "type": "string"
+                    },
+                    "third_level_of_chronology": {
+                        "type": "string"
+                    },
+                    "second_level_of_chronology": {
+                        "type": "string"
+                    },
+                    "alternative_numbering_scheme_chronology": {
+                        "type": "string"
+                    },
+                    "fourth_level_of_chronology": {
+                        "type": "string"
+                    },
+                    "first_level_textual_designation": {
+                        "type": "string"
+                    },
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "string"
+                    },
+                    "public_note": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "first_level_of_chronology_issuance": {
+                        "type": "string"
                     }
                 }
             }
@@ -1115,91 +1025,52 @@
                 "type": "object",
                 "properties": {
                     "price_type_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "currency_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "price_amount": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "price_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "unit_of_pricing": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "price_effective_until": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "price_effective_from": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "tax_rate_2": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "tax_rate_1": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "marc_country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "iso_country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "identification_of_pricing_entity": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_price_type_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1211,79 +1082,46 @@
                 "type": "object",
                 "properties": {
                     "publishers_compressed_title_identification": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "availability_status_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "detailed_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "expected_next_availability_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_made_out_of_print": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "publisher_s_discount_category": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "marc_country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "iso_country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "identification_of_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_availability_status_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1295,25 +1133,28 @@
                 "type": "object",
                 "properties": {
                     "language_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "language_term": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "language_term": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1325,25 +1166,28 @@
                 "type": "object",
                 "properties": {
                     "form_of_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1355,31 +1199,40 @@
                 "type": "object",
                 "properties": {
                     "other_distinguishing_characteristic": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1397,43 +1250,64 @@
                         "enum": ["No information provided", "Intended for access", "Not intended for access"]
                     },
                     "medium_of_performance": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "soloist": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "doubling_instrument": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "alternative_medium_of_performance": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "number_of_performers_of_the_same_medium": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "total_number_of_performers": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1445,40 +1319,40 @@
                 "type": "object",
                 "properties": {
                     "serial_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "thematic_index_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "opus_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "publisher_associated_with_opus_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "thematic_index_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1490,19 +1364,16 @@
                     "enum": ["Original key ", "Transposed key ", "Relationship to original unknown "]
                 },
                 "key": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "linkage": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -1513,46 +1384,43 @@
                 "type": "object",
                 "properties": {
                     "audience_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "audience_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "demographic_group_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "demographic_group_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1564,46 +1432,43 @@
                 "type": "object",
                 "properties": {
                     "creator_contributor_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "creator_contributor_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "demographic_group_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "demographic_group_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd4xx.json
+++ b/dojson/contrib/marc21/schemas/bd4xx.json
@@ -14,91 +14,79 @@
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
                     },
                     "personal_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "titles_and_other_words_associated_with_a_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "numeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dates_associated_with_a_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "volume_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title_of_a_work": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
                     }
                 }
             }
@@ -116,88 +104,82 @@
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
                     },
                     "corporate_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting_or_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "volume_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title_of_a_work": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
                     }
                 }
             }
@@ -215,94 +197,76 @@
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
                     },
                     "meeting_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "volume_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_meeting_following_jurisdiction_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title_of_a_work": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
                     }
                 }
             }
@@ -317,43 +281,46 @@
                         "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "volume_sequential_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
-                    },
-                    "authority_record_control_number": {
-                        "type": "string"
-                    },
-                    "bibliographic_record_control_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "authority_record_control_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "bibliographic_record_control_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -368,34 +335,37 @@
                         "enum": ["Series not traced", "Series traced"]
                     },
                     "series_statement": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "international_standard_serial_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "library_of_congress_call_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
+                        "type": "string"
+                    },
+                    "volume_sequential_designation": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "volume_sequential_designation": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd4xx.json
+++ b/dojson/contrib/marc21/schemas/bd4xx.json
@@ -8,7 +8,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_personal_name_entry_element": {
-                        "enum": ["Surname", "Forename", "Family name"]
+                        "enum": ["Family name", "Surname", "Forename"]
                     },
                     "pronoun_represents_main_entry": {
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
@@ -110,7 +110,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_corporate_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "pronoun_represents_main_entry": {
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
@@ -209,7 +209,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_meeting_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "pronoun_represents_main_entry": {
                         "enum": ["Main entry represented by pronoun", "Main entry not represented by pronoun"]
@@ -314,7 +314,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters"]
+                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "title": {
                         "type": "array",
@@ -365,7 +365,7 @@
                 "type": "object",
                 "properties": {
                     "series_tracing_policy": {
-                        "enum": ["Series traced", "Series not traced"]
+                        "enum": ["Series not traced", "Series traced"]
                     },
                     "series_statement": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd5xx.json
+++ b/dojson/contrib/marc21/schemas/bd5xx.json
@@ -8,31 +8,22 @@
                 "type": "object",
                 "properties": {
                     "general_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "materials_specified": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "materials_specified": {
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -44,25 +35,19 @@
                 "type": "object",
                 "properties": {
                     "with_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "institution_to_which_field_applies": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "institution_to_which_field_applies": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -74,43 +59,37 @@
                 "type": "object",
                 "properties": {
                     "dissertation_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_granting_institution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "degree_type": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "year_degree_granted": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "string"
-                    },
-                    "dissertation_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "dissertation_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -122,25 +101,19 @@
                 "type": "object",
                 "properties": {
                     "bibliography_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "number_of_references": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "number_of_references": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -158,31 +131,40 @@
                         "enum": ["Enhanced", "Basic"]
                     },
                     "formatted_contents_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "string"
-                    },
-                    "statement_of_responsibility": {
-                        "type": "string"
-                    },
-                    "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "title": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "statement_of_responsibility": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "title": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -197,55 +179,61 @@
                         "enum": ["No restrictions", "Restrictions apply", "No information provided"]
                     },
                     "terms_governing_access": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "physical_access_provisions": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "jurisdiction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authorization": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authorized_users": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standardized_terminology_for_access_restriction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -254,25 +242,19 @@
             "description": "Scale Note for Graphic Material",
             "properties": {
                 "representative_fraction_of_scale_note": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "field_link_and_sequence_number": {
                     "type": "string"
                 },
-                "remainder_of_scale_note": {
+                "field_link_and_sequence_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
+                "remainder_of_scale_note": {
+                    "type": "string"
+                },
                 "linkage": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 }
             }
         },
@@ -283,19 +265,16 @@
                 "type": "object",
                 "properties": {
                     "creation_production_credits_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -310,46 +289,34 @@
                         "enum": ["Coverage is selective", "Location in source given", "Coverage unknown", "Location in source not given", "Coverage complete"]
                     },
                     "name_of_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_within_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coverage_of_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -364,19 +331,16 @@
                         "enum": ["Cast", "No display constant generated"]
                     },
                     "participant_or_performer_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -388,25 +352,19 @@
                 "type": "object",
                 "properties": {
                     "type_of_report": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "period_covered": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "period_covered": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -415,73 +373,79 @@
             "description": "Data Quality Note",
             "properties": {
                 "attribute_accuracy_report": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "attribute_accuracy_explanation": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "attribute_accuracy_value": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "completeness_report": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "logical_consistency_report": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "horizontal_position_accuracy_value": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "horizontal_position_accuracy_report": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "vertical_positional_accuracy_report": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "horizontal_position_accuracy_explanation": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "vertical_positional_accuracy_explanation": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "vertical_positional_accuracy_value": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "cloud_cover": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
+                    "type": "string"
                 },
                 "uniform_resource_identifier": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
-                "field_link_and_sequence_number": {
+                "linkage": {
                     "type": "string"
                 },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "display_note": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -492,19 +456,16 @@
                 "type": "object",
                 "properties": {
                     "numbering_peculiarities_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -519,19 +480,16 @@
                         "enum": ["Type of file", "No display constant generated"]
                     },
                     "type_of_computer_file_or_data_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -543,40 +501,49 @@
                 "type": "object",
                 "properties": {
                     "date_time_and_place_of_an_event_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_event": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "place_of_event": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "other_event_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -591,46 +558,34 @@
                         "enum": ["Review", "Summary", "Scope and content", "Content advice", "No display constant generated", "Abstract", "Subject"]
                     },
                     "summary": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "assigning_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "expansion_of_summary_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -645,28 +600,25 @@
                         "enum": ["Interest age level", "Interest grade level", "Motivation/interest level", "Audience", "Reading grade level", "No display constant generated", "Special audience characteristics"]
                     },
                     "target_audience_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -681,19 +633,16 @@
                         "enum": ["Geographic coverage", "No display constant generated"]
                     },
                     "geographic_coverage_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -708,31 +657,22 @@
                         "enum": ["Cite as", "No display constant generated"]
                     },
                     "preferred_citation_of_described_materials_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "materials_specified": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "materials_specified": {
+                        "type": "string"
                     },
                     "source_of_schema_used": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -744,19 +684,16 @@
                 "type": "object",
                 "properties": {
                     "supplement_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -771,55 +708,43 @@
                         "enum": ["No display constant generated", "Reading program"]
                     },
                     "program_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "nonpublic_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "reading_level": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "interest_level": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_point_value": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "display_text": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -831,46 +756,34 @@
                 "type": "object",
                 "properties": {
                     "additional_physical_form_available_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "availability_conditions": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "availability_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "order_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -882,64 +795,61 @@
                 "type": "object",
                 "properties": {
                     "type_of_reproduction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "agency_responsible_for_reproduction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "place_of_reproduction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description_of_reproduction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_reproduction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_statement_of_reproduction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dates_and_or_sequential_designation_of_issues_reproduced": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note_about_reproduction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "fixed_length_data_elements_of_reproduction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -951,85 +861,76 @@
                 "type": "object",
                 "properties": {
                     "main_entry_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "publication_distribution_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition_statement_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "physical_description_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_statement_of_original": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "key_title_of_original": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note_about_original": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "introductory_phrase": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_statement_of_original": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "international_standard_book_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1044,40 +945,40 @@
                         "enum": ["Holder of duplicates", "Holder of originals"]
                     },
                     "custodian": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "postal_address": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "telecommunications_address": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "repository_location_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1089,40 +990,58 @@
                 "type": "object",
                 "properties": {
                     "text_of_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "grant_number": {
-                        "type": "string"
-                    },
-                    "contract_number": {
-                        "type": "string"
-                    },
-                    "program_element_number": {
-                        "type": "string"
-                    },
-                    "undifferentiated_number": {
-                        "type": "string"
-                    },
-                    "task_number": {
-                        "type": "string"
-                    },
-                    "project_number": {
-                        "type": "string"
-                    },
-                    "work_unit_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "contract_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "program_element_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "undifferentiated_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "task_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "project_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "work_unit_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1134,37 +1053,34 @@
                 "type": "object",
                 "properties": {
                     "system_details_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "display_text": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
                     },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1176,52 +1092,37 @@
                 "type": "object",
                 "properties": {
                     "terms_governing_use_and_reproduction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authorization": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "jurisdiction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authorized_users": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1236,73 +1137,52 @@
                         "enum": ["Not private", "No information provided", "Private"]
                     },
                     "source_of_acquisition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "method_of_acquisition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "address": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "accession_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_acquisition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "owner": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "purchase_price": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "type_of_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "extent": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1317,115 +1197,100 @@
                         "enum": ["Not private", "No information provided", "Private"]
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "personal_creator": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "corporate_creator": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "personal_creator_death_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "copyright_holder_contact_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "copyright_holder": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "copyright_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "copyright_statement": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "publication_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "copyright_renewal_date": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "publisher": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "creation_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "publication_status": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "copyright_status": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "research_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "supplying_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country_of_publication_or_creation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "jurisdiction_of_copyright_assessment": {
+                        "type": "string"
+                    },
+                    "uniform_resource_identifier": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "uniform_resource_identifier": {
-                        "type": "string"
                     }
                 }
             }
@@ -1440,37 +1305,52 @@
                         "enum": ["No information provided", "Associated materials", "Related materials"]
                     },
                     "custodian": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "country": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "address": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "provenance": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "title": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1485,28 +1365,25 @@
                         "enum": ["Administrative history", "Biographical sketch", "No information provided"]
                     },
                     "biographical_or_historical_data": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "expansion": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "uniform_resource_identifier": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "uniform_resource_identifier": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1518,28 +1395,25 @@
                 "type": "object",
                 "properties": {
                     "language_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "information_code_or_alphabet": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "information_code_or_alphabet": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1551,19 +1425,16 @@
                 "type": "object",
                 "properties": {
                     "former_title_complexity_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1575,19 +1446,16 @@
                 "type": "object",
                 "properties": {
                     "issuing_body_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1599,103 +1467,85 @@
                 "type": "object",
                 "properties": {
                     "entity_type_label": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attribute_label": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "entity_type_definition_and_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "enumerated_domain_value": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "attribute_definition_and_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "range_domain_minimum_and_maximum": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "enumerated_domain_value_definition_and_source": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "unrepresentable_domain": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "codeset_name_and_source": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "beginning_and_ending_date_of_attribute_values": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attribute_units_of_measurement_and_resolution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attribute_value_accuracy_explanation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "attribute_value_accuracy": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "entity_and_attribute_overview": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "attribute_measurement_frequency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "entity_and_attribute_detail_citation": {
-                        "type": "string"
-                    },
-                    "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
                         "type": "string"
                     },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "display_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1710,43 +1560,37 @@
                         "enum": ["Finding aids", "No display constant generated", "Indexes"]
                     },
                     "cumulative_index_finding_aids_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "degree_of_control": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "availability_source": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "bibliographic_reference": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1761,22 +1605,22 @@
                         "enum": ["Documentation", "No display constant generated"]
                     },
                     "information_about_documentation_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "international_standard_book_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1791,34 +1635,28 @@
                         "enum": ["Not private", "No information provided", "Private"]
                     },
                     "history": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1830,40 +1668,49 @@
                 "type": "object",
                 "properties": {
                     "identifying_markings": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version_identification": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "copy_identification": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "number_of_copies": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "presentation_format": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1875,34 +1722,28 @@
                 "type": "object",
                 "properties": {
                     "binding_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1917,37 +1758,43 @@
                         "enum": ["File size", "Case file characteristics", "No display constant generated"]
                     },
                     "number_of_cases_variables": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "unit_of_analysis": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_variable": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "filing_scheme_or_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "universe_of_data": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1962,19 +1809,16 @@
                         "enum": ["Methodology", "No display constant generated"]
                     },
                     "methodology_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -1986,19 +1830,16 @@
                 "type": "object",
                 "properties": {
                     "linking_entry_complexity_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -2013,28 +1854,25 @@
                         "enum": ["Publications", "No display constant generated"]
                     },
                     "publications_about_described_materials_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "international_standard_book_number": {
                         "type": "string"
                     },
-                    "linkage": {
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -2049,82 +1887,115 @@
                         "enum": ["Not private", "No information provided", "Private"]
                     },
                     "action": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "nonpublic_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "time_date_of_action": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "action_identification": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "contingency_for_action": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "action_interval": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authorization": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "method_of_action": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "jurisdiction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "action_agent": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "site_of_action": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "status": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "type_of_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "extent": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_resource_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -2136,31 +2007,31 @@
                 "type": "object",
                 "properties": {
                     "accumulation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "frequency_of_use": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -2172,31 +2043,22 @@
                 "type": "object",
                 "properties": {
                     "exhibitions_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "materials_specified": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "materials_specified": {
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -2211,25 +2073,19 @@
                         "enum": ["Awards", "No display constant generated"]
                     },
                     "awards_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "materials_specified": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "materials_specified": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -2241,25 +2097,19 @@
                 "type": "object",
                 "properties": {
                     "source_of_description_note": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "institution_to_which_field_applies": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "institution_to_which_field_applies": {
+                        "type": "string"
+                    },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd5xx.json
+++ b/dojson/contrib/marc21/schemas/bd5xx.json
@@ -152,7 +152,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Incomplete contents", "Contents", "Partial contents", "No display constant generated"]
+                        "enum": ["Incomplete contents", "No display constant generated", "Contents", "Partial contents"]
                     },
                     "level_of_content_designation": {
                         "enum": ["Enhanced", "Basic"]
@@ -194,7 +194,7 @@
                 "type": "object",
                 "properties": {
                     "restriction": {
-                        "enum": ["Restrictions apply", "No restrictions", "No information provided"]
+                        "enum": ["No restrictions", "Restrictions apply", "No information provided"]
                     },
                     "terms_governing_access": {
                         "type": "array",
@@ -307,7 +307,7 @@
                 "type": "object",
                 "properties": {
                     "coverage_location_in_source": {
-                        "enum": ["Coverage complete", "Coverage unknown", "Location in source not given", "Coverage is selective", "Location in source given"]
+                        "enum": ["Coverage is selective", "Location in source given", "Coverage unknown", "Location in source not given", "Coverage complete"]
                     },
                     "name_of_source": {
                         "type": "array",
@@ -516,7 +516,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Type of file"]
+                        "enum": ["Type of file", "No display constant generated"]
                     },
                     "type_of_computer_file_or_data_note": {
                         "type": "array",
@@ -588,7 +588,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Summary", "Review", "Subject", "Abstract", "Scope and content", "Content advice", "No display constant generated"]
+                        "enum": ["Review", "Summary", "Scope and content", "Content advice", "No display constant generated", "Abstract", "Subject"]
                     },
                     "summary": {
                         "type": "array",
@@ -642,7 +642,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Audience", "Interest age level", "Reading grade level", "Special audience characteristics", "Interest grade level", "Motivation/interest level", "No display constant generated"]
+                        "enum": ["Interest age level", "Interest grade level", "Motivation/interest level", "Audience", "Reading grade level", "No display constant generated", "Special audience characteristics"]
                     },
                     "target_audience_note": {
                         "type": "string"
@@ -678,7 +678,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Geographic coverage"]
+                        "enum": ["Geographic coverage", "No display constant generated"]
                     },
                     "geographic_coverage_note": {
                         "type": "array",
@@ -705,7 +705,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Cite as"]
+                        "enum": ["Cite as", "No display constant generated"]
                     },
                     "preferred_citation_of_described_materials_note": {
                         "type": "array",
@@ -768,7 +768,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Reading program", "No display constant generated"]
+                        "enum": ["No display constant generated", "Reading program"]
                     },
                     "program_name": {
                         "type": "array",
@@ -1041,7 +1041,7 @@
                 "type": "object",
                 "properties": {
                     "custodial_role": {
-                        "enum": ["Holder of originals", "Holder of duplicates"]
+                        "enum": ["Holder of duplicates", "Holder of originals"]
                     },
                     "custodian": {
                         "type": "array",
@@ -1233,7 +1233,7 @@
                 "type": "object",
                 "properties": {
                     "privacy": {
-                        "enum": ["Not private", "Private", "No information provided"]
+                        "enum": ["Not private", "No information provided", "Private"]
                     },
                     "source_of_acquisition": {
                         "type": "array",
@@ -1314,7 +1314,7 @@
                 "type": "object",
                 "properties": {
                     "privacy": {
-                        "enum": ["Not private", "Private", "No information provided"]
+                        "enum": ["Not private", "No information provided", "Private"]
                     },
                     "materials_specified": {
                         "type": "array",
@@ -1437,7 +1437,7 @@
                 "type": "object",
                 "properties": {
                     "relationship": {
-                        "enum": ["Related materials", "Associated materials", "No information provided"]
+                        "enum": ["No information provided", "Associated materials", "Related materials"]
                     },
                     "custodian": {
                         "type": "string"
@@ -1707,7 +1707,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Finding aids", "Indexes", "No display constant generated"]
+                        "enum": ["Finding aids", "No display constant generated", "Indexes"]
                     },
                     "cumulative_index_finding_aids_note": {
                         "type": "array",
@@ -1758,7 +1758,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Documentation"]
+                        "enum": ["Documentation", "No display constant generated"]
                     },
                     "information_about_documentation_note": {
                         "type": "array",
@@ -1788,7 +1788,7 @@
                 "type": "object",
                 "properties": {
                     "privacy": {
-                        "enum": ["Not private", "Private", "No information provided"]
+                        "enum": ["Not private", "No information provided", "Private"]
                     },
                     "history": {
                         "type": "array",
@@ -1914,7 +1914,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["Case file characteristics", "File size", "No display constant generated"]
+                        "enum": ["File size", "Case file characteristics", "No display constant generated"]
                     },
                     "number_of_cases_variables": {
                         "type": "array",
@@ -1959,7 +1959,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Methodology"]
+                        "enum": ["Methodology", "No display constant generated"]
                     },
                     "methodology_note": {
                         "type": "array",
@@ -2010,7 +2010,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Publications"]
+                        "enum": ["Publications", "No display constant generated"]
                     },
                     "publications_about_described_materials_note": {
                         "type": "array",
@@ -2046,7 +2046,7 @@
                 "type": "object",
                 "properties": {
                     "privacy": {
-                        "enum": ["Not private", "Private", "No information provided"]
+                        "enum": ["Not private", "No information provided", "Private"]
                     },
                     "action": {
                         "type": "array",
@@ -2208,7 +2208,7 @@
                 "type": "object",
                 "properties": {
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Awards"]
+                        "enum": ["Awards", "No display constant generated"]
                     },
                     "awards_note": {
                         "type": "array",

--- a/dojson/contrib/marc21/schemas/bd6xx.json
+++ b/dojson/contrib/marc21/schemas/bd6xx.json
@@ -8,10 +8,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_personal_name_entry_element": {
-                        "enum": ["Surname", "Forename", "Family name"]
+                        "enum": ["Family name", "Surname", "Forename"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -161,10 +161,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_corporate_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -302,10 +302,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_meeting_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -436,8 +436,11 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "nonfiling_characters": {
+                        "enum": ["Number of nonfiling characters"]
+                    },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -560,10 +563,10 @@
                 "type": "object",
                 "properties": {
                     "type_of_date_or_time_period": {
-                        "enum": ["Date or time period of creation or origin", "Date or time period covered or depicted", "No information provided"]
+                        "enum": ["Date or time period of creation or origin", "No information provided", "Date or time period covered or depicted"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings", "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re"]
                     },
                     "chronological_term": {
                         "type": "array",
@@ -617,10 +620,10 @@
                 "type": "object",
                 "properties": {
                     "level_of_subject": {
-                        "enum": ["Primary", "No level specified", "No information provided", "Secondary"]
+                        "enum": ["No level specified", "Primary", "No information provided", "Secondary"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "topical_term_or_geographic_name_entry_element": {
                         "type": "array",
@@ -698,7 +701,7 @@
                 "type": "object",
                 "properties": {
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "geographic_name": {
                         "type": "array",
@@ -758,10 +761,10 @@
                 "type": "object",
                 "properties": {
                     "level_of_index_term": {
-                        "enum": ["Primary", "No level specified", "No information provided", "Secondary"]
+                        "enum": ["No level specified", "Primary", "No information provided", "Secondary"]
                     },
                     "type_of_term_or_name": {
-                        "enum": ["No information provided", "Personal name", "Topical term", "Meeting name", "Corporate name", "Geographic name", "Chronological term", "Genre/form term"]
+                        "enum": ["Topical term", "No information provided", "Meeting name", "Geographic name", "Personal name", "Genre/form term", "Chronological term", "Corporate name"]
                     },
                     "uncontrolled_term": {
                         "type": "string"
@@ -785,7 +788,7 @@
                 "type": "object",
                 "properties": {
                     "level_of_subject": {
-                        "enum": ["Primary", "No level specified", "No information provided", "Secondary"]
+                        "enum": ["No level specified", "Primary", "No information provided", "Secondary"]
                     },
                     "focus_term": {
                         "type": "string"
@@ -848,7 +851,7 @@
                         "enum": ["Faceted", "Basic"]
                     },
                     "thesaurus": {
-                        "enum": ["LC subject headings for children\u0027s literature", "Library of Congress Subject Headings", "National Agricultural Library subject authority file", "Medical Subject Headings", "Canadian Subject Headings", "Source not specified", "Source specified in subfield $2", "R\u00e9pertoire de vedettes-mati\u00e8re"]
+                        "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "genre_form_data_or_focus_term": {
                         "type": "array",

--- a/dojson/contrib/marc21/schemas/bd6xx.json
+++ b/dojson/contrib/marc21/schemas/bd6xx.json
@@ -14,142 +14,136 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "personal_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "titles_and_other_words_associated_with_a_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "numeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dates_associated_with_a_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "attribution_qualifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "fuller_form_of_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "form_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "form_subdivision": {
-                        "type": "string"
-                    },
                     "chronological_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -167,130 +161,130 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "corporate_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting_or_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "form_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "form_subdivision": {
-                        "type": "string"
-                    },
                     "chronological_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -308,124 +302,118 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "meeting_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_meeting_following_jurisdiction_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "form_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "form_subdivision": {
-                        "type": "string"
-                    },
                     "chronological_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -443,115 +431,118 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "form_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "form_subdivision": {
-                        "type": "string"
-                    },
                     "chronological_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -569,46 +560,52 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings", "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re"]
                     },
                     "chronological_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "chronological_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -626,70 +623,73 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "topical_term_or_geographic_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "location_of_event": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "topical_term_following_geographic_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "active_dates": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "chronological_subdivision": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -704,52 +704,64 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "geographic_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "chronological_subdivision": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -767,16 +779,19 @@
                         "enum": ["Topical term", "No information provided", "Meeting name", "Geographic name", "Personal name", "Genre/form term", "Chronological term", "Corporate name"]
                     },
                     "uncontrolled_term": {
-                        "type": "string"
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -791,52 +806,73 @@
                         "enum": ["No level specified", "Primary", "No information provided", "Secondary"]
                     },
                     "focus_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "facet_hierarchy_designation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "non_focus_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "chronological_subdivision": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -854,58 +890,67 @@
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
                     "genre_form_data_or_focus_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "facet_hierarchy_designation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "non_focus_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "chronological_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -917,52 +962,55 @@
                 "type": "object",
                 "properties": {
                     "occupation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "chronological_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -974,46 +1022,52 @@
                 "type": "object",
                 "properties": {
                     "function": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "general_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "form_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "chronological_subdivision": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "chronological_subdivision": {
-                        "type": "string"
-                    },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "geographic_subdivision": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1025,40 +1079,31 @@
                 "type": "object",
                 "properties": {
                     "main_curriculum_objective": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "curriculum_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_curriculum_objective": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "correlation_factor": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_term_or_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1070,55 +1115,70 @@
                 "type": "object",
                 "properties": {
                     "country_or_larger_entity": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "intermediate_political_jurisdiction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "first_order_political_jurisdiction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "city": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_nonjurisdictional_geographic_region_and_feature": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "city_subsection": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "extraterrestrial_area": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd70x75x.json
+++ b/dojson/contrib/marc21/schemas/bd70x75x.json
@@ -14,139 +14,121 @@
                         "enum": ["No information provided", "Analytical entry"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "personal_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "titles_and_other_words_associated_with_a_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "numeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dates_associated_with_a_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "attribution_qualifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "fuller_form_of_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "name_of_part_section_of_a_work": {
                         "type": "string"
                     },
-                    "version": {
+                    "name_of_part_section_of_a_work": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "version": {
+                        "type": "string"
                     },
                     "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -164,127 +146,115 @@
                         "enum": ["No information provided", "Analytical entry"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "corporate_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting_or_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -302,121 +272,103 @@
                         "enum": ["No information provided", "Analytical entry"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "meeting_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_meeting_following_jurisdiction_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "name_of_part_section_of_a_work": {
                         "type": "string"
                     },
-                    "version": {
+                    "name_of_part_section_of_a_work": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "version": {
+                        "type": "string"
                     },
                     "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -431,25 +383,28 @@
                         "enum": ["Personal", "Not specified", "Other"]
                     },
                     "name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
-                    "relator_term": {
-                        "type": "string"
-                    },
-                    "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "relator_term": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "relator_code": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "linkage": {
+                        "type": "string"
                     }
                 }
             }
@@ -467,106 +422,91 @@
                         "enum": ["No information provided", "Analytical entry"]
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "version": {
+                    "key_for_music": {
+                        "type": "string"
+                    },
+                    "institution_to_which_field_applies": {
+                        "type": "string"
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "version": {
+                        "type": "string"
                     }
                 }
             }
@@ -584,37 +524,34 @@
                         "enum": ["No information provided", "Analytical entry"]
                     },
                     "uncontrolled_related_analytical_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "institution_to_which_field_applies": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -626,40 +563,40 @@
                 "type": "object",
                 "properties": {
                     "geographic_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_code": {
-                        "type": "string"
-                    },
-                    "linkage": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "linkage": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -671,49 +608,58 @@
                 "type": "object",
                 "properties": {
                     "country_or_larger_entity": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "intermediate_political_jurisdiction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "first_order_political_jurisdiction": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "city": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_nonjurisdictional_geographic_region_and_feature": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "city_subsection": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "extraterrestrial_area": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_heading_or_term": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -725,31 +671,22 @@
                 "type": "object",
                 "properties": {
                     "make_and_model_of_machine": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "operating_system": {
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "operating_system": {
+                        "type": "string"
                     },
                     "programming_language": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -761,37 +698,52 @@
                 "type": "object",
                 "properties": {
                     "taxonomic_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "non_public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "taxonomic_category": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "common_or_alternative_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_of_taxonomic_identification": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
-                        "type": "string"
-                    },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd70x75x.json
+++ b/dojson/contrib/marc21/schemas/bd70x75x.json
@@ -8,7 +8,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_personal_name_entry_element": {
-                        "enum": ["Surname", "Forename", "Family name"]
+                        "enum": ["Family name", "Surname", "Forename"]
                     },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
@@ -158,7 +158,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_corporate_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
@@ -296,7 +296,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_meeting_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
@@ -460,6 +460,9 @@
             "items": {
                 "type": "object",
                 "properties": {
+                    "nonfiling_characters": {
+                        "enum": ["Number of nonfiling characters"]
+                    },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
                     },
@@ -575,7 +578,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters"]
+                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]

--- a/dojson/contrib/marc21/schemas/bd76x78x.json
+++ b/dojson/contrib/marc21/schemas/bd76x78x.json
@@ -11,7 +11,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Main series"]
+                        "enum": ["Main series", "No display constant generated"]
                     },
                     "main_entry_heading": {
                         "type": "array",
@@ -119,7 +119,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Has subseries"]
+                        "enum": ["Has subseries", "No display constant generated"]
                     },
                     "main_entry_heading": {
                         "type": "array",
@@ -227,7 +227,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Translation of"]
+                        "enum": ["Translation of", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -350,7 +350,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Translated as"]
+                        "enum": ["Translated as", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -473,7 +473,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Has supplement"]
+                        "enum": ["Has supplement", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -596,7 +596,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["Parent", "Supplement to", "No display constant generated"]
+                        "enum": ["Supplement to", "Parent", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -719,7 +719,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "In"]
+                        "enum": ["In", "No display constant generated"]
                     },
                     "materials_specified": {
                         "type": "array",
@@ -854,7 +854,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Constituent unit"]
+                        "enum": ["Constituent unit", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -977,7 +977,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Other edition available"]
+                        "enum": ["Other edition available", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -1112,7 +1112,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Available in another form"]
+                        "enum": ["Available in another form", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -1235,7 +1235,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Issued with"]
+                        "enum": ["Issued with", "No display constant generated"]
                     },
                     "main_entry_heading": {
                         "type": "array",
@@ -1346,7 +1346,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "type_of_relationship": {
-                        "enum": ["Continues in part", "Continues", "Supersedes in part", "Supersedes", "Absorbed", "Formed by the union of ... and ...", "Separated from", "Absorbed in part"]
+                        "enum": ["Continues", "Continues in part", "Absorbed in part", "Supersedes in part", "Absorbed", "Formed by the union of ... and ...", "Separated from", "Supersedes"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -1469,7 +1469,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "type_of_relationship": {
-                        "enum": ["Continued in part by", "Continued by", "Superseded in part by", "Superseded by", "Absorbed in part by", "Absorbed by", "Merged with ... to form ...", "Split into ... and ...", "Changed back to"]
+                        "enum": ["Merged with ... to form ...", "Changed back to", "Continued by", "Absorbed in part by", "Superseded in part by", "Split into ... and ...", "Absorbed by", "Superseded by", "Continued in part by"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -1592,7 +1592,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Data source"]
+                        "enum": ["Data source", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"
@@ -1733,7 +1733,7 @@
                         "enum": ["Do not display note", "Display note"]
                     },
                     "display_constant_controller": {
-                        "enum": ["No display constant generated", "Related item"]
+                        "enum": ["Related item", "No display constant generated"]
                     },
                     "relationship_code": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd76x78x.json
+++ b/dojson/contrib/marc21/schemas/bd76x78x.json
@@ -14,97 +14,82 @@
                         "enum": ["Main series", "No display constant generated"]
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title": {
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "coden_designation": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title": {
+                        "type": "string"
                     }
                 }
             }
@@ -122,97 +107,82 @@
                         "enum": ["Has subseries", "No display constant generated"]
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title": {
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "coden_designation": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title": {
+                        "type": "string"
                     }
                 }
             }
@@ -230,112 +200,103 @@
                         "enum": ["Translation of", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -353,112 +314,103 @@
                         "enum": ["Translated as", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -476,112 +428,103 @@
                         "enum": ["Has supplement", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -599,112 +542,103 @@
                         "enum": ["Supplement to", "Parent", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -722,124 +656,109 @@
                         "enum": ["In", "No display constant generated"]
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "enumeration_and_first_page": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "abbreviated_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -857,112 +776,103 @@
                         "enum": ["Constituent unit", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -980,124 +890,109 @@
                         "enum": ["Other edition available", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "language_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1115,112 +1010,103 @@
                         "enum": ["Available in another form", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1238,100 +1124,88 @@
                         "enum": ["Issued with", "No display constant generated"]
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "field_link_and_sequence_number": {
                         "type": "string"
                     },
-                    "title": {
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "coden_designation": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
+                    },
+                    "title": {
+                        "type": "string"
                     }
                 }
             }
@@ -1349,112 +1223,103 @@
                         "enum": ["Continues", "Continues in part", "Absorbed in part", "Supersedes in part", "Absorbed", "Formed by the union of ... and ...", "Separated from", "Supersedes"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1472,112 +1337,103 @@
                         "enum": ["Merged with ... to form ...", "Changed back to", "Continued by", "Absorbed in part by", "Superseded in part by", "Split into ... and ...", "Absorbed by", "Superseded by", "Continued in part by"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1595,130 +1451,112 @@
                         "enum": ["Data source", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "period_of_content": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "abbreviated_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "source_contribution": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }
@@ -1736,112 +1574,103 @@
                         "enum": ["Related item", "No display constant generated"]
                     },
                     "relationship_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "main_entry_heading": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "qualifying_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "edition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "place_publisher_and_date_of_publication": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "related_parts": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relationship_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "physical_description": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "series_data_for_related_item": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "material_specific_details": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "other_item_identifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "report_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "standard_technical_report_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coden_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "international_standard_serial_number": {
+                        "type": "string"
+                    },
+                    "international_standard_book_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "international_standard_book_number": {
-                        "type": "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd80x83x.json
+++ b/dojson/contrib/marc21/schemas/bd80x83x.json
@@ -11,148 +11,130 @@
                         "enum": ["Family name", "Surname", "Forename"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "personal_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "titles_and_other_words_associated_with_a_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "numeration": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "dates_associated_with_a_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "attribution_qualifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "fuller_form_of_name": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "bibliographic_record_control_number": {
                         "type": "string"
                     },
-                    "volume_sequential_designation": {
+                    "key_for_music": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "bibliographic_record_control_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "volume_sequential_designation": {
+                        "type": "string"
+                    },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -167,136 +149,124 @@
                         "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "corporate_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting_or_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "bibliographic_record_control_number": {
                         "type": "string"
                     },
-                    "volume_sequential_designation": {
+                    "key_for_music": {
+                        "type": "string"
+                    },
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "bibliographic_record_control_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "volume_sequential_designation": {
+                        "type": "string"
+                    },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -311,130 +281,112 @@
                         "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_code": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "meeting_name_or_jurisdiction_name_as_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "subordinate_unit": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "date_of_meeting": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "relator_term": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_meeting": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_meeting_following_jurisdiction_name_entry_element": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "affiliation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "bibliographic_record_control_number": {
                         "type": "string"
                     },
-                    "volume_sequential_designation": {
+                    "affiliation": {
+                        "type": "string"
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "bibliographic_record_control_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "volume_sequential_designation": {
+                        "type": "string"
+                    },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }
@@ -449,115 +401,100 @@
                         "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "authority_record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "institution_to_which_field_applies": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "control_subfield": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_treaty_signing": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "miscellaneous_information": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "date_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "medium": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "form_subheading": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "medium_of_performance_for_music": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "language_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "arranged_statement_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "number_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "name_of_part_section_of_a_work": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "version": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "key_for_music": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "title_of_a_work": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "bibliographic_record_control_number": {
                         "type": "string"
                     },
-                    "volume_sequential_designation": {
+                    "key_for_music": {
+                        "type": "string"
+                    },
+                    "title_of_a_work": {
+                        "type": "string"
+                    },
+                    "bibliographic_record_control_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
+                    "volume_sequential_designation": {
+                        "type": "string"
+                    },
                     "international_standard_serial_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/bd80x83x.json
+++ b/dojson/contrib/marc21/schemas/bd80x83x.json
@@ -8,7 +8,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_personal_name_entry_element": {
-                        "enum": ["Surname", "Forename", "Family name"]
+                        "enum": ["Family name", "Surname", "Forename"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -164,7 +164,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_corporate_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -308,7 +308,7 @@
                 "type": "object",
                 "properties": {
                     "type_of_meeting_name_entry_element": {
-                        "enum": ["Jurisdiction name", "Inverted name", "Name in direct order"]
+                        "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
                     "authority_record_control_number": {
                         "type": "string"
@@ -446,7 +446,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters"]
+                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
                     "authority_record_control_number": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd84188x.json
+++ b/dojson/contrib/marc21/schemas/bd84188x.json
@@ -23,10 +23,10 @@
                 "type": "object",
                 "properties": {
                     "shelving_scheme": {
-                        "enum": ["No information provided", "Dewey Decimal classification", "Library of Congress classification", "Superintendent of Documents classification", "National Library of Medicine classification", "Title", "Shelving control number", "Source specified in subfield $2", "Shelved separately", "Other scheme"]
+                        "enum": ["No information provided", "Dewey Decimal classification", "Title", "Shelved separately", "Source specified in subfield $2", "Shelving control number", "Superintendent of Documents classification", "Other scheme", "Library of Congress classification", "National Library of Medicine classification"]
                     },
                     "shelving_order": {
-                        "enum": ["Primary enumeration", "Not enumeration", "No information provided", "Alternative enumeration"]
+                        "enum": ["No information provided", "Primary enumeration", "Not enumeration", "Alternative enumeration"]
                     },
                     "materials_specified": {
                         "type": "array",
@@ -149,7 +149,7 @@
                 "type": "object",
                 "properties": {
                     "relationship": {
-                        "enum": ["Version of resource", "Resource", "No information provided", "Related resource", "No display constant generated"]
+                        "enum": ["Version of resource", "No information provided", "Resource", "Related resource", "No display constant generated"]
                     },
                     "materials_specified": {
                         "type": "array",
@@ -304,7 +304,7 @@
                 "type": "object",
                 "properties": {
                     "method_of_machine_assignment": {
-                        "enum": ["Partially machine-generated", "Fully machine-generated", "No information provided/not applicable"]
+                        "enum": ["Fully machine-generated", "No information provided/not applicable", "Partially machine-generated"]
                     },
                     "generation_process": {
                         "type": "array",

--- a/dojson/contrib/marc21/schemas/bd84188x.json
+++ b/dojson/contrib/marc21/schemas/bd84188x.json
@@ -8,10 +8,16 @@
                 "type": "object",
                 "properties": {
                     "holding_institution": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -29,115 +35,118 @@
                         "enum": ["No information provided", "Primary enumeration", "Not enumeration", "Alternative enumeration"]
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_classification_or_shelving_scheme": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "sequence_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "location": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "shelving_location": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "sublocation_or_collection": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "address": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "former_shelving_location": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "non_coded_location_qualifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "coded_location_qualifier": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "item_part": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "classification_part": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "call_number_prefix": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "shelving_control_number": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "call_number_suffix": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "shelving_form_of_title": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "country_code": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "piece_physical_condition": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "piece_designation": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "copyright_article_fee_code": {
-                        "type": "string"
-                    },
-                    "uniform_resource_identifier": {
-                        "type": "string"
-                    },
-                    "copy_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "nonpublic_note": {
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "copy_number": {
                         "type": "string"
                     },
+                    "nonpublic_note": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -152,124 +161,136 @@
                         "enum": ["Version of resource", "No information provided", "Resource", "Related resource", "No display constant generated"]
                     },
                     "materials_specified": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "access_method": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "linkage": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "field_link_and_sequence_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "host_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "compression_information": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "access_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "path": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "electronic_name": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "instruction": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "processor_of_request": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "password": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bits_per_second": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "contact_for_access_assistance": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "logon": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "operating_system": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "name_of_location_of_host": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "electronic_format_type": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "port": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "file_size": {
-                        "type": "string"
-                    },
-                    "settings": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "uniform_resource_identifier": {
+                    "settings": {
                         "type": "string"
+                    },
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "terminal_emulation": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "record_control_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "hours_access_method_available": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "link_text": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "nonpublic_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "public_note": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -278,22 +299,31 @@
             "description": "Replacement Record Information",
             "properties": {
                 "replacement_title": {
-                    "type": "string"
-                },
-                "field_link_and_sequence_number": {
-                    "type": "string"
-                },
-                "explanatory_text": {
-                    "type": "string"
-                },
-                "replacement_bibliographic_record_control_number": {
-                    "type": "string"
-                },
-                "linkage": {
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
+                },
+                "field_link_and_sequence_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "explanatory_text": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "replacement_bibliographic_record_control_number": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "linkage": {
+                    "type": "string"
                 }
             }
         },
@@ -307,49 +337,40 @@
                         "enum": ["Fully machine-generated", "No information provided/not applicable", "Partially machine-generated"]
                     },
                     "generation_process": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "confidence_value": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "generation_date": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "generation_agency": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "authority_record_control_number_or_standard_number": {
-                        "type": "string"
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     },
                     "uniform_resource_identifier": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "bibliographic_record_control_number": {
-                        "type": "string"
-                    },
-                    "validity_end_date": {
                         "type": "array",
                         "items": {
                             "type": "string"
                         }
                     },
-                    "field_link_and_sequence_number": {
+                    "validity_end_date": {
                         "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -361,16 +382,10 @@
                 "type": "object",
                 "properties": {
                     "content_of_non_marc_field": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     },
                     "source_of_data": {
-                        "type": "array",
-                        "items": {
-                            "type": "string"
-                        }
+                        "type": "string"
                     }
                 }
             }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -62,6 +62,12 @@ RECORD = """<record>
   </datafield>
 </record>"""
 
+RECORD_SIMPLE = """<record>
+  <datafield tag="100" ind1=" " ind2=" ">
+    <subfield code="a">Donges, Jonathan F</subfield>
+  </datafield>
+</record>"""
+
 
 def test_index_creation():
     """Test index creation."""
@@ -102,8 +108,8 @@ def test_marc21_field_247_matching():
     })
 
     assert data['other_standard_identifier'][0]['standard_number_or_code'] \
-        == ['A']  # repeatable subfield
-    assert data['former_title'][0]['title'] == ['B']
+        == 'A'
+    assert data['former_title'][0]['title'] == 'B'
     assert len(data) == 2
 
 
@@ -117,3 +123,15 @@ def test_marc21_from_xml():
     data = marc21.do(blob)
 
     assert 'former_title' not in data
+
+
+def test_simple_record_from_xml():
+    """Test simple record loading from XML."""
+    from dojson.contrib.marc21 import marc21
+    from dojson.contrib.marc21.utils import create_record
+
+    blob = create_record(RECORD_SIMPLE)
+    data = marc21.do(blob)
+    expected = {'main_entry_personal_name': {'personal_name': 'Donges, Jonathan F'}}
+
+    assert data == expected


### PR DESCRIPTION
- FIX Addresses issue when allowed indicators where defined as a range.
  (closes #22)
- BETTER Sorts and removes duplicated enum values.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
