### PR TITLE
global: index using sre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ language: python
 
 python:
   - "2.7"
-# FIXME esmre is not Python 3 compatible
-#  - "3.3"
-#  - "3.4"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 install:
   - pip install --upgrade pip

--- a/dojson/cli.py
+++ b/dojson/cli.py
@@ -28,10 +28,10 @@ New extensions with loaders, dumpers, or rules can be provided via entry points.
 - ``dojson.cli.rule`` instances of :class:`dojson.Overdo` with loaded rules.
 """
 
-import pkg_resources
 import sys
 
 import click
+import pkg_resources
 
 
 @click.group()

--- a/dojson/contrib/marc21/__init__.py
+++ b/dojson/contrib/marc21/__init__.py
@@ -7,6 +7,8 @@
 # modify it under the terms of the Revised BSD License; see LICENSE
 # file for more details.
 
-from model import marc21
+"""Define model for transforming MARC21."""
 
-__all__ = ('marc21',)
+from .model import marc21
+
+__all__ = ('marc21', )

--- a/dojson/contrib/marc21/model.py
+++ b/dojson/contrib/marc21/model.py
@@ -9,7 +9,6 @@
 
 """MARC 21 model definition."""
 
-from dojson import Overdo
-from dojson import utils
+from dojson import Overdo, utils
 
 marc21 = Overdo(entry_point_group='dojson.contrib.marc21')

--- a/dojson/contrib/marc21/utils.py
+++ b/dojson/contrib/marc21/utils.py
@@ -9,12 +9,12 @@
 
 """Utilities for converting MARC21."""
 
-import pkg_resources
 import re
+from collections import Counter, OrderedDict
 
-from collections import OrderedDict, Counter
+import pkg_resources
 from lxml import etree
-from six import StringIO, string_types, iteritems
+from six import StringIO, binary_type, iteritems, text_type
 
 split_marc = re.compile('<record.*?>.*?</record>', re.DOTALL)
 
@@ -103,7 +103,7 @@ class GroupableOrderedDict(OrderedDict):
     def __eq__(self, other):
         if (len(self.keys()) != len(other.keys()) and
                 '__order__' not in other and
-                len(self.keys) - 1 == len(other.keys())):
+                len(self.keys()) - 1 == len(other.keys())):
 
             return False
 
@@ -244,13 +244,16 @@ def create_record(marcxml, correct=False, keep_singletons=True):
     If correct == 1, then perform DTD validation
     If correct == 0, then do not perform DTD validation
     """
-    if isinstance(marcxml, string_types):
+    if isinstance(marcxml, binary_type):
+        marcxml = marcxml.decode('utf-8')
+
+    if isinstance(marcxml, text_type):
         parser = etree.XMLParser(dtd_validation=correct, recover=True)
 
         if correct:
