### PR TITLE
installation: pydocstyle>=1.0.0

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,6 @@
 # it under the terms of the Revised BSD License; see LICENSE file for
 # more details.
 
-pep257 --match-dir='dojson' dojson && \
+pydocstyle --match-dir='dojson' dojson && \
 sphinx-build -qnNW docs docs/_build/html && \
 python setup.py test

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join('dojson', 'version.py'), 'rt') as f:
     ).group('version')
 
 tests_require = [
-    'pep257>=0.7.0',
+    'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',


### PR DESCRIPTION
- Replaces pep257 with pydocstyle.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
