### PR TITLE
marc21: load source from stream

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,9 +42,9 @@ A simple example on how to convert MARCXML to JSON:
 
 .. code:: python
 
-    from dojson.contrib.marc21.utils import create_record, split_blob
+    from dojson.contrib.marc21.utils import create_record, split_stream
     from dojson.contrib.marc21 import marc21
-    [marc21.do(create_record(data)) for data in split_blob(open('/tmp/data.xml', 'r').read())]
+    [marc21.do(create_record(data)) for data in split_stream(open('/tmp/data.xml', 'r'))]
 
 
 API

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -170,6 +170,27 @@ def test_marc21_loader():
     assert len(records) == 2
 
 
+def test_marc21_split_stream():
+    """Test MARC21 split_stream()."""
+    from six import StringIO, u
+    from dojson.contrib.marc21.utils import split_stream
+
+    # Testing regular situation
+    COLLECTION = '<collection>{0}{1}</collection>'.format(
+        RECORD, RECORD_SIMPLE
+    )
+    generator = split_stream(StringIO(COLLECTION))
+    assert generator.next() == RECORD
+    assert generator.next() == RECORD_SIMPLE
+
+    # Testing records over single line
+    records = StringIO(" <record>foo</record> <record>会意字</record> ")
+
+    generator = split_stream(records)
+    assert generator.next() == "<record>foo</record>"
+    assert generator.next() == "<record>会意字</record>"
+
+
 def test_simple_record_tomarc21():
     """Test simple record marc21 - json - marc21."""
     from dojson.contrib.marc21 import marc21


### PR DESCRIPTION
- BETTER improves dojson.contrib.marc2.utils.load() to actually read
  the input by iterating of the open stream, rather than loading it
  all in memory in one go.

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
