### PR TITLE
Generating XML with kept ordering.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ sudo: false
 language: python
 
 python:
-  - "2.6"
   - "2.7"
 # FIXME esmre is not Python 3 compatible
 #  - "3.3"

--- a/dojson/cli.py
+++ b/dojson/cli.py
@@ -28,7 +28,6 @@ New extensions with loaders, dumpers, or rules can be provided via entry points.
 - ``dojson.cli.rule`` instances of :class:`dojson.Overdo` with loaded rules.
 """
 
-import json
 import pkg_resources
 import sys
 
@@ -88,6 +87,8 @@ def missing_fields(source, load, rule):
     else:
         for item in data:
             missing |= set(rule.missing(item))
+
+    missing.discard('__order__')
 
     if missing:
         click.echo(', '.join(missing))

--- a/dojson/contrib/marc21/fields/__init__.py
+++ b/dojson/contrib/marc21/fields/__init__.py
@@ -8,5 +8,3 @@
 # file for more details.
 
 """MARC 21 model definition."""
-
-from __future__ import unicode_literals

--- a/dojson/contrib/marc21/fields/bd00x.py
+++ b/dojson/contrib/marc21/fields/bd00x.py
@@ -15,19 +15,19 @@ from ..model import marc21
 @marc21.over('control_number', '^001')
 def control_number(self, key, value):
     """Control Number."""
-    return value[0]
+    return value
 
 
 @marc21.over('control_number_identifier', '^003')
 def control_number_identifier(self, key, value):
     """Control Number Identifier."""
-    return value[0]
+    return value
 
 
 @marc21.over('date_and_time_of_latest_transaction', '^005')
 def date_and_time_of_latest_transaction(self, key, value):
     """Date and Time of Latest Transaction."""
-    return value[0]
+    return value
 
 
 @marc21.over(
@@ -35,10 +35,10 @@ def date_and_time_of_latest_transaction(self, key, value):
 def fixed_length_data_elements_additional_material_characteristics(
         self, key, value):
     """Fixed-Length Data Elements-Additional Material Characteristics."""
-    return value[0]
+    return value
 
 
 @marc21.over('fixed_length_data_elements', '^008')
 def fixed_length_data_elements(self, key, value):
     """Fixed-Length Data Elements."""
-    return value[0]
+    return value

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2015 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""Utilities for converting to MARC21."""
+
+from __future__ import unicode_literals
+
+import pkg_resources
+
+from lxml import etree
+from lxml.builder import E
+
+
+MARC21_DTD = pkg_resources.resource_filename(
+    'dojson.contrib.marc21', 'MARC21slim.dtd')
+"""Location of the MARC21 DTD file"""
+
+MARC21_NS = "http://www.loc.gov/MARC21/slim"
+"""MARCXML XML Schema"""
+
+
+def dumps(*records, **kwargs):
+    """Dump records into a MarcXML file."""
+
+    root = etree.Element('collection', nsmap={None: MARC21_NS})
+    for record in records:
+        rec = E.record()
+        for df, subfields in record.items():
+            if isinstance(subfields, list):
+                controlfield = E.controlfield(subfields[0])
+                print(df)
+                controlfield.attrib['tag'] = df[0:3]
+                rec.append(controlfield)
+            else:
+                df = df.replace('_', ' ')
+                datafield = E.datafield()
+                datafield.attrib['tag'] = df[0:3]
+                datafield.attrib['ind1'] = df[3]
+                datafield.attrib['ind2'] = df[4]
+
+                for code, value in subfields.items(repeated=True):
+                    if not isinstance(value, basestring):
+                        for v in value:
+                            datafield.append(E.subfield(v, code=code))
+                    else:
+                        datafield.append(E.subfield(value, code=code))
+
+                rec.append(datafield)
+        root.append(rec)
+
+    return etree.tostring(root, **kwargs)

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -51,7 +51,7 @@ def for_each_value(f):
     """Apply function to each item."""
     @functools.wraps(f)
     def wrapper(self, key, values, **kwargs):
-        if isinstance(values, list):
+        if isinstance(values, (list, tuple, set)):
             return [f(self, key, value, **kwargs) for value in values]
         return [f(self, key, values, **kwargs)]
     return wrapper
@@ -61,7 +61,7 @@ def reverse_for_each_value(f):
     """Undo what `for_each_value` does."""
     @functools.wraps(f)
     def wrapper(self, key, values, **kwargs):
