### PR TITLE
dojson: decorator for ignoring None value

### DIFF
--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -14,6 +14,7 @@ import re
 import esmre
 
 from six import iteritems
+from .utils import IgnoreKey
 
 
 class Overdo(object):
@@ -55,7 +56,10 @@ class Overdo(object):
 
         for key, value in iteritems(blob):
             for name, creator, field in self._query(key):
-                output[name] = creator(output, key, value)
+                try:
+                    output[name] = creator(output, key, value)
+                except IgnoreKey:
+                    pass
 
         return output
 

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -13,6 +13,32 @@ import functools
 import six
 
 
+class IgnoreKey(Exception):
+
+    """The corresponding key has been ignored.
+
+    .. versionadded:: 0.2.0
+
+    """
+
+    pass
+
+
+def ignore_value(f):
+    """Remove key for None value.
+
+    .. versionadded:: 0.2.0
+
+    """
+    @functools.wraps(f)
+    def wrapper(self, key, value, **kwargs):
+        result = f(self, key, value, **kwargs)
+        if result is None:
+            raise IgnoreKey(key)
+        return result
+    return wrapper
+
+
 def filter_values(f):
     """Remove None values from dictionary."""
     @functools.wraps(f)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,6 +10,7 @@
 """Test suite for DoJSON."""
 
 import dojson
+import pytest
 
 RECORD = """<record>
   <controlfield tag="001">17575</controlfield>
@@ -135,3 +136,31 @@ def test_simple_record_from_xml():
     expected = {'main_entry_personal_name': {'personal_name': 'Donges, Jonathan F'}}
 
     assert data == expected
+
+
+def test_none_value():
+    """Test none value."""
+    overdo = dojson.Overdo()
+    from dojson.utils import ignore_value
+
+    @overdo.over('024', '^024..')
+    @ignore_value
+    def match(self, key, value):
+        return None
+
+    data = overdo.do({'0247_': 'this should not be added'})
+    assert "024" not in data, "key with None value should not be added"
+
+
+def test_no_none_value():
+    """Test a valid value with the ignore_value decorator."""
+    overdo = dojson.Overdo()
+    from dojson.utils import ignore_value
+
+    @overdo.over('024', '^024..')
+    @ignore_value
+    def match(self, key, value):
+        return value
+
+    data = overdo.do({'0247_': 'valid value'})
+    assert data.get('024') == 'valid value'


### PR DESCRIPTION
In some cases it can be interesting to have conditional properties. For example, given the length of the ISBN identifier, it will be assigned to isbn10 or isbn13. We want in this case:
{"isbn10": "0123456789"} or {"isbn13": "01234567890123"}.

Signed-off-by: Johnny Mariéthoz johnny.mariethoz@rero.ch
