### PR TITLE
global: addition of ignore missing option

### DIFF
--- a/dojson/cli.py
+++ b/dojson/cli.py
@@ -59,15 +59,17 @@ def open_entry_point(group_name):
 @click.option('-d', '--dump', callback=open_entry_point('dojson.cli.dump'),
               default='json')
 @click.argument('rule', callback=open_entry_point('dojson.cli.rule'))
-def apply_rule(source, load, dump, rule):
+@click.option('--strict', is_flag=True, default=False,
+              help='Raise when there is not matching rule for a key.')
+def apply_rule(source, load, dump, rule, strict):
     """Create JSON using given rule."""
     data = load(source)
 
     if isinstance(data, dict):
-        click.echo(dump(rule.do(data)))
+        click.echo(dump(rule.do(data, ignore_missing=not strict)))
     else:
         click.echo(dump([
-            rule.do(item) for item in data
+            rule.do(item, ignore_missing=not strict) for item in data
         ]))
 
 

--- a/dojson/errors.py
+++ b/dojson/errors.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2015 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""Define all DoJSON exceptions."""
+
+
+class DoJSONException(Exception):
+    """Parent for all DoJSON exceptions.
+
+    .. versionadded:: 1.0.0
+
+    """
+
+
+class IgnoreKey(DoJSONException):
+    """The corresponding key has been ignored.
+
+    .. versionadded:: 0.2.0
+
+    """
+
+
+class MissingRule(DoJSONException):
+    """Raise when no matching rule was found.
+
+    .. versionadded:: 1.0.0
+
+    """

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -15,15 +15,7 @@ import json
 
 import six
 
-
-class IgnoreKey(Exception):
-    """The corresponding key has been ignored.
-
-    .. versionadded:: 0.2.0
-
-    """
-
-    pass
+from .errors import IgnoreKey
 
 
 def ignore_value(f):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,12 @@ RECORD_SIMPLE = """<record>
   </datafield>
 </record>"""
 
+RECORD_999_FIELD = """<record>
+  <datafield tag="999" ind1=" " ind2=" ">
+    <subfield code="a">I'm crazy field!</subfield>
+  </datafield>
+</record>"""
+
 # http://www.loc.gov/marc/umb/um07to10.html
 RECORD_THEATER = """<record>
   <datafield tag="650" ind1=" " ind2=" ">


### PR DESCRIPTION
- NEW Adds `ignore_missing` option to `Overdo.do` method to specify if
  method should raise when there is no matching rule for any key.
  (closes #51)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