-        if isinstance(values, list):
+        if isinstance(values, (list, tuple, set)):
             if len(values) == 1:
                 return f(self, key, values[0], **kwargs)
             return [f(self, key, value, **kwargs) for value in values]
@@ -71,8 +71,8 @@ def reverse_for_each_value(f):
 
 def force_list(data):
     """Wrap data in list."""
-    if data is not None and not isinstance(data, (list, set)):
-        return [data]
+    if data is not None and not isinstance(data, (list, tuple, set)):
+        return (data,)
     return data
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,6 @@
 from click.testing import CliRunner
 
 import json
-import pytest
 
 
 def test_cli_do_marc21_from_xml():
@@ -39,7 +38,7 @@ def test_cli_do_marc21_from_xml():
             ['-i', 'record.xml', '-l', 'marcxml', 'marc21']
         )
         data = json.loads(result.output)
-        assert data == expected
+        assert expected == data
 
 
 def test_cli_do_marc21_from_json():
@@ -52,19 +51,20 @@ def test_cli_do_marc21_from_json():
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        with open('record.json', 'wb') as f:
-            f.write(json.dumps(create_record(RECORD_SIMPLE)))
+        with open('record.json', 'wb') as fp:
+            record = create_record(RECORD_SIMPLE)
+            json.dump(record, fp)
 
         result = runner.invoke(
             cli.missing_fields,
             ['-i', 'record.json', 'marc21']
         )
-        assert result.output == ''
-        assert result.exit_code == 0
+        assert '' == result.output
+        assert 0 == result.exit_code
 
         result = runner.invoke(
             cli.apply_rule,
             ['-i', 'record.json', 'marc21']
         )
         data = json.loads(result.output)
-        assert data == expected
+        assert expected == data

