### PR TITLE
global: entry points usage

### DIFF
--- a/dojson/contrib/marc21/__init__.py
+++ b/dojson/contrib/marc21/__init__.py
@@ -7,22 +7,6 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-from .fields import (
-    bd00x,
-    bd01x09x,
-    bd1xx,
-    bd20x24x,
-    bd25x28x,
-    bd3xx,
-    bd4xx,
-    bd5xx,
-    bd6xx,
-    bd70x75x,
-    bd76x78x,
-    bd80x83x,
-    bd84188x,
-)
-
 from model import marc21
 
 __all__ = ('marc21',)

--- a/dojson/contrib/marc21/model.py
+++ b/dojson/contrib/marc21/model.py
@@ -12,4 +12,4 @@
 from dojson import Overdo
 from dojson import utils
 
-marc21 = Overdo()
+marc21 = Overdo(entry_point_group='dojson.contrib.marc21')

--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -10,8 +10,9 @@
 """Do JSON translation."""
 
 import re
-
 import esmre
+
+from pkg_resources import iter_entry_points
 
 from six import iteritems
 from .utils import IgnoreKey
@@ -21,13 +22,26 @@ class Overdo(object):
 
     """Translation index."""
 
-    def __init__(self):
+    def __init__(self, bases=None, entry_point_group=None):
         """Constructor."""
         self.rules = []
+        if bases:
+            for base in bases:
+                base._collect_entry_points()
+                self.rules.extend(base.rules)
+        self.entry_point_group = entry_point_group
         self.index = None
+
+    def _collect_entry_points(self):
+        """Collect entry points."""
+        if self.entry_point_group is not None:
+            for entry_point in iter_entry_points(
+                    group=self.entry_point_group, name=None):
+                entry_point.load()
 
     def build(self):
         """Build."""
+        self._collect_entry_points()
         self.index = esmre.Index()
         for rule in self.rules:
             self.index.enter(*rule)

--- a/setup.py
+++ b/setup.py
@@ -104,4 +104,21 @@ setup(
     ],
     tests_require=tests_require,
     cmdclass={'test': PyTest},
+    entry_points={
+        'dojson.contrib.marc21': [
+            'bd00x = dojson.contrib.marc21.fields.bd00x',
+            'bd01x09x = dojson.contrib.marc21.fields.bd01x09x',
+            'bd1xx = dojson.contrib.marc21.fields.bd1xx',
+            'bd20x24x = dojson.contrib.marc21.fields.bd20x24x',
+            'bd25x28x = dojson.contrib.marc21.fields.bd25x28x',
+            'bd3xx = dojson.contrib.marc21.fields.bd3xx',
+            'bd4xx = dojson.contrib.marc21.fields.bd4xx',
+            'bd5xx = dojson.contrib.marc21.fields.bd5xx',
+            'bd6xx = dojson.contrib.marc21.fields.bd6xx',
+            'bd70x75x = dojson.contrib.marc21.fields.bd70x75x',
+            'bd76x78x = dojson.contrib.marc21.fields.bd76x78x',
+            'bd80x83x = dojson.contrib.marc21.fields.bd80x83x',
+            'bd84188x = dojson.contrib.marc21.fields.bd84188x',
+        ]
+    }
 )


### PR DESCRIPTION
- BETTER Uses entry points instead of using plain imports to load
  the creator rules.
- NEW Adds the posibility to use base doJSON models so the rules
  are "inherit" from them.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
