### PR TITLE
marc21: load source from stream

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,9 +42,9 @@ A simple example on how to convert MARCXML to JSON:
 
 .. code:: python
 
-    from dojson.contrib.marc21.utils import create_record, split_blob
+    from dojson.contrib.marc21.utils import create_record, split_stream
     from dojson.contrib.marc21 import marc21
-    [marc21.do(create_record(data)) for data in split_blob(open('/tmp/data.xml', 'r').read())]
+    [marc21.do(create_record(data)) for data in split_stream(open('/tmp/data.xml', 'r'))]
 
 
 API


### PR DESCRIPTION
- BETTER Improves dojson.contrib.marc2.utils.load() to read the input
  by iterating of the open stream, rather than loading it all in
  memory in one go.  (closes #45) (closes #46)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
Co-authored-by: Jiri Kuncar jiri.kuncar@cern.ch