--- a/tests/test_contrib_marc21.py
+++ b/tests/test_contrib_marc21.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2015 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Test suite for DoJSON contrib MARC21 module."""
+
+import copy
+import json
+import pytest
+
+from dojson.contrib.marc21.utils import GroupableOrderedDict
+
+
+@pytest.fixture
+def god():
+    """Create a GroupableOrderedDict for testing."""
+    return GroupableOrderedDict([('a', 'dojson'), ('b', 2), ('c', 'invenio'),
+                                 ('a', 4), ('b', 5)])
+
+
+def test_groupable_ordered_dict_is_immutable(god):
+    """Test that a GroupableOrderedDict is immutable indeed."""
+    with pytest.raises(TypeError):
+        god['a'] = [1, 2]
+
+    with pytest.raises(AttributeError):
+        god['a'].append(1)
+
+    god.values().append(('spam', 'ham'))
+    with pytest.raises(KeyError):
+        god['spam']
+
+
+def test_groupable_ordered_dict_keys(god):
+    """Test that a GroupableOrderedDict has keys like a dict, but more."""
+    assert ('a', 'b', 'c') == god.keys()
+    assert ('a', 'b', 'c', 'a', 'b') == god.keys(repeated=True)
+
+
+def test_groupable_ordered_dict_items(god):
+    """Test that a GroupableOrderedDict has items like a dict, but more."""
+    assert (('a', ('dojson', 4)), ('b', (2, 5)), ('c', 'invenio')) == god.items()
+    assert (('__order__', ('a', 'b', 'c', 'a', 'b')),
+            ('a', ('dojson', 4)),
+            ('b', (2, 5)),
+            ('c', 'invenio')) == god.items(with_order=True)
+
+
+def test_groupable_ordered_dict_get(god):
+    """Test that a GroupableOrderedDict has get like a dict."""
+    assert ('dojson', 4) == god.get('a')
+    assert 'spam' == god.get('d', 'spam')
+
+
+def test_groupable_ordered_dict_values(god):
+    """Test that a GroupableOrderedDict has values like a dict, but more."""
+    assert ['dojson', 2, 'invenio', 4, 5] == god.values(expand=True)
+    assert [('dojson', 4), (2, 5), 'invenio'] == god.values()
+
+
+def test_groupable_ordered_dict_eq(god):
+    """Test that a GroupableOrderedDict can be compared with ==."""
+    expected = {'a': ('dojson', 4), 'b': (2, 5), 'c': 'invenio'}
+
+    assert expected == god
+    assert not(expected != god)
+
+
+def test_groupable_ordered_dict_copy(god):
+    """Test that a GroupableOrderedDict can be copied."""
+    god2 = copy.copy(god)
+
+    assert god == god2
+
+
+def test_groupable_ordered_dict_new(god):
+    """Test that a GroupableOrderedDict can be created from a same element."""
+    god2 = GroupableOrderedDict(god)
+
+    assert god == god2
+
+
+def test_groupable_ordered_dict_to_json(god):
+    """Test that a GroupableOrderedDict can be serialized to JSON."""
+    expected = json.dumps({'__order__': ('a', 'b', 'c', 'a', 'b'),
+                           'a': ['dojson', 4],
+                           'b': [2, 5],
+                           'c': 'invenio'},
+                          sort_keys=True,
+                          indent=4)
+
+    assert expected == json.dumps(god, indent=4)
+
+
+def test_groupable_ordered_dict_iterable(god):
+    """Test that a GroupableOrderedDict is iterable like a dict."""
+    iterator = iter(god)
+
+    assert 'a' == iterator.next()
+    assert 'b' == iterator.next()
+    assert 'c' == iterator.next()
+    with pytest.raises(StopIteration):
+        iterator.next()
+
+
+def test_groupable_ordered_dict_recreate(god):
+    """Test that a GroupableOrderedDict can be recreated from a dict."""
+    god2 = GroupableOrderedDict({'__order__': ('a', 'b', 'c', 'a', 'b'),
+                                 'a': ['dojson', 4],
+                                 'b': [2, 5],
+                                 'c': 'invenio'})
+
+    assert god2 == god

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,6 @@
 
 """Test suite for DoJSON."""
 
-
 import dojson
 from lxml import etree
 
@@ -325,31 +324,31 @@ def test_marc21_856_indicators():
 
     expected_8564 = {
         'electronic_location_and_access': [
-            {'public_note': ['0'],
+            {'public_note': ('0',),
              'access_method': 'HTTP',
-             'uniform_resource_identifier': [
-                 'https://zenodo.org/record/17575/files/...'],
-             'file_size': ['272681']}
+             'uniform_resource_identifier': (
+                 'https://zenodo.org/record/17575/files/...',),
+             'file_size': ('272681',)}
         ]
     }
     expected_8567 = {
         'electronic_location_and_access': [
-            {'public_note': ['0'],
+            {'public_note': ('0',),
              'access_method': 'Awesome access method',
-             'uniform_resource_identifier': [
-                 'https://zenodo.org/record/17575/files/...'],
-             'file_size': ['272681']}
+             'uniform_resource_identifier': (
+                 'https://zenodo.org/record/17575/files/...',),
+             'file_size': ('272681',)}
         ]
     }
 
     blob = create_record(RECORD_8564)
     data = marc21.do(blob)
-    assert data == expected_8564
+    assert expected_8564 == data
     back_blob = to_marc21.do(data)
     assert blob == back_blob
 
     blob = create_record(RECORD_8567)
     data = marc21.do(blob)
-    assert data == expected_8567
+    assert expected_8567 == data
     back_blob = to_marc21.do(data)
     assert blob == back_blob

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,6 +9,7 @@
 
 """Test suite for DoJSON."""
 
+
 import dojson
 from lxml import etree
 
@@ -274,6 +275,30 @@ def test_tomarc21_from_xml():
         back_blob = to_marc21.do(data)
 
         assert blob == back_blob, name
+
+
+def test_toxml_from_xml():
+    """Test MARC21 loading from XML and recreating to XML."""
+    from dojson.contrib.marc21.utils import create_record
+    from dojson.contrib.to_marc21.utils import dumps
+    from lxml import etree, objectify
+
+    for name, record in RECORDS.items():
+        blob = create_record(record)
+        xml = dumps(blob)
+
+        options = {'xml_declaration': True,
+                   'encoding': 'utf8',
+                   'pretty_print': True}
+
+        recordxml = ('<collection xmlns="http://www.loc.gov/MARC21/slim">' +
+                     record +
+                     '</collection>')
+
+        expected = etree.tostring(objectify.fromstring(recordxml), **options)
+        actual = etree.tostring(objectify.fromstring(xml), **options)
+
+        assert expected == actual
 
 
 def test_marc21_856_indicators():


### PR DESCRIPTION
- A record is filled into a `GroupOrderedDict`. An immutable object that keeps things in order.
- MARC XML can be generated too.
- MARC JSON format has a key called `__order__` to be able to reconstruct it.