-            marcxml = ('<?xml version="1.0" encoding="UTF-8"?>\n'
-                       '<!DOCTYPE collection SYSTEM "file://{0}">\n'
-                       '<collection>\n{1}\n</collection>'.format(
+            marcxml = (u'<?xml version="1.0" encoding="UTF-8"?>\n'
+                       u'<!DOCTYPE collection SYSTEM "file://{0}">\n'
+                       u'<collection>\n{1}\n</collection>'.format(
                            MARC21_DTD, marcxml))
 
         tree = etree.parse(StringIO(marcxml), parser)

--- a/dojson/contrib/marc21/utils.py
+++ b/dojson/contrib/marc21/utils.py
@@ -78,7 +78,7 @@ class GroupableOrderedDict(OrderedDict):
                 OrderedDict.__getitem__(new, key).extend(v)
 
         # Immutable...
-        for key, value in dict.iteritems(new):
+        for key, value in dict.items(new):
             OrderedDict.__setitem__(new, key, tuple(value))
 
         OrderedDict.__setitem__(new, '__order__', tuple(ordering))

--- a/dojson/contrib/marc21/utils.py
+++ b/dojson/contrib/marc21/utils.py
@@ -14,7 +14,7 @@ import re
 
 from collections import OrderedDict, Counter
 from lxml import etree
-from six import StringIO, string_types
+from six import StringIO, string_types, iteritems
 
 split_marc = re.compile('<record.*?>.*?</record>', re.DOTALL)
 
@@ -61,7 +61,7 @@ class GroupableOrderedDict(OrderedDict):
                         c[key] += 1
                     values = tmp
                 else:
-                    values = values.iteritems()
+                    values = iteritems(values)
 
             for key, value in values:
                 if key not in new:
@@ -183,12 +183,13 @@ class GroupableOrderedDict(OrderedDict):
                 values.append(dict.__getitem__(self, key)[occurences[key]])
                 occurences[key] += 1
         else:
-            for key, value in OrderedDict.iteritems(self):
+            for key, value in OrderedDict.items(self):
                 if key == '__order__':
                     continue
                 if len(value) == 1:
                     values.append(value[0])
-                values.append(value)
+                else:
+                    values.append(value)
         return values
 
     def keys(self, repeated=False):
@@ -199,13 +200,13 @@ class GroupableOrderedDict(OrderedDict):
         keys. It may contain repetitions.
         """
         if not repeated:
-            keys = OrderedDict.keys(self)
+            keys = list(OrderedDict.keys(self))
             keys.remove('__order__')
             return keys
         else:
             return list(self['__order__'])
 
-    def items(self, with_order=False, repeated=False):
+    def items(self, with_order=True, repeated=False):
         """
         list of D's (key, value) pairs, as 2-tuples.
 
@@ -219,14 +220,14 @@ class GroupableOrderedDict(OrderedDict):
     def iteritems(self, with_order=True, repeated=False):
         """Just like D.items() but as an iterator."""
         if not repeated:
-            for key, value in OrderedDict.iteritems(self):
+            if with_order:
+                yield '__order__', self['__order__']
+            for key, value in OrderedDict.items(self):
                 if key != '__order__':
                     if len(value) == 1:
                         yield key, value[0]
                     else:
                         yield key, value
-                elif with_order:
-                    yield key, value
         else:
             occurences = Counter()
             order = self['__order__']

--- a/dojson/contrib/to_marc21/model.py
+++ b/dojson/contrib/to_marc21/model.py
@@ -10,13 +10,11 @@
 """To MARC 21 model definition."""
 
 import warnings
-
 from collections import MutableMapping, MutableSequence
+
 from six import iteritems
 
-from dojson import Overdo
-from dojson import utils
-
+from dojson import Overdo, utils
 
 warnings.warn('MARC21 undo feature is experimental')
 

--- a/dojson/contrib/to_marc21/model.py
+++ b/dojson/contrib/to_marc21/model.py
@@ -36,7 +36,9 @@ class Underdo(Overdo):
             self.build()
 
         for key, value in iteritems(blob):
-            for name, creator, field in self._query(key):
+            result = self.index.query(key)
+            if result:
+                name, creator = result
                 try:
                     value = creator(output, key, value)
                     if isinstance(value, MutableMapping):

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -10,12 +10,9 @@
 """Utilities for converting to MARC21."""
 
 import pkg_resources
-
-from six import string_types
-
 from lxml import etree
 from lxml.builder import E
-
+from six import string_types
 
 MARC21_DTD = pkg_resources.resource_filename(
     'dojson.contrib.marc21', 'MARC21slim.dtd')

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -11,6 +11,8 @@
 
 import pkg_resources
 
+from six import string_types
+
 from lxml import etree
 from lxml.builder import E
 
@@ -29,10 +31,10 @@ def dumps(*records, **kwargs):
 
     for record in records:
         rec = E.record()
-        for df, subfields in record.items(repeated=True):
+        for df, subfields in record.items(with_order=False, repeated=True):
             # Control fields
             if len(df) == 3:
-                if isinstance(subfields, basestring):
+                if isinstance(subfields, string_types):
                     controlfield = E.controlfield(subfields)
                     controlfield.attrib['tag'] = df[0:3]
                     rec.append(controlfield)
@@ -52,8 +54,8 @@ def dumps(*records, **kwargs):
                     datafield.attrib['ind1'] = df[3]
                     datafield.attrib['ind2'] = df[4]
 
-                    for code, value in subfield.items(repeated=True):
-                        if not isinstance(value, basestring):
+                    for code, value in subfield.items(with_order=False, repeated=True):
+                        if not isinstance(value, string_types):
                             for v in value:
                                 datafield.append(E.subfield(v, code=code))
                         else:

--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -9,14 +9,15 @@
 
 """Do JSON translation."""
 
-from sre_parse import Pattern, SubPattern, parse
 from sre_compile import compile as sre_compile
 from sre_constants import BRANCH, SUBPATTERN
+from sre_parse import Pattern, SubPattern, parse
 
 from pkg_resources import iter_entry_points
-
 from six import iteritems
+
 from six.moves import zip_longest
+
 from .utils import IgnoreKey
 
 

--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -9,13 +9,57 @@
 
 """Do JSON translation."""
 
-import re
-import esmre
+from sre_parse import Pattern, SubPattern, parse
+from sre_compile import compile as sre_compile
+from sre_constants import BRANCH, SUBPATTERN
 
 from pkg_resources import iter_entry_points
 
 from six import iteritems
+from six.moves import zip_longest
 from .utils import IgnoreKey
+
+
+class Index(object):
+    """Index implementation based on build-in Python SRE module."""
+
+    def __init__(self, rules=None, flags=0, branch_size=99):
+        """Initialize index structures.
+
+        :param rules: list of tuples (regular expression, data)
+        :param flags: additional flags passed to SRE parser
+        :param branch_size: number of groups in a branch (max. 99)
+        """
+        self._patterns = []
+        self.flags = flags
+        self.rules = rules or []
+        self.branch_size = branch_size
+
+        def make_pattern(rules, flags=0):
+            """Compile a rules to single branch with groups."""
+            pattern = Pattern()
+            pattern.flags = flags
+            pattern.subpatterns = [None] * (len(rules) + 1)
+
+            return sre_compile(SubPattern(pattern, [
+                (BRANCH, (None, [SubPattern(pattern, [
+                    (SUBPATTERN, (group, parse(regex, flags, pattern))),
+                ]) for group, (regex, _) in enumerate(rules, 1)]))
+            ]))
+
+        for rules in zip_longest(*[iter(self.rules)] * self.branch_size):
+            self._patterns.append(make_pattern([
+                rule for rule in rules if rule is not None
+            ]))
+
+    def query(self, key):
+        """Yield data matching the key."""
+        for section, pattern in enumerate(self._patterns):
+            match = pattern.match(key)
+            if match:
+                return self.rules[
+                    section * self.branch_size + match.lastindex - 1
+                ][1]
 
 
 class Overdo(object):
@@ -41,24 +85,16 @@ class Overdo(object):
     def build(self):
         """Build."""
         self._collect_entry_points()
-        self.index = esmre.Index()
-        for rule in self.rules:
-            self.index.enter(*rule)
+        self.index = Index(self.rules)
 
     def over(self, name, *source_tags):
         """Register creator rule."""
         def decorator(creator):
             self.index = None
             for field in source_tags:
-                self.rules.append((field, (name, creator, re.compile(field))))
+                self.rules.append((field, (name, creator)))
             return creator
         return decorator
-
-    def _query(self, key):
-        """Query."""
-        for name, creator, field in self.index.query(key):
-            if field.match(key):
-                yield name, creator, field
 
     def do(self, blob):
         """Translate blob values and instantiate new model instance."""
@@ -68,7 +104,9 @@ class Overdo(object):
             self.build()
 
         for key, value in iteritems(blob):
-            for name, creator, field in self._query(key):
+            result = self.index.query(key)
+            if result:
+                name, creator = result
                 try:
                     data = creator(output, key, value)
                     if getattr(creator, '__extend__', False):
@@ -86,4 +124,4 @@ class Overdo(object):
         """Return keys with missing rules."""
         if self.index is None:
             self.build()
-        return [key for key in blob.keys() if not len(list(self._query(key)))]
+        return [key for key in blob.keys() if self.index.query(key) is None]

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -9,7 +9,10 @@
 
 """Utility functions."""
 
+import codecs
 import functools
+import json
+
 import six
 
 
@@ -85,3 +88,9 @@ def reverse_force_list(data):
     if isinstance(data, (list, set)) and len(data) == 1:
         return data[0]
     return data
+
+
+def load(stream):
+    """Load JSON from bytestream."""
+    reader = codecs.getreader("utf-8")
+    return json.load(reader(stream))

--- a/dojson/version.py
+++ b/dojson/version.py
@@ -16,4 +16,4 @@ This file is imported by ``dojson.__init__``, and parsed by
 # Do not change the format of this next line. Doing so risks breaking
 # setup.py and docs/conf.py
 
-__version__ = "0.4.1.dev20151118"
+__version__ = "1.0.0.dev20151217"

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ setup(
     platforms='any',
     install_requires=[
         'click',
-        'esmre',
         'lxml',
         'six',
     ],
@@ -100,7 +99,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
-        'Development Status :: 5 - Production/Stable',
+        'Development Status :: 1 - Planning',
     ],
     tests_require=tests_require,
     cmdclass={'test': PyTest},

--- a/setup.py
+++ b/setup.py
@@ -142,7 +142,7 @@ setup(
             'to_marc21 = dojson.contrib.to_marc21:to_marc21',
         ],
         'dojson.cli.load': [
-            'json = json:load',
+            'json = dojson.utils:load',
             'marcxml = dojson.contrib.marc21.utils:load',
         ],
         'dojson.cli.dump': [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,7 @@ def test_cli_do_marc21_from_xml():
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        with open('record.xml', 'wb') as f:
+        with open('record.xml', 'w') as f:
             f.write(RECORD_SIMPLE)
 
         result = runner.invoke(
@@ -51,7 +51,7 @@ def test_cli_do_marc21_from_json():
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        with open('record.json', 'wb') as fp:
+        with open('record.json', 'w') as fp:
             record = create_record(RECORD_SIMPLE)
             json.dump(record, fp)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,8 +23,8 @@ def test_cli_do_marc21_from_xml():
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        with open('record.xml', 'w') as f:
-            f.write(RECORD_SIMPLE)
+        with open('record.xml', 'wb') as f:
+            f.write(RECORD_SIMPLE.encode('utf-8'))
 
         result = runner.invoke(
             cli.missing_fields,
@@ -51,9 +51,9 @@ def test_cli_do_marc21_from_json():
     runner = CliRunner()
 
     with runner.isolated_filesystem():
-        with open('record.json', 'w') as fp:
+        with open('record.json', 'wb') as fp:
             record = create_record(RECORD_SIMPLE)
-            json.dump(record, fp)
+            fp.write(json.dumps(record).encode('utf-8'))
 
         result = runner.invoke(
             cli.missing_fields,

--- a/tests/test_contrib_marc21.py
+++ b/tests/test_contrib_marc21.py
@@ -49,12 +49,12 @@ def test_groupable_ordered_dict_items(god):
     """Test that a GroupableOrderedDict has items like a dict, but more."""
     assert (('a', ('dojson', 4)),
             ('b', (2, 5)),
-            ('c', 'invenio')) == god.items()
+            ('c', 'invenio')) == god.items(with_order=False)
 
     assert (('__order__', ('a', 'b', 'c', 'a', 'b')),
             ('a', ('dojson', 4)),
             ('b', (2, 5)),
-            ('c', 'invenio')) == god.items(with_order=True)
+            ('c', 'invenio')) == god.items()
 
     assert (('__order__', ('a', 'b', 'c', 'a', 'b')),
             ('a', 'dojson'),
@@ -115,12 +115,12 @@ def test_groupable_ordered_dict_iterable(god):
     """Test that a GroupableOrderedDict is iterable like a dict."""
     iterator = iter(god)
 
-    assert '__order__' == iterator.next()
-    assert 'a' == iterator.next()
-    assert 'b' == iterator.next()
-    assert 'c' == iterator.next()
+    assert '__order__' == next(iterator)
+    assert 'a' == next(iterator)
+    assert 'b' == next(iterator)
+    assert 'c' == next(iterator)
     with pytest.raises(StopIteration):
-        iterator.next()
+        next(iterator)
 
 
 def test_groupable_ordered_dict_recreate(god):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -238,30 +238,32 @@ def test_marc21_loader():
 
 def test_marc21_split_stream():
     """Test MARC21 split_stream()."""
-    from six import StringIO
+    from six import BytesIO
     from dojson.contrib.marc21.utils import split_stream
 
-    COLLECTION = '<collection>{0}{1}</collection>'.format(
+    COLLECTION = u'<collection>{0}{1}</collection>'.format(
         RECORD, RECORD_SIMPLE
     )
-    generator = split_stream(StringIO(COLLECTION.encode('utf-8')))
-    assert etree.tostring(generator.next(), method='html') == RECORD
-    assert etree.tostring(generator.next(), method='html') == RECORD_SIMPLE
+    generator = split_stream(BytesIO(COLLECTION.encode('utf-8')))
+    assert etree.tostring(
+        next(generator), method='html').decode('utf-8') == RECORD
+    assert etree.tostring(
+        next(generator), method='html').decode('utf-8') == RECORD_SIMPLE
 
 
 def test_marc21_records_over_single_line():
     """Test records over single line."""
-    from six import StringIO, u
+    from six import BytesIO
     from dojson.contrib.marc21.utils import split_stream
 
-    records = (u('<record>foo</record>'),
-               u('<record>会意字</record>'),
-               u('<record>&gt;&amp;&lt;</record>'))
-    collection = u('<collection>{0}</collection>').format(u('').join(records))
+    records = (u'<record>foo</record>',
+               u'<record>会意字</record>',
+               u'<record>&gt;&amp;&lt;</record>')
+    collection = u'<collection>{0}</collection>'.format(u''.join(records))
 
-    generator = split_stream(StringIO(collection.encode('utf-8')))
+    generator = split_stream(BytesIO(collection.encode('utf-8')))
     for record in records:
-        result = etree.tostring(generator.next(),
+        result = etree.tostring(next(generator),
                                 encoding='utf-8',
                                 method='xml')
         assert record.encode('utf-8') == result


### PR DESCRIPTION
- INCOMPATIBLE Removes support for matching multiple rules for single
  key - make your rules mutually exclusive!
- BETTER Adds support for Python 3+.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
