### PR TITLE
fix pytest>=2.8.0 incompatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ bin/
 build/
 develop-eggs/
 dist/
-eggs/
+.eggs
 lib/
 lib64/
 parts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
   - pip install --upgrade pip
   - pip install coveralls pep257
   - pip install pytest pytest-pep8 pytest-cov pytest-cache
-  - pip install -e .[docs]
+  - pip install -e .[docs,tests]
 
 script:
   - pep257 --match-dir='dojson'

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,5 @@ Active contributors:
 
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Esteban J. G. Gabancho <esteban.jose.garcia.gabancho@cern.ch>
+* Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 * Tibor Simko <tibor.simko@cern.ch>

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ WORKDIR /code
 ADD . /code
 
 # Install dojson:
-RUN pip install -e .
+RUN pip install -e .[docs]
 
 # Run container as user `dojson` with UID `1000`, which should match
 # current host user in most situations:

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,4 @@
 
 [pytest]
 pep8ignore = E501
-addopts = --clearcache --pep8 --ignore=docs --cov=dojson --cov-report=term-missing tests dojson
+addopts = --pep8 --ignore=docs --cov=dojson --cov-report=term-missing tests dojson

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ setup(
     ],
     extras_require={
         'docs': ['sphinx_rtd_theme'],
+        'tests': tests_require,
     },
     classifiers=[
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,6 @@ class PyTest(TestCommand):
         """Rest tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
@@ -62,10 +59,10 @@ with open(os.path.join('dojson', 'version.py'), 'rt') as f:
 
 tests_require = [
     'pytest-cache>=1.0',
-    'pytest-cov>=1.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.6.1',
-    'coverage',
+    'pytest>=2.8.0',
+    'coverage>=4.0.0',
     'mock',
 ]
 


### PR DESCRIPTION
tests: fix incompatibility with pytest>=2.8.0

```
* FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.
```

git: .eggs folder to .gitignore

```
* Adds .eggs folder to the git ignore list.
```
