### PR TITLE
dojson: field ordering fixes

### DIFF
--- a/dojson/contrib/marc21/fields/ad01x09x.py
+++ b/dojson/contrib/marc21/fields/ad01x09x.py
@@ -229,7 +229,17 @@ def coded_cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def system_control_number(self, key, value):
     """System Control Number."""
+    field_map = {
+        'a': 'system_control_number',
+        'z': 'canceled_invalid_control_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'system_control_number': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')

--- a/dojson/contrib/marc21/fields/ad1xx3xx.py
+++ b/dojson/contrib/marc21/fields/ad1xx3xx.py
@@ -521,7 +521,7 @@ def complex_see_also_reference_subject(self, key, value):
         'heading_referred_to': utils.force_list(
             value.get('a')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'explanatory_text': utils.force_list(

--- a/dojson/contrib/marc21/fields/ad260360.py
+++ b/dojson/contrib/marc21/fields/ad260360.py
@@ -23,7 +23,7 @@ def complex_see_reference_subject(self, key, value):
         'heading_referred_to': utils.force_list(
             value.get('a')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'explanatory_text': utils.force_list(
@@ -45,7 +45,7 @@ def complex_see_also_reference_subject(self, key, value):
         'heading_referred_to': utils.force_list(
             value.get('a')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'explanatory_text': utils.force_list(

--- a/dojson/contrib/marc21/fields/bd00x.py
+++ b/dojson/contrib/marc21/fields/bd00x.py
@@ -38,6 +38,12 @@ def fixed_length_data_elements_additional_material_characteristics(
     return value
 
 
+@marc21.over('physical_description_fixed_field', '^007')
+def reverse_physical_description_fixed_field(self, key, value):
+    """Physical Description Fixed Field."""
+    return value
+
+
 @marc21.over('fixed_length_data_elements', '^008')
 def fixed_length_data_elements(self, key, value):
     """Fixed-Length Data Elements."""

--- a/dojson/contrib/marc21/fields/bd01x09x.py
+++ b/dojson/contrib/marc21/fields/bd01x09x.py
@@ -62,7 +62,19 @@ def patent_control_information(self, key, value):
 @utils.filter_values
 def national_bibliography_number(self, key, value):
     """National Bibliography Number."""
+    field_map = {
+        'a': 'national_bibliography_number',
+        'q': 'qualifying_information',
+        'z': 'canceled_invalid_national_bibliography_number',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'national_bibliography_number': utils.force_list(
             value.get('a')
         ),
@@ -86,9 +98,24 @@ def national_bibliography_number(self, key, value):
 def national_bibliographic_agency_control_number(self, key, value):
     """National Bibliographic Agency Control Number."""
     indicator_map1 = {
-        "#": "Library and Archives Canada",
-        "7": "Source specified in subfield $2"}
+        '#': 'Library and Archives Canada',
+        '7': 'Source specified in subfield $2',
+    }
+
+    field_map = {
+        'a': 'record_control_number',
+        'z': 'canceled_invalid_control_number',
+        '2': 'source',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('national_bibliographic_agency')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'record_control_number': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -108,8 +135,27 @@ def copyright_or_legal_deposit_number(self, key, value):
     """Copyright or Legal Deposit Number."""
     indicator_map2 = {
         "#": "Copyright or legal deposit number",
-        "8": "No display constant generated"}
+        "8": "No display constant generated",
+    }
+
+    field_map = {
+        'a': 'copyright_or_legal_deposit_number',
+        'b': 'assigning_agency',
+        'd': 'date',
+        'i': 'display_text',
+        'z': 'canceled_invalid_copyright_or_legal',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'copyright_or_legal_deposit_number': utils.force_list(
             value.get('a')
         ),
@@ -319,13 +365,32 @@ def publisher_number(self, key, value):
         "2": "Plate number",
         "3": "Other music number",
         "4": "Videorecording number",
-        "5": "Other publisher number"}
+        "5": "Other publisher number",
+    }
     indicator_map2 = {
         "0": "No note, no added entry",
         "1": "Note, added entry",
         "2": "Note, no added entry",
-        "3": "No note, added entry"}
+        "3": "No note, added entry",
+    }
+
+    field_map = {
+        'a': 'publisher_number',
+        'b': 'source',
+        'q': 'qualifying_information',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_publisher_number')
+    if key[4] in indicator_map2:
+        order.append('note_added_entry_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'publisher_number': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -426,13 +491,36 @@ def date_time_and_place_of_an_event(self, key, value):
         "#": "No date information ",
         "0": "Single date ",
         "1": "Multiple single dates ",
-        "2": "Range of dates "}
+        "2": "Range of dates ",
+    }
     indicator_map2 = {
         "#": "No information provided ",
         "0": "Capture ",
         "1": "Broadcast ",
-        "2": "Finding "}
+        "2": "Finding ",
+    }
+
+    field_map = {
+        'a': 'formatted_date_time',
+        'b': 'geographic_classification_area_code',
+        'c': 'geographic_classification_subarea_code',
+        'p': 'place_of_event',
+        '0': 'authority_record_control_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_date_in_subfield_a')
+    if key[4] in indicator_map2:
+        order.append('type_of_event')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'formatted_date_time': utils.force_list(
             value.get('a')
         ),
@@ -445,7 +533,7 @@ def date_time_and_place_of_an_event(self, key, value):
         'place_of_event': utils.force_list(
             value.get('p')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -469,12 +557,50 @@ def coded_cartographic_mathematical_data(self, key, value):
     indicator_map1 = {
         "0": "Scale indeterminable/No scale recorded",
         "1": "Single scale",
-        "3": "Range of scales"}
+        "3": "Range of scales",
+    }
     indicator_map2 = {
         "#": "Not applicable",
         "0": "Outer ring",
-        "1": "Exclusion ring"}
+        "1": "Exclusion ring",
+    }
+
+    field_map = {
+        'a': 'category_of_scale',
+        'b': 'constant_ratio_linear_horizontal_scale',
+        'c': 'constant_ratio_linear_vertical_scale',
+        'd': 'coordinates_westernmost_longitude',
+        'e': 'coordinates_easternmost_longitude',
+        'f': 'coordinates_northernmost_latitude',
+        'g': 'coordinates_southernmost_latitude',
+        'h': 'angular_scale',
+        'j': 'declination_northern_limit',
+        'k': 'declination_southern_limit',
+        'm': 'right_ascension_eastern_limit',
+        'n': 'right_ascension_western_limit',
+        'p': 'equinox',
+        'r': 'distance_from_earth',
+        's': 'g_ring_latitude',
+        't': 'g_ring_longitude',
+        'x': 'beginning_date',
+        'y': 'ending_date',
+        'z': 'name_of_extraterrestrial_body',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_scale')
+    if key[4] in indicator_map2:
+        order.append('type_of_ring')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
@@ -523,7 +649,17 @@ def coded_cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def system_control_number(self, key, value):
     """System Control Number."""
+    field_map = {
+        'a': 'system_control_number',
+        'z': 'canceled_invalid_control_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'system_control_number': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -554,7 +690,32 @@ def original_study_number_for_computer_data_files(self, key, value):
 @utils.filter_values
 def source_of_acquisition(self, key, value):
     """Source of Acquisition."""
+    indicator_map1 = {
+        'Not applicable/No information provided/Earliest': '#',
+        'Intervening': '2',
+        'Current/Latest': '3',
+    }
+
+    field_map = {
+        'a': 'stock_number',
+        'b': 'source_of_stock_number_acquisition',
+        'c': 'terms_of_availability',
+        'f': 'form_of_issue',
+        'g': 'additional_format_characteristics',
+        'n': 'note',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('source_of_acquisition_sequence')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'stock_number': value.get('a'),
         'terms_of_availability': utils.force_list(
             value.get('c')
@@ -573,6 +734,7 @@ def source_of_acquisition(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
+        'source_of_acquisition_sequence': indicator_map1.get(key[3], '_'),
     }
 
 
@@ -593,7 +755,19 @@ def record_content_licensor(self, key, value):
 @utils.filter_values
 def cataloging_source(self, key, value):
     """Cataloging Source."""
+    field_map = {
+        'a': 'original_cataloging_agency',
+        'b': 'language_of_cataloging',
+        'c': 'transcribing_agency',
+        'd': 'modifying_agency',
+        'e': 'description_conventions',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
     return {
+        '__order__': tuple(order) if len(order) else None,
         'original_cataloging_agency': value.get('a'),
         'transcribing_agency': value.get('c'),
         'language_of_cataloging': value.get('b'),
@@ -701,10 +875,23 @@ def geographic_area_code(self, key, value):
 
 
 @marc21.over('country_of_publishing_producing_entity_code', '^044..')
+@utils.for_each_value
 @utils.filter_values
 def country_of_publishing_producing_entity_code(self, key, value):
     """Country of Publishing/Producing Entity Code."""
+    field_map = {
+        'a': 'marc_country_code',
+        'b': 'local_subentity_code',
+        'c': 'iso_country_code',
+        '2': 'source_of_local_subentity_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'marc_country_code': utils.force_list(
             value.get('a')
         ),
@@ -756,7 +943,28 @@ def time_period_of_content(self, key, value):
 @utils.filter_values
 def special_coded_dates(self, key, value):
     """Special Coded Dates."""
+    field_map = {
+        'a': 'type_of_date_code',
+        'b': 'date_1_b.c._date',
+        'c': 'date_1_c.e._date',
+        'd': 'date_2_b.c._date',
+        'e': 'date_2_c.e._date',
+        'j': 'date_resource_modified',
+        'k': 'beginning_or_single_date_created',
+        'l': 'ending_date_created',
+        'm': 'beginning_of_date_valid',
+        'n': 'end_of_date_valid',
+        'o': 'single_or_starting_date_for_aggregated_content',
+        'p': 'ending_date_for_aggregated_content',
+        '2': 'source_of_date',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'type_of_date_code': value.get('a'),
         'date_1_ce_date': value.get('c'),
         'date_1_bc_date': value.get('b'),
@@ -782,7 +990,24 @@ def special_coded_dates(self, key, value):
 @utils.filter_values
 def form_of_musical_composition_code(self, key, value):
     """Form of Musical Composition Code."""
+    indicator_map2 = {
+        '#': 'MARC musical composition code',
+        '7': 'Source specified in subfield $2',
+    }
+
+    field_map = {
+        'form_of_musical_composition_code': 'a',
+        'source_of_code': '2',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] != '#' and key[4] in indicator_map2:
+        order.append('source_of_code')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'form_of_musical_composition_code': utils.force_list(
             value.get('a')
         ),
@@ -818,13 +1043,32 @@ def number_of_musical_instruments_or_voices_code(self, key, value):
 def library_of_congress_call_number(self, key, value):
     """Library of Congress Call Number."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Item is in LC",
-        "1": "Item is not in LC"}
+        '#': 'No information provided',
+        '0': 'Item is in LC',
+        '1': 'Item is not in LC',
+    }
     indicator_map2 = {
-        "0": "Assigned by LC",
-        "4": "Assigned by agency other than LC"}
+        '0': 'Assigned by LC',
+        '4': 'Assigned by agency other than LC',
+    }
+
+    field_map = {
+        'a': 'classification_number',
+        'b': 'item_number',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_lc_collection')
+    if key[4] in indicator_map2:
+        order.append('source_of_call_number')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'classification_number': utils.force_list(
             value.get('a')
         ),
@@ -859,7 +1103,28 @@ def library_of_congress_copy_issue_offprint_statement(self, key, value):
 @utils.filter_values
 def geographic_classification(self, key, value):
     """Geographic Classification."""
+    indicator_map1 = {
+        '#': 'Library of Congress Classification',
+        '1': 'U.S. Dept. of Defense Classification',
+        '7': 'Source specified in subfield $2',
+    }
+
+    field_map = {
+        'a': 'geographic_classification_area_code',
+        'b': 'geographic_classification_subarea_code',
+        'd': 'populated_place_name',
+        '2': 'code_source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('code_source')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'geographic_classification_area_code': value.get('a'),
         'geographic_classification_subarea_code': utils.force_list(
             value.get('b')
@@ -917,11 +1182,28 @@ def national_library_of_medicine_call_number(self, key, value):
     indicator_map1 = {
         "#": "No information provided",
         "0": "Item is in NLM",
-        "1": "Item is not in NLM"}
+        "1": "Item is not in NLM",
+    }
     indicator_map2 = {
         "0": "Assigned by NLM",
-        "4": "Assigned by agency other than NLM"}
+        "4": "Assigned by agency other than NLM",
+    }
+
+    field_map = {
+        'a': 'classification_number_r',
+        'b': 'item_number',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_nlm_collection')
+    if key[4] in indicator_map2:
+        order.append('source_of_call_number')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'classification_number_r': utils.force_list(
             value.get('a')
         ),
@@ -970,7 +1252,19 @@ def character_sets_present(self, key, value):
 def national_agricultural_library_call_number(self, key, value):
     """National Agricultural Library Call Number."""
     indicator_map1 = {"0": "Item is in NAL", "1": "Item is not in NAL"}
+    field_map = {
+        'a': 'classification_number',
+        'b': 'item_number',
+        '8': 'field_link_and_sequence_number_r',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_nal_collection')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'classification_number': utils.force_list(
             value.get('a')
         ),
@@ -1195,16 +1489,36 @@ def synthesized_classification_number_components(self, key, value):
 @utils.filter_values
 def government_document_classification_number(self, key, value):
     """Government Document Classification Number."""
+    indicator_map1 = {
+        '#': 'Source specified in subfield $2',
+        '0': 'Superintendent of Documents Classification System',
+        '1': 'Government of Canada Publications: Outline of Classification',
+    }
+
+    field_map = {
+        'a': 'classification_number',
+        'z': 'canceled_invalid_classification_number',
+        '2': 'number_source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] != '#' and key[3] in indicator_map1:
+        order.append('number_source')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'classification_number': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'number_source': value.get('2'),
         'canceled_invalid_classification_number': utils.force_list(
             value.get('z')
         ),
         'linkage': value.get('6'),
+        'number_source': value.get('2') if key[3] == '#' else indicator_map1.get(key[3]),
     }
 
 

--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -15,11 +15,45 @@ from ..model import marc21
 
 
 @marc21.over('main_entry_personal_name', '^100[103_].')
+@utils.for_each_value
 @utils.filter_values
 def main_entry_personal_name(self, key, value):
     """Main Entry-Personal Name."""
-    indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
+    indicator_map1 = {
+        '0': 'Forename',
+        '1': 'Surname',
+        '3': 'Family name',
+    }
+
+    field_map = {
+        'a': 'personal_name',
+        'b': 'numeration',
+        'c': 'titles_and_words_associated_with_a_name',
+        'd': 'dates_associated_with_a_name',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'j': 'attribution_qualifier',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'fuller_form_of_name',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        '0': 'authority_record_control_number_or_standard_number',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'personal_name': value.get('a'),
         'titles_and_words_associated_with_a_name': utils.force_list(
             value.get('c')
@@ -45,7 +79,7 @@ def main_entry_personal_name(self, key, value):
             value.get('n')
         ),
         'fuller_form_of_name': value.get('q'),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'affiliation': value.get('u'),
@@ -66,10 +100,38 @@ def main_entry_personal_name(self, key, value):
 def main_entry_corporate_name(self, key, value):
     """Main Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
+    field_map = {
+        'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
+        'b': 'subordinate_unit',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting_or_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        '0': 'authority_record_control_number_or_standard_number',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
         'location_of_meeting': value.get('c'),
         'subordinate_unit': utils.force_list(
@@ -93,7 +155,7 @@ def main_entry_corporate_name(self, key, value):
         'number_of_part_section_meeting': utils.force_list(
             value.get('n')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'affiliation': value.get('u'),
@@ -116,8 +178,37 @@ def main_entry_meeting_name(self, key, value):
     indicator_map1 = {
         "0": "Inverted name",
         "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        "2": "Name in direct order",
+    }
+
+    field_map = {
+        'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting',
+        'e': 'subordinate_unit',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'j': 'relator_term',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'name_of_meeting_following_jurisdiction_name_entry_element',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        '0': 'authority_record_control_number_or_standard_number',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
         'location_of_meeting': value.get('c'),
         'subordinate_unit': utils.force_list(
@@ -140,7 +231,7 @@ def main_entry_meeting_name(self, key, value):
             value.get('n')
         ),
         'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'affiliation': value.get('u'),
@@ -157,21 +248,39 @@ def main_entry_meeting_name(self, key, value):
 
 
 @marc21.over('main_entry_uniform_title', '^130[_1032547698].')
+@utils.for_each_value
 @utils.filter_values
 def main_entry_uniform_title(self, key, value):
     """Main Entry-Uniform Title."""
-    indicator_map1 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        '0': 'authority_record_control_number_or_standard_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
@@ -193,7 +302,7 @@ def main_entry_uniform_title(self, key, value):
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'version': value.get('s'),
@@ -203,5 +312,5 @@ def main_entry_uniform_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': indicator_map1.get(key[3]),
+        'nonfiling_characters': key[3] if key[3] else '_',
     }

--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -105,7 +105,7 @@ def uniform_title(self, key, value):
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'version': value.get('s'),
@@ -164,19 +164,41 @@ def collective_uniform_title(self, key, value):
     """Collective Uniform Title."""
     indicator_map1 = {
         "0": "Not printed or displayed",
-        "1": "Printed or displayed"}
-    indicator_map2 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+        "1": "Printed or displayed",
+    }
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('uniform_title_printed_or_displayed')
+
+    order.append('nonfiling_characters')
+    if key[4] in valid_nonfiling_characters:
+        nonfiling_characters = key[4]
+    else:
+        nonfiling_characters = '_'
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
         'date_of_treaty_signing': utils.force_list(
             value.get('d')
@@ -205,7 +227,7 @@ def collective_uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': nonfiling_characters,
     }
 
 
@@ -323,9 +345,37 @@ def varying_form_of_title(self, key, value):
 @utils.filter_values
 def former_title(self, key, value):
     """Former Title."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
+    }
+    indicator_map2 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
+    field_map = {
+        'a': 'title',
+        'b': 'remainder_of_title',
+        'f': 'date_or_sequential_designation',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        'x': 'international_standard_serial_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in indicator_map2:
+        order.append('note_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'remainder_of_title': value.get('b'),

--- a/dojson/contrib/marc21/fields/bd25x28x.py
+++ b/dojson/contrib/marc21/fields/bd25x28x.py
@@ -116,8 +116,28 @@ def publication_distribution_imprint(self, key, value):
     indicator_map1 = {
         "#": "Not applicable/No information provided/Earliest available publisher",
         "2": "Intervening publisher",
-        "3": "Current/latest publisher"}
+        "3": "Current/latest publisher",
+    }
+
+    field_map = {
+        'a': 'place_of_publication_distribution',
+        'b': 'name_of_publisher_distributor',
+        'c': 'date_of_publication_distribution',
+        'e': 'place_of_manufacture',
+        'f': 'manufacturer',
+        'g': 'date_of_manufacture',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('sequence_of_publishing_statements')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'place_of_publication_distribution': utils.force_list(
             value.get('a')
         ),

--- a/dojson/contrib/marc21/fields/bd3xx.py
+++ b/dojson/contrib/marc21/fields/bd3xx.py
@@ -19,7 +19,22 @@ from ..model import marc21
 @utils.filter_values
 def physical_description(self, key, value):
     """Physical Description."""
+    field_map = {
+        'a': 'extent',
+        'b': 'other_physical_details',
+        'c': 'dimensions',
+        'e': 'accompanying_material',
+        'f': 'type_of_unit',
+        'g': 'size_of_unit',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'extent': utils.force_list(
             value.get('a')
         ),
@@ -93,7 +108,17 @@ def current_publication_frequency(self, key, value):
 @utils.filter_values
 def former_publication_frequency(self, key, value):
     """Former Publication Frequency."""
+    field_map = {
+        'a': 'former_publication_frequency',
+        'b': 'dates_of_former_publication_frequency',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'former_publication_frequency': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -129,7 +154,20 @@ def content_type(self, key, value):
 @utils.filter_values
 def media_type(self, key, value):
     """Media Type."""
+    field_map = {
+        'a': 'media_type_term',
+        'b': 'media_type_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'media_type_term': utils.force_list(
             value.get('a')
         ),
@@ -150,7 +188,20 @@ def media_type(self, key, value):
 @utils.filter_values
 def carrier_type(self, key, value):
     """Carrier Type."""
+    field_map = {
+        'a': 'carrier_type_term',
+        'b': 'carrier_type_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'carrier_type_term': utils.force_list(
             value.get('a')
         ),
@@ -306,7 +357,26 @@ def planar_coordinate_data(self, key, value):
 @utils.filter_values
 def sound_characteristics(self, key, value):
     """Sound Characteristics."""
+    field_map = {
+        'a': 'type_of_recording',
+        'b': 'recording_medium',
+        'c': 'playing_speed',
+        'd': 'groove_characteristic',
+        'e': 'track_configuration',
+        'f': 'tape_configuration',
+        'g': 'configuration_of_playback_channels',
+        'h': 'special_playback_characteristics',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'type_of_recording': utils.force_list(
             value.get('a')
         ),
@@ -432,7 +502,19 @@ def digital_file_characteristics(self, key, value):
 @utils.filter_values
 def organization_and_arrangement_of_materials(self, key, value):
     """Organization and Arrangement of Materials."""
+    field_map = {
+        'a': 'organization',
+        'b': 'arrangement',
+        'c': 'hierarchical_level',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'organization': utils.force_list(
             value.get('a')
         ),
@@ -665,7 +747,18 @@ def associated_language(self, key, value):
 @utils.filter_values
 def form_of_work(self, key, value):
     """Form of Work."""
+    field_map = {
+        'a': 'form_of_work',
+        '0': 'record_control_number',
+        '2': 'source_of_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'form_of_work': utils.force_list(
             value.get('a')
         ),

--- a/dojson/contrib/marc21/fields/bd4xx.py
+++ b/dojson/contrib/marc21/fields/bd4xx.py
@@ -166,18 +166,27 @@ def series_statement_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def series_statement_added_entry_title(self, key, value):
     """Series Statement/Added Entry-Title."""
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'a': 'title',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        'v': 'volume_sequential_designation',
+        'w': 'bibliographic_record_control_number',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'name_of_part_section_of_a_work': utils.force_list(
@@ -187,7 +196,7 @@ def series_statement_added_entry_title(self, key, value):
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'bibliographic_record_control_number': utils.force_list(
@@ -197,7 +206,7 @@ def series_statement_added_entry_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 

--- a/dojson/contrib/marc21/fields/bd5xx.py
+++ b/dojson/contrib/marc21/fields/bd5xx.py
@@ -462,8 +462,29 @@ def study_program_information_note(self, key, value):
     """Study Program Information Note."""
     indicator_map1 = {
         "0": "Reading program",
-        "8": "No display constant generated"}
+        "8": "No display constant generated",
+    }
+
+    field_map = {
+        'a': 'program_name',
+        'b': 'interest_level',
+        'c': 'reading_level',
+        'd': 'title_point_value',
+        'i': 'display_text',
+        'x': 'nonpublic_note',
+        'z': 'public_note',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'program_name': value.get('a'),
         'nonpublic_note': utils.force_list(
             value.get('x')
@@ -489,7 +510,21 @@ def study_program_information_note(self, key, value):
 @utils.filter_values
 def additional_physical_form_available_note(self, key, value):
     """Additional Physical Form Available Note."""
+    field_map = {
+        'a': 'additional_physical_form_available_note',
+        'b': 'availability_source',
+        'c': 'availability_conditions',
+        'd': 'order_number',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'additional_physical_form_available_note': value.get('a'),
         'availability_conditions': value.get('c'),
         'availability_source': value.get('b'),
@@ -510,7 +545,26 @@ def additional_physical_form_available_note(self, key, value):
 @utils.filter_values
 def reproduction_note(self, key, value):
     """Reproduction Note."""
+    field_map = {
+        'a': 'type_of_reproduction',
+        'b': 'place_of_reproduction',
+        'c': 'agency_responsible_for_reproduction',
+        'd': 'date_of_reproduction',
+        'e': 'physical_description_of_reproduction',
+        'f': 'series_statement_of_reproduction',
+        'm': 'dates_and_or_sequential_designation_of_issues_reproduced',
+        'n': 'note_about_reproduction',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '7': 'fixed_length_data_elements_of_reproduction',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'type_of_reproduction': value.get('a'),
         'agency_responsible_for_reproduction': utils.force_list(
             value.get('c')
@@ -544,7 +598,30 @@ def reproduction_note(self, key, value):
 @utils.filter_values
 def original_version_note(self, key, value):
     """Original Version Note."""
+    field_map = {
+        'a': 'main_entry_of_original',
+        'b': 'edition_statement_of_original',
+        'c': 'publication_distribution_of_original',
+        'e': 'physical_description_of_original',
+        'f': 'series_statement_of_original',
+        'k': 'key_title_of_original',
+        'l': 'location_of_original',
+        'm': 'material_specific_details',
+        'n': 'note_about_original',
+        'o': 'other_resource_identifier',
+        'p': 'introductory_phrase',
+        't': 'title_statement_of_original',
+        'x': 'international_standard_serial_number',
+        'z': 'international_standard_book_number',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'main_entry_of_original': value.get('a'),
         'international_standard_serial_number': utils.force_list(
             value.get('x')
@@ -611,7 +688,23 @@ def location_of_originals_duplicates_note(self, key, value):
 @utils.filter_values
 def funding_information_note(self, key, value):
     """Funding Information Note."""
+    field_map = {
+        'a': 'text_of_note',
+        'b': 'contract_number',
+        'c': 'grant_number',
+        'd': 'undifferentiated_number',
+        'e': 'program_element_number',
+        'f': 'project_number',
+        'g': 'task_number',
+        'h': 'work_unit_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'text_of_note': value.get('a'),
         'grant_number': utils.force_list(
             value.get('c')
@@ -885,7 +978,16 @@ def former_title_complexity_note(self, key, value):
 @utils.filter_values
 def issuing_body_note(self, key, value):
     """Issuing Body Note."""
+    field_map = {
+        'a': 'issuing_body_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'issuing_body_note': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -1269,11 +1371,31 @@ def awards_note(self, key, value):
 @utils.filter_values
 def source_of_description_note(self, key, value):
     """Source of Description Note."""
+    indicator_map1 = {
+        '#': 'No information provided',
+        '0': 'Source of description',
+        '1': 'Latest issue consulted',
+    }
+
+    field_map = {
+        'a': 'source_of_description_note',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'source_of_description_note': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
+        'display_constant_controller': indicator_map1.get(key[3], '_')
     }

--- a/dojson/contrib/marc21/fields/bd6xx.py
+++ b/dojson/contrib/marc21/fields/bd6xx.py
@@ -28,9 +28,52 @@ def subject_added_entry_personal_name(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2",
+    }
+
+    field_map = {
+        'a': 'personal_name',
+        'b': 'numeration',
+        'c': 'titles_and_other_words_associated_with_a_name',
+        'd': 'dates_associated_with_a_name',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'j': 'attribution_qualifier',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'fuller_form_of_name',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -110,9 +153,50 @@ def subject_added_entry_corporate_name(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2"
+    }
+
+    field_map = {
+        'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
+        'b': 'subordinate_unit',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting_or_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_meeting',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -190,9 +274,48 @@ def subject_added_entry_meeting_name(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2",
+    }
+
+    field_map = {
+        'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting',
+        'e': 'subordinate_unit',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'j': 'relator_term',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'name_of_meeting_following_jurisdiction_name_entry_element',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -253,17 +376,7 @@ def subject_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def subject_added_entry_uniform_title(self, key, value):
     """Subject Added Entry-Uniform Title."""
-    indicator_map1 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {
         "0": "Library of Congress Subject Headings",
         "1": "LC subject headings for children\u0027s literature",
@@ -272,9 +385,47 @@ def subject_added_entry_uniform_title(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2"
+    }
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -325,7 +476,7 @@ def subject_added_entry_uniform_title(self, key, value):
         'geographic_subdivision': utils.force_list(
             value.get('z')
         ),
-        'nonfiling_characters': indicator_map1.get(key[3]),
+        'nonfiling_characters': key[3],
         'thesaurus': indicator_map2.get(key[4]),
     }
 
@@ -347,8 +498,25 @@ def subject_added_entry_chronological_term(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2"
+    }
+
+    field_map = {
+        'a': 'chronological_term',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'chronological_term': value.get('a'),
         'general_subdivision': utils.force_list(
             value.get('x')
@@ -395,13 +563,33 @@ def subject_added_entry_topical_term(self, key, value):
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
         "7": "Source specified in subfield $2"}
+
     field_map = {
-        '2': 'source_of_heading_or_term',
         'a': 'topical_term_or_geographic_name_entry_element',
+        'b': 'topical_term_following_geographic_name_entry_element',
+        'c': 'location_of_event',
+        'd': 'active_dates',
+        'e': 'relator_term',
+        'g': 'miscellaneous_information',
+        '4': 'relator_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
         'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
         'z': 'geographic_subdivision',
     }
+
     order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_subject')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'topical_term_or_geographic_name_entry_element': value.get('a'),
@@ -417,7 +605,7 @@ def subject_added_entry_topical_term(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -453,8 +641,32 @@ def subject_added_entry_geographic_name(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2"
+    }
+
+    field_map = {
+        'a': 'geographic_name',
+        'e': 'relator_term',
+        'g': 'miscellaneous_information',
+        '4': 'relator_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'geographic_name': value.get('a'),
         'general_subdivision': utils.force_list(
             value.get('x')
@@ -465,7 +677,7 @@ def subject_added_entry_geographic_name(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -505,8 +717,24 @@ def index_term_uncontrolled(self, key, value):
         "3": "Meeting name",
         "4": "Chronological term",
         "5": "Geographic name",
-        "6": "Genre/form term"}
+        "6": "Genre/form term"
+    }
+
+    field_map = {
+        'a': 'uncontrolled_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_index_term')
+    if key[4] in indicator_map2:
+        order.append('type_of_term_or_name')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uncontrolled_term': utils.force_list(
             value.get('a')
         ),
@@ -528,8 +756,32 @@ def subject_added_entry_faceted_topical_terms(self, key, value):
         "#": "No information provided",
         "0": "No level specified",
         "1": "Primary",
-        "2": "Secondary"}
+        "2": "Secondary"
+    }
+
+    field_map = {
+        'a': 'focus_term',
+        'b': 'non_focus_term',
+        'c': 'facet_hierarchy_designation',
+        'e': 'relator_term',
+        'v': 'form_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_subject')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'focus_term': utils.force_list(
             value.get('a')
         ),
@@ -545,7 +797,7 @@ def subject_added_entry_faceted_topical_terms(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -581,8 +833,34 @@ def index_term_genre_form(self, key, value):
         "4": "Source not specified",
         "5": "Canadian Subject Headings",
         "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        "7": "Source specified in subfield $2"
+    }
+
+    field_map = {
+        'a': 'genre_form_data_or_focus_term',
+        'b': 'non_focus_term',
+        'c': 'facet_hierarchy_designation',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_heading')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'genre_form_data_or_focus_term': value.get('a'),
         'general_subdivision': utils.force_list(
             value.get('x')
@@ -596,7 +874,7 @@ def index_term_genre_form(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -622,7 +900,24 @@ def index_term_genre_form(self, key, value):
 @utils.filter_values
 def index_term_occupation(self, key, value):
     """Index Term-Occupation."""
+    field_map = {
+        'a': 'occupation',
+        'k': 'form',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'occupation': value.get('a'),
         'general_subdivision': utils.force_list(
             value.get('x')
@@ -631,7 +926,7 @@ def index_term_occupation(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -654,7 +949,23 @@ def index_term_occupation(self, key, value):
 @utils.filter_values
 def index_term_function(self, key, value):
     """Index Term-Function."""
+    field_map = {
+        'a': 'function',
+        'v': 'form_subdivision',
+        'x': 'general_subdivision',
+        'y': 'chronological_subdivision',
+        'z': 'geographic_subdivision',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'function': value.get('a'),
         'general_subdivision': utils.force_list(
             value.get('x')
@@ -662,7 +973,7 @@ def index_term_function(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -685,7 +996,20 @@ def index_term_function(self, key, value):
 @utils.filter_values
 def index_term_curriculum_objective(self, key, value):
     """Index Term-Curriculum Objective."""
+    field_map = {
+        'a': 'main_curriculum_objective',
+        'b': 'subordinate_curriculum_objective',
+        'c': 'curriculum_code',
+        'd': 'correlation_factor',
+        '2': 'source_of_term_or_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'main_curriculum_objective': value.get('a'),
         'curriculum_code': value.get('c'),
         'subordinate_curriculum_objective': utils.force_list(
@@ -705,7 +1029,26 @@ def index_term_curriculum_objective(self, key, value):
 @utils.filter_values
 def subject_added_entry_hierarchical_place_name(self, key, value):
     """Subject Added Entry-Hierarchical Place Name."""
+    field_map = {
+        'a': 'country_or_larger_entity',
+        'b': 'first_order_political_jurisdiction',
+        'c': 'intermediate_political_jurisdiction',
+        'd': 'city',
+        'e': 'relator_term',
+        'f': 'city_subsection',
+        'g': 'other_nonjurisdictional_geographic_region_and_feature',
+        'h': 'extraterrestrial_area',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'country_or_larger_entity': utils.force_list(
             value.get('a')
         ),
@@ -726,7 +1069,7 @@ def subject_added_entry_hierarchical_place_name(self, key, value):
         'extraterrestrial_area': utils.force_list(
             value.get('h')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'source_of_heading_or_term': value.get('2'),

--- a/dojson/contrib/marc21/fields/bd70x75x.py
+++ b/dojson/contrib/marc21/fields/bd70x75x.py
@@ -22,7 +22,7 @@ def added_entry_personal_name(self, key, value):
     indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
     field_map = {
-        '0': 'authority_record_control_number',
+        '0': 'authority_record_control_number_or_standard_number',
         '3': 'materials_specified',
         '4': 'relator_code',
         '5': 'institution_to_which_field_applies',
@@ -57,7 +57,7 @@ def added_entry_personal_name(self, key, value):
         order.append('type_of_added_entry')
 
     return {
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -123,8 +123,46 @@ def added_entry_corporate_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+
+    field_map = {
+        'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
+        'b': 'subordinate_unit',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting_or_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'i': 'relationship_information',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_meeting',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -187,8 +225,44 @@ def added_entry_meeting_name(self, key, value):
         "1": "Jurisdiction name",
         "2": "Name in direct order"}
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+
+    field_map = {
+        'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting',
+        'e': 'subordinate_unit',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'i': 'relationship_information',
+        'j': 'relator_term',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'name_of_meeting_following_jurisdiction_name_entry_element',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -241,7 +315,22 @@ def added_entry_meeting_name(self, key, value):
 def added_entry_uncontrolled_name(self, key, value):
     """Added Entry-Uncontrolled Name."""
     indicator_map1 = {"#": "Not specified", "1": "Personal", "2": "Other"}
+
+    field_map = {
+        'a': 'name',
+        'e': 'relator_term',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_name')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'name': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -262,19 +351,45 @@ def added_entry_uncontrolled_name(self, key, value):
 @utils.filter_values
 def added_entry_uniform_title(self, key, value):
     """Added Entry-Uniform Title."""
-    indicator_map1 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
-    indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+    indicator_map2 = {
+        '#': 'No information provided',
+        '2': 'Analytical entry',
+    }
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'i': 'relationship_information',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'name_of_part_section_of_a_work': utils.force_list(
@@ -300,7 +415,7 @@ def added_entry_uniform_title(self, key, value):
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -312,30 +427,40 @@ def added_entry_uniform_title(self, key, value):
             value.get('8')
         ),
         'version': value.get('s'),
-        'nonfiling_characters': indicator_map1.get(key[3]),
+        'nonfiling_characters': key[3],
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
 
 @marc21.over(
-    'added_entry_uncontrolled_related_analytical_title', '^740[_1032547698][_2]')
+    'added_entry_uncontrolled_related_analytical_title',
+    '^740[_1032547698][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uncontrolled_related_analytical_title(self, key, value):
     """Added Entry-Uncontrolled Related/Analytical Title."""
-    indicator_map1 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+
+    field_map = {
+        'a': 'uncontrolled_related_analytical_title',
+        'h': 'medium',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uncontrolled_related_analytical_title': value.get('a'),
         'medium': value.get('h'),
         'number_of_part_section_of_a_work': utils.force_list(
@@ -349,7 +474,7 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': indicator_map1.get(key[3]),
+        'nonfiling_characters': key[3],
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
@@ -359,12 +484,26 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
 @utils.filter_values
 def added_entry_geographic_name(self, key, value):
     """Added Entry-Geographic Name."""
+    field_map = {
+        'a': 'geographic_name',
+        'e': 'relator_term',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'geographic_name': value.get('a'),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -384,7 +523,24 @@ def added_entry_geographic_name(self, key, value):
 @utils.filter_values
 def added_entry_hierarchical_place_name(self, key, value):
     """Added Entry-Hierarchical Place Name."""
+    field_map = {
+        'a': 'country_or_larger_entity',
+        'b': 'first_order_political_jurisdiction',
+        'c': 'intermediate_political_jurisdiction',
+        'd': 'city',
+        'f': 'city_subsection',
+        'g': 'other_nonjurisdictional_geographic_region_and_feature',
+        'h': 'extraterrestrial_area',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_heading_or_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'country_or_larger_entity': utils.force_list(
             value.get('a')
         ),
@@ -402,7 +558,7 @@ def added_entry_hierarchical_place_name(self, key, value):
         'extraterrestrial_area': utils.force_list(
             value.get('h')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'source_of_heading_or_term': value.get('2'),
@@ -418,7 +574,18 @@ def added_entry_hierarchical_place_name(self, key, value):
 @utils.filter_values
 def system_details_access_to_computer_files(self, key, value):
     """System Details Access to Computer Files."""
+    field_map = {
+        'a': 'make_and_model_of_machine',
+        'b': 'programming_language',
+        'c': 'operating_system',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'make_and_model_of_machine': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -434,7 +601,22 @@ def system_details_access_to_computer_files(self, key, value):
 @utils.filter_values
 def added_entry_taxonomic_identification(self, key, value):
     """Added Entry-Taxonomic Identification."""
+    field_map = {
+        'a': 'taxonomic_name',
+        'c': 'taxonomic_category',
+        'd': 'common_or_alternative_name',
+        'x': 'non_public_note',
+        'z': 'public_note',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_taxonomic_identification',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'taxonomic_name': utils.force_list(
             value.get('a')
         ),
@@ -447,7 +629,7 @@ def added_entry_taxonomic_identification(self, key, value):
         'common_or_alternative_name': utils.force_list(
             value.get('d')
         ),
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'source_of_taxonomic_identification': value.get('2'),

--- a/dojson/contrib/marc21/fields/bd76x78x.py
+++ b/dojson/contrib/marc21/fields/bd76x78x.py
@@ -21,7 +21,38 @@ def main_series_entry(self, key, value):
     """Main Series Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Main series", "8": "No display constant generated"}
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        's': 'uniform_title',
+        't': 'title',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'qualifying_information': value.get('c'),
@@ -68,8 +99,40 @@ def subseries_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Has subseries",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        's': 'uniform_title',
+        't': 'title',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'qualifying_information': value.get('c'),
@@ -116,8 +179,44 @@ def original_language_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Translation of",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -174,8 +273,44 @@ def translation_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Translated as",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -232,8 +367,44 @@ def supplement_special_issue_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Has supplement",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -291,8 +462,44 @@ def supplement_parent_entry(self, key, value):
     indicator_map2 = {
         "#": "Supplement to",
         "0": "Parent",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -348,12 +555,42 @@ def host_item_entry(self, key, value):
     """Host Item Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "In", "8": "No display constant generated"}
+
     field_map = {
         'a': 'main_entry_heading',
+        'b': 'edition',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
         'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
         'n': 'note',
+        'o': 'other_item_identifier',
+        'p': 'abbreviated_title',
+        'q': 'enumeration_and_first_page',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '3': 'materials_specified',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
     }
+
     order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'materials_specified': value.get('3'),
@@ -414,8 +651,44 @@ def constituent_unit_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Constituent unit",
-        "8": "No display constant generated"}
+        "8": "No display constant generated"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -473,12 +746,43 @@ def other_edition_entry(self, key, value):
     indicator_map2 = {
         "#": "Other edition available",
         "8": "No display constant generated"}
+
     field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'e': 'language_code',
+        'f': 'country_code',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
         's': 'uniform_title',
+        't': 'title',
         'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
         'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
     }
+
     order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
@@ -540,7 +844,42 @@ def additional_physical_form_entry(self, key, value):
     indicator_map2 = {
         "#": "Available in another form",
         "8": "No display constant generated"}
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -596,7 +935,39 @@ def issued_with_entry(self, key, value):
     """Issued With Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Issued with", "8": "No display constant generated"}
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        's': 'uniform_title',
+        't': 'title',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
         'international_standard_serial_number': value.get('x'),
         'qualifying_information': value.get('c'),
@@ -652,8 +1023,44 @@ def preceding_entry(self, key, value):
         "4": "Formed by the union of ... and ...",
         "5": "Absorbed",
         "6": "Absorbed in part",
-        "7": "Separated from"}
+        "7": "Separated from"
+    }
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('type_of_relationship')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -718,7 +1125,42 @@ def succeeding_entry(self, key, value):
         "6": "Split into ... and ...",
         "7": "Merged with ... to form ...",
         "8": "Changed back to"}
+
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number'
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('type_of_relationship')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -774,7 +1216,45 @@ def data_source_entry(self, key, value):
     """Data Source Entry."""
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {"#": "Data source", "8": "No display constant generated"}
+
+    field_map = {
+        'a': 'main_entry_heading_(nr)',
+        'b': 'edition_(nr)',
+        'c': 'qualifying_information_(nr)',
+        'd': 'place_publisher_and_date_of_publication_(nr)',
+        'g': 'related_parts_(r)',
+        'h': 'physical_description_(nr)',
+        'i': 'relationship_information_(r)',
+        'j': 'period_of_content_(nr)',
+        'k': 'series_data_for_related_item_(r)',
+        'm': 'material_specific_details_(nr)',
+        'n': 'note_(r)',
+        'o': 'other_item_identifier_(r)',
+        'p': 'abbreviated_title_(nr)',
+        'r': 'report_number_(r)',
+        's': 'uniform_title_(nr)',
+        't': 'title_(nr)',
+        'u': 'standard_technical_report_number_(nr)',
+        'v': 'source_contribution_(nr)',
+        'w': 'record_control_number_(r)',
+        'x': 'international_standard_serial_number_(nr)',
+        'y': 'coden_designation_(nr)',
+        'z': 'international_standard_book_number_(r)',
+        '4': 'relationship_code_(r)',
+        '6': 'linkage_(nr)',
+        '7': 'control_subfield_(nr)',
+        '8': 'field_link_and_sequence_number_(r)',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),
@@ -834,8 +1314,43 @@ def other_relationship_entry(self, key, value):
     indicator_map1 = {"0": "Display note", "1": "Do not display note"}
     indicator_map2 = {
         "#": "Related item",
-        "8": "No display constant generated"}
+        "8": "No display constant generated",
+    }
+    field_map = {
+        'a': 'main_entry_heading',
+        'b': 'edition',
+        'c': 'qualifying_information',
+        'd': 'place_publisher_and_date_of_publication',
+        'g': 'related_parts',
+        'h': 'physical_description',
+        'i': 'relationship_information',
+        'k': 'series_data_for_related_item',
+        'm': 'material_specific_details',
+        'n': 'note',
+        'o': 'other_item_identifier',
+        'r': 'report_number',
+        's': 'uniform_title',
+        't': 'title',
+        'u': 'standard_technical_report_number',
+        'w': 'record_control_number',
+        'x': 'international_standard_serial_number',
+        'y': 'coden_designation',
+        'z': 'international_standard_book_number',
+        '4': 'relationship_code',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'relationship_code': utils.force_list(
             value.get('4')
         ),

--- a/dojson/contrib/marc21/fields/bd80x83x.py
+++ b/dojson/contrib/marc21/fields/bd80x83x.py
@@ -19,9 +19,53 @@ from ..model import marc21
 @utils.filter_values
 def series_added_entry_personal_name(self, key, value):
     """Series Added Entry-Personal Name."""
-    indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
+    indicator_map1 = {
+        '0': 'Forename',
+        '1': 'Surname',
+        '3': 'Family name',
+    }
+
+    field_map = {
+        'a': 'personal_name',
+        'b': 'numeration',
+        'c': 'titles_and_other_words_associated_with_a_name',
+        'd': 'dates_associated_with_a_name',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'j': 'attribution_qualifier',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'fuller_form_of_name',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'volume_sequential_designation',
+        'w': 'bibliographic_record_control_number',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -85,11 +129,50 @@ def series_added_entry_personal_name(self, key, value):
 def series_added_entry_corporate_name(self, key, value):
     """Series Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
+    field_map = {
+        'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
+        'b': 'subordinate_unit',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting_or_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_meeting',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'volume_sequential_designation',
+        'w': 'bibliographic_record_control_number',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -151,11 +234,48 @@ def series_added_entry_corporate_name(self, key, value):
 def series_added_entry_meeting_name(self, key, value):
     """Series Added Entry-Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
+    field_map = {
+        'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting',
+        'e': 'subordinate_unit',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'j': 'relator_term',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'name_of_meeting_following_jurisdiction_name',
+        's': 'version',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'volume_sequential_designation',
+        'w': 'bibliographic_record_control_number',
+        'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '7': 'control_subfield',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+
     return {
-        'authority_record_control_number': utils.force_list(
+        '__order__': tuple(order) if len(order) else None,
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
@@ -222,7 +342,7 @@ def series_added_entry_uniform_title(self, key, value):
         "8": "Number of nonfiling characters",
         "9": "Number of nonfiling characters"}
     return {
-        'authority_record_control_number': utils.force_list(
+        'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),

--- a/dojson/contrib/marc21/fields/bd84188x.py
+++ b/dojson/contrib/marc21/fields/bd84188x.py
@@ -49,8 +49,46 @@ def location(self, key, value):
         "#": "No information provided",
         "0": "Not enumeration",
         "1": "Primary enumeration",
-        "2": "Alternative enumeration"}
+        "2": "Alternative enumeration"
+    }
+
+    field_map = {
+        'a': 'location',
+        'b': 'sublocation_or_collection',
+        'c': 'shelving_location',
+        'd': 'former_shelving_location',
+        'e': 'address',
+        'f': 'coded_location_qualifier',
+        'g': 'non_coded_location_qualifier',
+        'h': 'classification_part',
+        'i': 'item_part',
+        'j': 'shelving_control_number',
+        'k': 'call_number_prefix',
+        'l': 'shelving_form_of_title',
+        'm': 'call_number_suffix',
+        'n': 'country_code',
+        'p': 'piece_designation',
+        'q': 'piece_physical_condition',
+        's': 'copyright_article_fee_code',
+        't': 'copy_number',
+        'u': 'uniform_resource_identifier',
+        'x': 'nonpublic_note',
+        'z': 'public_note',
+        '2': 'source_of_classification_or_shelving_scheme',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('shelving_scheme')
+    if key[4] in indicator_map2:
+        order.append('shelving_order')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'materials_specified': value.get('3'),
         'source_of_classification_or_shelving_scheme': value.get('2'),
         'linkage': value.get('6'),
@@ -164,6 +202,7 @@ def electronic_location_and_access(self, key, value):
         order.append('relationship')
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'materials_specified': value.get('3'),
         'access_method':
         value.get('2') if key[3] == '7' else indicator_map1.get(key[3]),
@@ -226,7 +265,6 @@ def electronic_location_and_access(self, key, value):
             value.get('z')
         ),
         'relationship': indicator_map2.get(key[4]),
-        '__order__': tuple(order) if len(order) else None,
     }
 
 

--- a/dojson/contrib/marc21/model.py
+++ b/dojson/contrib/marc21/model.py
@@ -14,6 +14,21 @@ from dojson import Overdo, utils
 marc21 = Overdo(entry_point_group='dojson.contrib.marc21')
 """MARC 21 Format for Bibliographic Data."""
 
+
+@marc21.over('__order__', '__order__')
+def order(self, key, value):
+    """Preserve order of datafields."""
+    order = []
+    for field in value:
+        name = marc21.index.query(field)
+        if name:
+            name = name[0]
+        else:
+            name = field
+        order.append(name)
+
+    return order
+
 marc21_authority = Overdo(entry_point_group='dojson.contrib.marc21_authority')
 """MARC 21 Format for Authority Data."""
 

--- a/dojson/contrib/marc21/schemas/ad1xx3xx.json
+++ b/dojson/contrib/marc21/schemas/ad1xx3xx.json
@@ -894,7 +894,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/ad260360.json
+++ b/dojson/contrib/marc21/schemas/ad260360.json
@@ -13,7 +13,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -49,7 +49,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/bd01x09x.json
+++ b/dojson/contrib/marc21/schemas/bd01x09x.json
@@ -653,7 +653,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/bd1xx.json
+++ b/dojson/contrib/marc21/schemas/bd1xx.json
@@ -64,7 +64,7 @@
                 "fuller_form_of_name": {
                     "type": "string"
                 },
-                "authority_record_control_number": {
+                "authority_record_control_number_or_standard_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -150,7 +150,7 @@
                         "type": "string"
                     }
                 },
-                "authority_record_control_number": {
+                "authority_record_control_number_or_standard_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -236,7 +236,7 @@
                 "name_of_meeting_following_jurisdiction_name_entry_element": {
                     "type": "string"
                 },
-                "authority_record_control_number": {
+                "authority_record_control_number_or_standard_number": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -319,7 +319,7 @@
                         "type": "string"
                     }
                 },
-                "authority_record_control_number": {
+                "authority_record_control_number_or_standard_number": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd20x24x.json
+++ b/dojson/contrib/marc21/schemas/bd20x24x.json
@@ -121,7 +121,7 @@
                         "type": "string"
                     }
                 },
-                "authority_record_control_number": {
+                "authority_record_control_number_or_standard_number": {
                     "type": "array",
                     "items": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/bd4xx.json
+++ b/dojson/contrib/marc21/schemas/bd4xx.json
@@ -301,7 +301,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/bd6xx.json
+++ b/dojson/contrib/marc21/schemas/bd6xx.json
@@ -13,7 +13,7 @@
                     "thesaurus": {
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -160,7 +160,7 @@
                     "thesaurus": {
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -301,7 +301,7 @@
                     "thesaurus": {
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -430,7 +430,7 @@
                     "thesaurus": {
                         "enum": ["Source specified in subfield $2", "LC subject headings for children\u0027s literature", "National Agricultural Library subject authority file", "Canadian Subject Headings", "R\u00e9pertoire de vedettes-mati\u00e8re", "Medical Subject Headings", "Source not specified", "Library of Congress Subject Headings"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -652,7 +652,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -724,7 +724,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -835,7 +835,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -916,7 +916,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -979,7 +979,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -1036,7 +1036,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -1156,7 +1156,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/bd70x75x.json
+++ b/dojson/contrib/marc21/schemas/bd70x75x.json
@@ -13,7 +13,7 @@
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -145,7 +145,7 @@
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -271,7 +271,7 @@
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -478,7 +478,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -571,7 +571,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -643,7 +643,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -721,7 +721,7 @@
                             "type": "string"
                         }
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/marc21/schemas/bd80x83x.json
+++ b/dojson/contrib/marc21/schemas/bd80x83x.json
@@ -10,7 +10,7 @@
                     "type_of_personal_name_entry_element": {
                         "enum": ["Family name", "Surname", "Forename"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -148,7 +148,7 @@
                     "type_of_corporate_name_entry_element": {
                         "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -280,7 +280,7 @@
                     "type_of_meeting_name_entry_element": {
                         "enum": ["Inverted name", "Jurisdiction name", "Name in direct order"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"
@@ -400,7 +400,7 @@
                     "nonfiling_characters": {
                         "enum": ["No nonfiling characters", "Number of nonfiling characters"]
                     },
-                    "authority_record_control_number": {
+                    "authority_record_control_number_or_standard_number": {
                         "type": "array",
                         "items": {
                             "type": "string"

--- a/dojson/contrib/to_marc21/fields/bd00x.py
+++ b/dojson/contrib/to_marc21/fields/bd00x.py
@@ -43,6 +43,12 @@ def reverse_fixed_length_data_elements_additional_material_characteristics(
     return [value]
 
 
+@to_marc21.over('007', '^physical_description_fixed_field$')
+def reverse_physical_description_fixed_field(self, key, value):
+    """Reverse - Physical Description Fixed Field."""
+    return [value]
+
+
 @to_marc21.over('008', '^fixed_length_data_elements$')
 def reverse_fixed_length_data_elements(self, key, value):
     """Reverse - Fixed-Length Data Elements."""

--- a/dojson/contrib/to_marc21/fields/bd01x09x.py
+++ b/dojson/contrib/to_marc21/fields/bd01x09x.py
@@ -66,7 +66,19 @@ def reverse_patent_control_information(self, key, value):
 @utils.filter_values
 def reverse_national_bibliography_number(self, key, value):
     """Reverse - National Bibliography Number."""
+    field_map = {
+        'national_bibliography_number': 'a',
+        'qualifying_information': 'q',
+        'canceled_invalid_national_bibliography_number': 'z',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('national_bibliography_number')
         ),
@@ -92,9 +104,24 @@ def reverse_national_bibliography_number(self, key, value):
 def reverse_national_bibliographic_agency_control_number(self, key, value):
     """Reverse - National Bibliographic Agency Control Number."""
     indicator_map1 = {
-        "Library and Archives Canada": "_",
-        "Source specified in subfield $2": "7"}
+        'Library and Archives Canada': '_',
+        'Source specified in subfield $2': '7',
+    }
+
+    field_map = {
+        'record_control_number': 'a',
+        'canceled_invalid_control_number': 'z',
+        'source': '2',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('national_bibliographic_agency')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('record_control_number'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -115,8 +142,27 @@ def reverse_copyright_or_legal_deposit_number(self, key, value):
     """Reverse - Copyright or Legal Deposit Number."""
     indicator_map2 = {
         "Copyright or legal deposit number": "_",
-        "No display constant generated": "8"}
+        "No display constant generated": "8",
+    }
+
+    field_map = {
+        'copyright_or_legal_deposit_number': 'a',
+        'assigning_agency': 'b',
+        'date': 'd',
+        'display_text': 'i',
+        'canceled_invalid_copyright_or_legal': 'z',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('copyright_or_legal_deposit_number')),
         'b': value.get('assigning_agency'),
@@ -335,13 +381,32 @@ def reverse_publisher_number(self, key, value):
         "Other music number": "3",
         "Other publisher number": "5",
         "Plate number": "2",
-        "Videorecording number": "4"}
+        "Videorecording number": "4",
+    }
     indicator_map2 = {
         "No note, added entry": "3",
         "No note, no added entry": "0",
         "Note, added entry": "1",
-        "Note, no added entry": "2"}
+        "Note, no added entry": "2",
+    }
+
+    field_map = {
+        'publisher_number': 'a',
+        'source': 'b',
+        'qualifying_information': 'q',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_publisher_number')
+    if key[4] in indicator_map2:
+        order.append('note_added_entry_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('publisher_number'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -450,13 +515,36 @@ def reverse_date_time_and_place_of_an_event(self, key, value):
         "Multiple single dates ": "1",
         "No date information ": "_",
         "Range of dates ": "2",
-        "Single date ": "0"}
+        "Single date ": "0",
+    }
     indicator_map2 = {
         "Broadcast ": "1",
         "Capture ": "0",
         "Finding ": "2",
-        "No information provided ": "_"}
+        "No information provided ": "_",
+    }
+
+    field_map = {
+        'formatted_date_time': 'a',
+        'geographic_classification_area_code': 'b',
+        'geographic_classification_subarea_code': 'c',
+        'place_of_event': 'p',
+        'authority_record_control_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_date_in_subfield_a')
+    if key[4] in indicator_map2:
+        order.append('type_of_event')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('formatted_date_time')),
         'c': utils.reverse_force_list(
@@ -466,7 +554,7 @@ def reverse_date_time_and_place_of_an_event(self, key, value):
         'p': utils.reverse_force_list(
             value.get('place_of_event')),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')),
+            value.get('authority_record_control_number_or_standard_number')),
         '3': value.get('materials_specified'),
         '2': utils.reverse_force_list(
             value.get('source_of_term')),
@@ -490,12 +578,50 @@ def reverse_coded_cartographic_mathematical_data(self, key, value):
     indicator_map1 = {
         "Range of scales": "3",
         "Scale indeterminable/No scale recorded": "0",
-        "Single scale": "1"}
+        "Single scale": "1",
+    }
     indicator_map2 = {
         "Exclusion ring": "1",
         "Not applicable": "_",
-        "Outer ring": "0"}
+        "Outer ring": "0",
+    }
+
+    field_map = {
+        'category_of_scale': 'a',
+        'constant_ratio_linear_horizontal_scale': 'b',
+        'constant_ratio_linear_vertical_scale': 'c',
+        'coordinates_westernmost_longitude': 'd',
+        'coordinates_easternmost_longitude': 'e',
+        'coordinates_northernmost_latitude': 'f',
+        'coordinates_southernmost_latitude': 'g',
+        'angular_scale': 'h',
+        'declination_northern_limit': 'j',
+        'declination_southern_limit': 'k',
+        'right_ascension_eastern_limit': 'm',
+        'right_ascension_western_limit': 'n',
+        'equinox': 'p',
+        'distance_from_earth': 'r',
+        'g_ring_latitude': 's',
+        'g_ring_longitude': 't',
+        'beginning_date': 'x',
+        'ending_date': 'y',
+        'name_of_extraterrestrial_body': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_scale')
+    if key[4] in indicator_map2:
+        order.append('type_of_ring')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
@@ -544,7 +670,17 @@ def reverse_coded_cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def reverse_system_control_number(self, key, value):
     """Reverse - System Control Number."""
+    field_map = {
+        'system_control_number': 'a',
+        'canceled_invalid_control_number': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('system_control_number'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -579,7 +715,32 @@ def reverse_original_study_number_for_computer_data_files(self, key, value):
 @utils.filter_values
 def reverse_source_of_acquisition(self, key, value):
     """Reverse - Source of Acquisition."""
+    indicator_map1 = {
+        '#': 'Not applicable/No information provided/Earliest',
+        '2': 'Intervening',
+        '3': 'Current/Latest',
+    }
+
+    field_map = {
+        'stock_number': 'a',
+        'source_of_stock_number_acquisition': 'b',
+        'terms_of_availability': 'c',
+        'form_of_issue': 'f',
+        'additional_format_characteristics': 'g',
+        'note': 'n',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('source_of_acquisition_sequence')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('stock_number'),
         'c': utils.reverse_force_list(
             value.get('terms_of_availability')
@@ -598,7 +759,7 @@ def reverse_source_of_acquisition(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': '_',
+        '$ind1': indicator_map1.get(key[3], '_'),
         '$ind2': '_',
     }
 
@@ -622,7 +783,20 @@ def reverse_record_content_licensor(self, key, value):
 @utils.filter_values
 def reverse_cataloging_source(self, key, value):
     """Reverse - Cataloging Source."""
+    field_map = {
+        'original_cataloging_agency': 'a',
+        'language_of_cataloging': 'b',
+        'transcribing_agency': 'c',
+        'modifying_agency': 'd',
+        'description_conventions': 'e',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('original_cataloging_agency'),
         'c': value.get('transcribing_agency'),
         'b': value.get('language_of_cataloging'),
@@ -742,7 +916,19 @@ def reverse_geographic_area_code(self, key, value):
 @utils.filter_values
 def reverse_country_of_publishing_producing_entity_code(self, key, value):
     """Reverse - Country of Publishing/Producing Entity Code."""
+    field_map = {
+        'marc_country_code': 'a',
+        'local_subentity_code': 'b',
+        'iso_country_code': 'c',
+        'source_of_local_subentity_code': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('marc_country_code')
         ),
@@ -795,7 +981,28 @@ def reverse_time_period_of_content(self, key, value):
 @utils.filter_values
 def reverse_special_coded_dates(self, key, value):
     """Reverse - Special Coded Dates."""
+    field_map = {
+        'type_of_date_code': 'a',
+        'date_1_b.c._date': 'b',
+        'date_1_c.e._date': 'c',
+        'date_2_b.c._date': 'd',
+        'date_2_c.e._date': 'e',
+        'date_resource_modified': 'j',
+        'beginning_or_single_date_created': 'k',
+        'ending_date_created': 'l',
+        'beginning_of_date_valid': 'm',
+        'end_of_date_valid': 'n',
+        'single_or_starting_date_for_aggregated_content': 'o',
+        'ending_date_for_aggregated_content': 'p',
+        'source_of_date': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('type_of_date_code'),
         'c': value.get('date_1_ce_date'),
         'b': value.get('date_1_bc_date'),
@@ -823,7 +1030,24 @@ def reverse_special_coded_dates(self, key, value):
 @utils.filter_values
 def reverse_form_of_musical_composition_code(self, key, value):
     """Reverse - Form of Musical Composition Code."""
+    indicator_map2 = {
+        'MARC musical composition code': '#',
+        'Source specified in subfield $2': '7',
+    }
+
+    field_map = {
+        'form_of_musical_composition_code': 'a',
+        'source_of_code': '2',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] != '#' and key[4] in indicator_map2:
+        order.append('source_of_code')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('form_of_musical_composition_code')
         ),
@@ -832,7 +1056,7 @@ def reverse_form_of_musical_composition_code(self, key, value):
         ),
         '2': value.get('source_of_code'),
         '$ind1': '_',
-        '$ind2': '_',
+        '$ind2': value.get(indicator_map2.get('source_of_code'), '#'),
     }
 
 
@@ -863,12 +1087,32 @@ def reverse_number_of_musical_instruments_or_voices_code(self, key, value):
 def reverse_library_of_congress_call_number(self, key, value):
     """Reverse - Library of Congress Call Number."""
     indicator_map1 = {
-        "Item is in LC": "0",
-        "Item is not in LC": "1",
-        "No information provided": "_"}
-    indicator_map2 = {"Assigned by LC": "0",
-                      "Assigned by agency other than LC": "4"}
+        'Item is in LC': '0',
+        'Item is not in LC': '1',
+        'No information provided': '_',
+    }
+    indicator_map2 = {
+        'Assigned by LC': '0',
+        'Assigned by agency other than LC': '4',
+    }
+
+    field_map = {
+        'classification_number': 'a',
+        'item_number': 'b',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_lc_collection')
+    if key[4] in indicator_map2:
+        order.append('source_of_call_number')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('classification_number')),
         '8': utils.reverse_force_list(
@@ -910,7 +1154,28 @@ def reverse_library_of_congress_copy_issue_offprint_statement(
 @utils.filter_values
 def reverse_geographic_classification(self, key, value):
     """Reverse - Geographic Classification."""
+    indicator_map1 = {
+        'Library of Congress Classification': '#',
+        'U.S. Dept. of Defense Classification': '1',
+        'Source specified in subfield $2': '7',
+    }
+
+    field_map = {
+        'geographic_classification_area_code': 'a',
+        'geographic_classification_subarea_code': 'b',
+        'populated_place_name': 'd',
+        'code_source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('code_source')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_classification_area_code'),
         'b': utils.reverse_force_list(
             value.get('geographic_classification_subarea_code')
@@ -923,7 +1188,7 @@ def reverse_geographic_classification(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': '_',
+        '$ind1': indicator_map1.get(value.get('code_source'), '_'),
         '$ind2': '_',
     }
 
@@ -972,10 +1237,28 @@ def reverse_national_library_of_medicine_call_number(self, key, value):
     indicator_map1 = {
         "Item is in NLM": "0",
         "Item is not in NLM": "1",
-        "No information provided": "_"}
-    indicator_map2 = {"Assigned by NLM": "0",
-                      "Assigned by agency other than NLM": "4"}
+        "No information provided": "_",
+    }
+    indicator_map2 = {
+        "Assigned by NLM": "0",
+        "Assigned by agency other than NLM": "4",
+    }
+
+    field_map = {
+        'classification_number_r': 'a',
+        'item_number': 'b',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_nlm_collection')
+    if key[4] in indicator_map2:
+        order.append('source_of_call_number')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('classification_number_r')),
         '8': utils.reverse_force_list(
@@ -1030,7 +1313,19 @@ def reverse_character_sets_present(self, key, value):
 def reverse_national_agricultural_library_call_number(self, key, value):
     """Reverse - National Agricultural Library Call Number."""
     indicator_map1 = {"Item is in NAL": "0", "Item is not in NAL": "1"}
+    field_map = {
+        'classification_number': 'a',
+        'item_number': 'b',
+        'field_link_and_sequence_number_r': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('existence_in_nal_collection')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('classification_number')),
         '8': utils.reverse_force_list(
@@ -1276,7 +1571,27 @@ def reverse_synthesized_classification_number_components(self, key, value):
 @utils.filter_values
 def reverse_government_document_classification_number(self, key, value):
     """Reverse - Government Document Classification Number."""
+    indicator_map1 = {
+        'Source specified in subfield $2': '#',
+        'Superintendent of Documents Classification System': '0',
+        'Government of Canada Publications: Outline of Classification': '1',
+    }
+
+    field_map = {
+        'classification_number': 'a',
+        'canceled_invalid_classification_number': 'z',
+        'number_source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if indicator_map1.get(value.get('number_source'), '#') != '7':
+        order.remove('2')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('classification_number'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -1286,7 +1601,7 @@ def reverse_government_document_classification_number(self, key, value):
             value.get('canceled_invalid_classification_number')
         ),
         '6': value.get('linkage'),
-        '$ind1': '_',
+        '$ind1': indicator_map1.get(value.get('number_source'), '#'),
         '$ind2': '_',
     }
 

--- a/dojson/contrib/to_marc21/fields/bd1xx.py
+++ b/dojson/contrib/to_marc21/fields/bd1xx.py
@@ -15,11 +15,45 @@ from ..model import to_marc21
 
 
 @to_marc21.over('100', '^main_entry_personal_name$')
+@utils.reverse_for_each_value
 @utils.filter_values
 def reverse_main_entry_personal_name(self, key, value):
     """Reverse - Main Entry-Personal Name."""
-    indicator_map1 = {"Family name": "3", "Forename": "0", "Surname": "1"}
+    indicator_map1 = {
+        'Forename': '0',
+        'Surname': '1',
+        'Family name': '3',
+    }
+
+    field_map = {
+        'personal_name': 'a',
+        'numeration': 'b',
+        'titles_and_words_associated_with_a_name': 'c',
+        'dates_associated_with_a_name': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'attribution_qualifier': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'fuller_form_of_name': 'q',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'authority_record_control_number_or_standard_number': '0',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('personal_name'),
         'c': utils.reverse_force_list(
             value.get('titles_and_words_associated_with_a_name')
@@ -46,7 +80,7 @@ def reverse_main_entry_personal_name(self, key, value):
         ),
         'q': value.get('fuller_form_of_name'),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         'u': value.get('affiliation'),
         '4': utils.reverse_force_list(
@@ -69,8 +103,36 @@ def reverse_main_entry_corporate_name(self, key, value):
     indicator_map1 = {
         "Inverted name": "0",
         "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        "Name in direct order": "2",
+    }
+
+    field_map = {
+        'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
+        'subordinate_unit': 'b',
+        'location_of_meeting': 'c',
+        'date_of_meeting_or_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'authority_record_control_number_or_standard_number': '0',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
         'c': value.get('location_of_meeting'),
         'b': utils.reverse_force_list(
@@ -95,7 +157,7 @@ def reverse_main_entry_corporate_name(self, key, value):
             value.get('number_of_part_section_meeting')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         'u': value.get('affiliation'),
         '4': utils.reverse_force_list(
@@ -118,8 +180,37 @@ def reverse_main_entry_meeting_name(self, key, value):
     indicator_map1 = {
         "Inverted name": "0",
         "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        "Name in direct order": "2",
+    }
+
+    field_map = {
+        'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
+        'location_of_meeting': 'c',
+        'date_of_meeting': 'd',
+        'subordinate_unit': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'relator_term': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'name_of_meeting_following_jurisdiction_name_entry_element': 'q',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'authority_record_control_number_or_standard_number': '0',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
         'c': value.get('location_of_meeting'),
         'e': utils.reverse_force_list(
@@ -143,7 +234,7 @@ def reverse_main_entry_meeting_name(self, key, value):
         ),
         'q': value.get('name_of_meeting_following_jurisdiction_name_entry_element'),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         'u': value.get('affiliation'),
         '4': utils.reverse_force_list(
@@ -160,11 +251,39 @@ def reverse_main_entry_meeting_name(self, key, value):
 
 
 @to_marc21.over('130', '^main_entry_uniform_title$')
+@utils.reverse_for_each_value
 @utils.filter_values
 def reverse_main_entry_uniform_title(self, key, value):
     """Reverse - Main Entry-Uniform Title."""
-    indicator_map1 = {"Number of nonfiling characters": "8"}
+    nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'authority_record_control_number_or_standard_number': '0',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
         'p': utils.reverse_force_list(
             value.get('name_of_part_section_of_a_work')
@@ -187,7 +306,7 @@ def reverse_main_entry_uniform_title(self, key, value):
             value.get('number_of_part_section_of_a_work')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         's': value.get('version'),
         'r': value.get('key_for_music'),
@@ -196,6 +315,6 @@ def reverse_main_entry_uniform_title(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': indicator_map1.get(value.get('nonfiling_characters'), '_'),
+        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') else '_',
         '$ind2': '_',
     }

--- a/dojson/contrib/to_marc21/fields/bd20x24x.py
+++ b/dojson/contrib/to_marc21/fields/bd20x24x.py
@@ -84,7 +84,7 @@ def reverse_uniform_title(self, key, value):
         'n': utils.reverse_force_list(
             value.get('number_of_part_section_of_a_work')),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')),
+            value.get('authority_record_control_number_or_standard_number')),
         's': value.get('version'),
         'r': value.get('key_for_music'),
         '6': value.get('linkage'),
@@ -135,9 +135,35 @@ def reverse_collective_uniform_title(self, key, value):
     """Reverse - Collective Uniform Title."""
     indicator_map1 = {
         "Not printed or displayed": "0",
-        "Printed or displayed": "1"}
-    indicator_map2 = {"Number of nonfiling characters": "8"}
+        "Printed or displayed": "1",
+    }
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('uniform_title_printed_or_displayed')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
         'd': utils.reverse_force_list(
             value.get('date_of_treaty_signing')),
@@ -162,9 +188,7 @@ def reverse_collective_uniform_title(self, key, value):
         '$ind1': indicator_map1.get(
             value.get('uniform_title_printed_or_displayed'),
             '_'),
-        '$ind2': indicator_map2.get(
-            value.get('nonfiling_characters'),
-            '_'),
+        '$ind2': value.get('nonfiling_characters', '_'),
     }
 
 
@@ -283,9 +307,37 @@ def reverse_varying_form_of_title(self, key, value):
 @utils.filter_values
 def reverse_former_title(self, key, value):
     """Reverse - Former Title."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
-    indicator_map2 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Added entry': '1',
+        'No added entry': '0',
+    }
+    indicator_map2 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
+    field_map = {
+        'title': 'a',
+        'remainder_of_title': 'b',
+        'date_or_sequential_designation': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'international_standard_serial_number': 'x',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in indicator_map2:
+        order.append('note_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'x': value.get('international_standard_serial_number'),
         'b': value.get('remainder_of_title'),

--- a/dojson/contrib/to_marc21/fields/bd25x28x.py
+++ b/dojson/contrib/to_marc21/fields/bd25x28x.py
@@ -128,8 +128,28 @@ def reverse_publication_distribution_imprint(self, key, value):
     indicator_map1 = {
         "Current/latest publisher": "3",
         "Intervening publisher": "2",
-        "Not applicable/No information provided/Earliest available publisher": "_"}
+        "Not applicable/No information provided/Earliest available publisher": "_",
+    }
+
+    field_map = {
+        'place_of_publication_distribution': 'a',
+        'name_of_publisher_distributor': 'b',
+        'date_of_publication_distribution': 'c',
+        'place_of_manufacture': 'e',
+        'manufacturer': 'f',
+        'date_of_manufacture': 'g',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('sequence_of_publishing_statements')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('place_of_publication_distribution')),
         'c': utils.reverse_force_list(

--- a/dojson/contrib/to_marc21/fields/bd3xx.py
+++ b/dojson/contrib/to_marc21/fields/bd3xx.py
@@ -19,7 +19,22 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_physical_description(self, key, value):
     """Reverse - Physical Description."""
+    field_map = {
+        'extent': 'a',
+        'other_physical_details': 'b',
+        'dimensions': 'c',
+        'accompanying_material': 'e',
+        'type_of_unit': 'f',
+        'size_of_unit': 'g',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('extent')),
         'c': utils.reverse_force_list(value.get('dimensions')),
         'b': utils.reverse_force_list(value.get('other_physical_details')),
@@ -82,7 +97,17 @@ def reverse_current_publication_frequency(self, key, value):
 @utils.filter_values
 def reverse_former_publication_frequency(self, key, value):
     """Reverse - Former Publication Frequency."""
+    field_map = {
+        'former_publication_frequency': 'a',
+        'dates_of_former_publication_frequency': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('former_publication_frequency')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         'b': utils.reverse_force_list(value.get('dates_of_former_publication_frequency')),
@@ -114,7 +139,20 @@ def reverse_content_type(self, key, value):
 @utils.filter_values
 def reverse_media_type(self, key, value):
     """Reverse - Media Type."""
+    field_map = {
+        'media_type_term': 'a',
+        'media_type_code': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('media_type_term')),
         'b': utils.reverse_force_list(value.get('media_type_code')),
         '3': utils.reverse_force_list(value.get('materials_specified')),
@@ -131,7 +169,20 @@ def reverse_media_type(self, key, value):
 @utils.filter_values
 def reverse_carrier_type(self, key, value):
     """Reverse - Carrier Type."""
+    field_map = {
+        'carrier_type_term': 'a',
+        'carrier_type_code': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('carrier_type_term')),
         'b': utils.reverse_force_list(value.get('carrier_type_code')),
         '3': utils.reverse_force_list(value.get('materials_specified')),
@@ -249,7 +300,26 @@ def reverse_planar_coordinate_data(self, key, value):
 @utils.filter_values
 def reverse_sound_characteristics(self, key, value):
     """Reverse - Sound Characteristics."""
+    field_map = {
+        'type_of_recording': 'a',
+        'recording_medium': 'b',
+        'playing_speed': 'c',
+        'groove_characteristic': 'd',
+        'track_configuration': 'e',
+        'tape_configuration': 'f',
+        'configuration_of_playback_channels': 'g',
+        'special_playback_characteristics': 'h',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('type_of_recording')),
         'c': utils.reverse_force_list(value.get('playing_speed')),
         'b': utils.reverse_force_list(value.get('recording_medium')),
@@ -331,7 +401,19 @@ def reverse_digital_file_characteristics(self, key, value):
 @utils.filter_values
 def reverse_organization_and_arrangement_of_materials(self, key, value):
     """Reverse - Organization and Arrangement of Materials."""
+    field_map = {
+        'organization': 'a',
+        'arrangement': 'b',
+        'hierarchical_level': 'c',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('organization')),
         'c': utils.reverse_force_list(value.get('hierarchical_level')),
         'b': utils.reverse_force_list(value.get('arrangement')),
@@ -542,7 +624,18 @@ def reverse_associated_language(self, key, value):
 @utils.filter_values
 def reverse_form_of_work(self, key, value):
     """Reverse - Form of Work."""
+    field_map = {
+        'form_of_work': 'a',
+        'record_control_number': '0',
+        'source_of_term': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('form_of_work')),
         '0': utils.reverse_force_list(value.get('record_control_number')),
         '2': utils.reverse_force_list(value.get('source_of_term')),

--- a/dojson/contrib/to_marc21/fields/bd4xx.py
+++ b/dojson/contrib/to_marc21/fields/bd4xx.py
@@ -159,10 +159,27 @@ def reverse_series_statement_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_series_statement_added_entry_title(self, key, value):
     """Reverse - Series Statement/Added Entry-Title."""
-    indicator_map2 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'title': 'a',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'volume_sequential_designation': 'v',
+        'bibliographic_record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number': '0',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'x': value.get('international_standard_serial_number'),
         'p': utils.reverse_force_list(
@@ -173,7 +190,7 @@ def reverse_series_statement_added_entry_title(self, key, value):
             value.get('number_of_part_section_of_a_work')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         'w': utils.reverse_force_list(
             value.get('bibliographic_record_control_number')
@@ -183,7 +200,7 @@ def reverse_series_statement_added_entry_title(self, key, value):
             value.get('field_link_and_sequence_number')
         ),
         '$ind1': '_',
-        '$ind2': indicator_map2.get(value.get('nonfiling_characters'), '_'),
+        '$ind2': value.get('nonfiling_characters', '_'),
     }
 
 

--- a/dojson/contrib/to_marc21/fields/bd5xx.py
+++ b/dojson/contrib/to_marc21/fields/bd5xx.py
@@ -496,8 +496,29 @@ def reverse_study_program_information_note(self, key, value):
     """Reverse - Study Program Information Note."""
     indicator_map1 = {
         "No display constant generated": "8",
-        "Reading program": "0"}
+        "Reading program": "0",
+    }
+
+    field_map = {
+        'program_name': 'a',
+        'interest_level': 'b',
+        'reading_level': 'c',
+        'title_point_value': 'd',
+        'display_text': 'i',
+        'nonpublic_note': 'x',
+        'public_note': 'z',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('program_name'),
         'x': utils.reverse_force_list(
             value.get('nonpublic_note')),
@@ -523,7 +544,21 @@ def reverse_study_program_information_note(self, key, value):
 @utils.filter_values
 def reverse_additional_physical_form_available_note(self, key, value):
     """Reverse - Additional Physical Form Available Note."""
+    field_map = {
+        'additional_physical_form_available_note': 'a',
+        'availability_source': 'b',
+        'availability_conditions': 'c',
+        'order_number': 'd',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('additional_physical_form_available_note'),
         'c': value.get('availability_conditions'),
         'b': value.get('availability_source'),
@@ -546,7 +581,26 @@ def reverse_additional_physical_form_available_note(self, key, value):
 @utils.filter_values
 def reverse_reproduction_note(self, key, value):
     """Reverse - Reproduction Note."""
+    field_map = {
+        'type_of_reproduction': 'a',
+        'place_of_reproduction': 'b',
+        'agency_responsible_for_reproduction': 'c',
+        'date_of_reproduction': 'd',
+        'physical_description_of_reproduction': 'e',
+        'series_statement_of_reproduction': 'f',
+        'dates_and_or_sequential_designation_of_issues_reproduced': 'm',
+        'note_about_reproduction': 'n',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'fixed_length_data_elements_of_reproduction': '7',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('type_of_reproduction'),
         'c': utils.reverse_force_list(
             value.get('agency_responsible_for_reproduction')
@@ -583,7 +637,30 @@ def reverse_reproduction_note(self, key, value):
 @utils.filter_values
 def reverse_original_version_note(self, key, value):
     """Reverse - Original Version Note."""
+    field_map = {
+        'main_entry_of_original': 'a',
+        'edition_statement_of_original': 'b',
+        'publication_distribution_of_original': 'c',
+        'physical_description_of_original': 'e',
+        'series_statement_of_original': 'f',
+        'key_title_of_original': 'k',
+        'location_of_original': 'l',
+        'material_specific_details': 'm',
+        'note_about_original': 'n',
+        'other_resource_identifier': 'o',
+        'introductory_phrase': 'p',
+        'title_statement_of_original': 't',
+        'international_standard_serial_number': 'x',
+        'international_standard_book_number': 'z',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_of_original'),
         'x': utils.reverse_force_list(
             value.get('international_standard_serial_number')
@@ -653,7 +730,23 @@ def reverse_location_of_originals_duplicates_note(self, key, value):
 @utils.filter_values
 def reverse_funding_information_note(self, key, value):
     """Reverse - Funding Information Note."""
+    field_map = {
+        'text_of_note': 'a',
+        'contract_number': 'b',
+        'grant_number': 'c',
+        'undifferentiated_number': 'd',
+        'program_element_number': 'e',
+        'project_number': 'f',
+        'task_number': 'g',
+        'work_unit_number': 'h',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('text_of_note'),
         'c': utils.reverse_force_list(
             value.get('grant_number')
@@ -941,7 +1034,16 @@ def reverse_former_title_complexity_note(self, key, value):
 @utils.filter_values
 def reverse_issuing_body_note(self, key, value):
     """Reverse - Issuing Body Note."""
+    field_map = {
+        'issuing_body_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('issuing_body_note'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -1345,13 +1447,32 @@ def reverse_awards_note(self, key, value):
 @utils.filter_values
 def reverse_source_of_description_note(self, key, value):
     """Reverse - Source of Description Note."""
+    indicator_map1 = {
+        'No information provided': '#',
+        'Source of description': '0',
+        'Latest issue consulted': '1',
+    }
+
+    field_map = {
+        'source_of_description_note': 'a',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('source_of_description_note'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
-        '$ind1': '_',
+        '$ind1': indicator_map1.get(value.get('display_constant_controller'), '_'),
         '$ind2': '_',
     }

--- a/dojson/contrib/to_marc21/fields/bd6xx.py
+++ b/dojson/contrib/to_marc21/fields/bd6xx.py
@@ -28,10 +28,53 @@ def reverse_subject_added_entry_personal_name(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'personal_name': 'a',
+        'numeration': 'b',
+        'titles_and_other_words_associated_with_a_name': 'c',
+        'dates_associated_with_a_name': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'attribution_qualifier': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'fuller_form_of_name': 'q',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -110,10 +153,51 @@ def reverse_subject_added_entry_corporate_name(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
+        'subordinate_unit': 'b',
+        'location_of_meeting': 'c',
+        'date_of_meeting_or_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_meeting': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -190,10 +274,49 @@ def reverse_subject_added_entry_meeting_name(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
+        'location_of_meeting': 'c',
+        'date_of_meeting': 'd',
+        'subordinate_unit': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'relator_term': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'name_of_meeting_following_jurisdiction_name_entry_element': 'q',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -252,7 +375,7 @@ def reverse_subject_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_subject_added_entry_uniform_title(self, key, value):
     """Reverse - Subject Added Entry-Uniform Title."""
-    indicator_map1 = {"Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {
         "Canadian Subject Headings": "5",
         "LC subject headings for children\u0027s literature": "1",
@@ -261,10 +384,49 @@ def reverse_subject_added_entry_uniform_title(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -314,7 +476,7 @@ def reverse_subject_added_entry_uniform_title(self, key, value):
         'z': utils.reverse_force_list(
             value.get('geographic_subdivision')
         ),
-        '$ind1': indicator_map1.get(value.get('nonfiling_characters'), '_'),
+        '$ind1': value.get('nonfiling_characters', '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
     }
 
@@ -336,8 +498,25 @@ def reverse_subject_added_entry_chronological_term(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'chronological_term': 'a',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('chronological_term'),
         'x': utils.reverse_force_list(
             value.get('general_subdivision')),
@@ -381,14 +560,35 @@ def reverse_subject_added_entry_topical_term(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7",
+    }
+
     field_map = {
-        'source_of_heading_or_term': '2',
         'topical_term_or_geographic_name_entry_element': 'a',
+        'topical_term_following_geographic_name_entry_element': 'b',
+        'location_of_event': 'c',
+        'active_dates': 'd',
+        'relator_term': 'e',
+        'miscellaneous_information': 'g',
+        'relator_code': '4',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
         'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
         'geographic_subdivision': 'z',
     }
+
     order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_subject')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('topical_term_or_geographic_name_entry_element'),
@@ -405,7 +605,7 @@ def reverse_subject_added_entry_topical_term(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -440,8 +640,32 @@ def reverse_subject_added_entry_geographic_name(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'geographic_name': 'a',
+        'relator_term': 'e',
+        'miscellaneous_information': 'g',
+        'relator_code': '4',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_name'),
         'x': utils.reverse_force_list(
             value.get('general_subdivision')
@@ -453,7 +677,7 @@ def reverse_subject_added_entry_geographic_name(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -493,8 +717,24 @@ def reverse_index_term_uncontrolled(self, key, value):
         "Meeting name": "3",
         "No information provided": "_",
         "Personal name": "1",
-        "Topical term": "0"}
+        "Topical term": "0"
+    }
+
+    field_map = {
+        'uncontrolled_term': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_index_term')
+    if key[4] in indicator_map2:
+        order.append('type_of_term_or_name')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('uncontrolled_term')
         ),
@@ -516,8 +756,32 @@ def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
         "No information provided": "_",
         "No level specified": "0",
         "Primary": "1",
-        "Secondary": "2"}
+        "Secondary": "2"
+    }
+
+    field_map = {
+        'focus_term': 'a',
+        'non_focus_term': 'b',
+        'facet_hierarchy_designation': 'c',
+        'relator_term': 'e',
+        'form_subdivision': 'v',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('level_of_subject')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('focus_term')
         ),
@@ -534,7 +798,7 @@ def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -570,8 +834,34 @@ def reverse_index_term_genre_form(self, key, value):
         "National Agricultural Library subject authority file": "3",
         "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
         "Source not specified": "4",
-        "Source specified in subfield $2": "7"}
+        "Source specified in subfield $2": "7"
+    }
+
+    field_map = {
+        'genre_form_data_or_focus_term': 'a',
+        'non_focus_term': 'b',
+        'facet_hierarchy_designation': 'c',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_heading')
+    if key[4] in indicator_map2:
+        order.append('thesaurus')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('genre_form_data_or_focus_term'),
         'x': utils.reverse_force_list(
             value.get('general_subdivision')
@@ -586,7 +876,7 @@ def reverse_index_term_genre_form(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_term'),
@@ -611,7 +901,24 @@ def reverse_index_term_genre_form(self, key, value):
 @utils.filter_values
 def reverse_index_term_occupation(self, key, value):
     """Reverse - Index Term-Occupation."""
+    field_map = {
+        'occupation': 'a',
+        'form': 'k',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('occupation'),
         'x': utils.reverse_force_list(
             value.get('general_subdivision')
@@ -621,7 +928,7 @@ def reverse_index_term_occupation(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_term'),
@@ -645,7 +952,23 @@ def reverse_index_term_occupation(self, key, value):
 @utils.filter_values
 def reverse_index_term_function(self, key, value):
     """Reverse - Index Term-Function."""
+    field_map = {
+        'function': 'a',
+        'form_subdivision': 'v',
+        'general_subdivision': 'x',
+        'chronological_subdivision': 'y',
+        'geographic_subdivision': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('function'),
         'x': utils.reverse_force_list(
             value.get('general_subdivision')
@@ -654,7 +977,7 @@ def reverse_index_term_function(self, key, value):
             value.get('form_subdivision')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_term'),
@@ -678,7 +1001,20 @@ def reverse_index_term_function(self, key, value):
 @utils.filter_values
 def reverse_index_term_curriculum_objective(self, key, value):
     """Reverse - Index Term-Curriculum Objective."""
+    field_map = {
+        'main_curriculum_objective': 'a',
+        'subordinate_curriculum_objective': 'b',
+        'curriculum_code': 'c',
+        'correlation_factor': 'd',
+        'source_of_term_or_code': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_curriculum_objective'),
         'c': value.get('curriculum_code'),
         'b': utils.reverse_force_list(
@@ -700,7 +1036,26 @@ def reverse_index_term_curriculum_objective(self, key, value):
 @utils.filter_values
 def reverse_subject_added_entry_hierarchical_place_name(self, key, value):
     """Reverse - Subject Added Entry-Hierarchical Place Name."""
+    field_map = {
+        'country_or_larger_entity': 'a',
+        'first_order_political_jurisdiction': 'b',
+        'intermediate_political_jurisdiction': 'c',
+        'city': 'd',
+        'relator_term': 'e',
+        'city_subsection': 'f',
+        'other_nonjurisdictional_geographic_region_and_feature': 'g',
+        'extraterrestrial_area': 'h',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('country_or_larger_entity')
         ),
@@ -722,7 +1077,7 @@ def reverse_subject_added_entry_hierarchical_place_name(self, key, value):
             value.get('extraterrestrial_area')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '2': value.get('source_of_heading_or_term'),
         '4': utils.reverse_force_list(

--- a/dojson/contrib/to_marc21/fields/bd70x75x.py
+++ b/dojson/contrib/to_marc21/fields/bd70x75x.py
@@ -22,7 +22,7 @@ def reverse_added_entry_personal_name(self, key, value):
     indicator_map1 = {"Family name": "3", "Forename": "0", "Surname": "1"}
     indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
     field_map = {
-        'authority_record_control_number': '0',
+        'authority_record_control_number_or_standard_number': '0',
         'materials_specified': '3',
         'relator_code': '4',
         'institution_to_which_field_applies': '5',
@@ -61,7 +61,7 @@ def reverse_added_entry_personal_name(self, key, value):
 
     return {
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
@@ -126,9 +126,47 @@ def reverse_added_entry_corporate_name(self, key, value):
         "Jurisdiction name": "1",
         "Name in direct order": "2"}
     indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    field_map = {
+        'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
+        'subordinate_unit': 'b',
+        'location_of_meeting': 'c',
+        'date_of_meeting_or_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'relationship_information': 'i',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_meeting': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
@@ -190,9 +228,45 @@ def reverse_added_entry_meeting_name(self, key, value):
         "Jurisdiction name": "1",
         "Name in direct order": "2"}
     indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    field_map = {
+        'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
+        'location_of_meeting': 'c',
+        'date_of_meeting': 'd',
+        'subordinate_unit': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'relationship_information': 'i',
+        'relator_term': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'name_of_meeting_following_jurisdiction_name_entry_element': 'q',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
@@ -244,7 +318,22 @@ def reverse_added_entry_meeting_name(self, key, value):
 def reverse_added_entry_uncontrolled_name(self, key, value):
     """Reverse - Added Entry-Uncontrolled Name."""
     indicator_map1 = {"Not specified": "_", "Other": "2", "Personal": "1"}
+
+    field_map = {
+        'name': 'a',
+        'relator_term': 'e',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_name')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('name'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -266,9 +355,42 @@ def reverse_added_entry_uncontrolled_name(self, key, value):
 @utils.filter_values
 def reverse_added_entry_uniform_title(self, key, value):
     """Reverse - Added Entry-Uniform Title."""
-    indicator_map1 = {"Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'relationship_information': 'i',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
         'x': value.get('international_standard_serial_number'),
         'p': utils.reverse_force_list(
@@ -295,7 +417,7 @@ def reverse_added_entry_uniform_title(self, key, value):
             value.get('number_of_part_section_of_a_work')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         'r': value.get('key_for_music'),
@@ -306,7 +428,7 @@ def reverse_added_entry_uniform_title(self, key, value):
             value.get('field_link_and_sequence_number')
         ),
         's': value.get('version'),
-        '$ind1': indicator_map1.get(value.get('nonfiling_characters'), '_'),
+        '$ind1': value.get('nonfiling_characters', '_'),
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
 
@@ -319,11 +441,28 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
         key,
         value):
     """Reverse - Added Entry-Uncontrolled Related/Analytical Title."""
-    indicator_map1 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    field_map = {
+        'uncontrolled_related_analytical_title': 'a',
+        'medium': 'h',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+    if key[4] in indicator_map2:
+        order.append('type_of_added_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uncontrolled_related_analytical_title'),
         'h': value.get('medium'),
         'n': utils.reverse_force_list(
@@ -337,7 +476,7 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': indicator_map1.get(value.get('nonfiling_characters'), '_'),
+        '$ind1': value.get('nonfiling_characters', '_'),
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
 
@@ -347,13 +486,27 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
 @utils.filter_values
 def reverse_added_entry_geographic_name(self, key, value):
     """Reverse - Added Entry-Geographic Name."""
+    field_map = {
+        'geographic_name': 'a',
+        'relator_term': 'e',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_name'),
         'e': utils.reverse_force_list(
             value.get('relator_term')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
@@ -374,7 +527,24 @@ def reverse_added_entry_geographic_name(self, key, value):
 @utils.filter_values
 def reverse_added_entry_hierarchical_place_name(self, key, value):
     """Reverse - Added Entry-Hierarchical Place Name."""
+    field_map = {
+        'country_or_larger_entity': 'a',
+        'first_order_political_jurisdiction': 'b',
+        'intermediate_political_jurisdiction': 'c',
+        'city': 'd',
+        'city_subsection': 'f',
+        'other_nonjurisdictional_geographic_region_and_feature': 'g',
+        'extraterrestrial_area': 'h',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_heading_or_term': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('country_or_larger_entity')
         ),
@@ -393,7 +563,7 @@ def reverse_added_entry_hierarchical_place_name(self, key, value):
             value.get('extraterrestrial_area')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '2': value.get('source_of_heading_or_term'),
         '6': value.get('linkage'),
@@ -410,7 +580,18 @@ def reverse_added_entry_hierarchical_place_name(self, key, value):
 @utils.filter_values
 def reverse_system_details_access_to_computer_files(self, key, value):
     """Reverse - System Details Access to Computer Files."""
+    field_map = {
+        'make_and_model_of_machine': 'a',
+        'programming_language': 'b',
+        'operating_system': 'c',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('make_and_model_of_machine'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -428,7 +609,22 @@ def reverse_system_details_access_to_computer_files(self, key, value):
 @utils.filter_values
 def reverse_added_entry_taxonomic_identification(self, key, value):
     """Reverse - Added Entry-Taxonomic Identification."""
+    field_map = {
+        'taxonomic_name': 'a',
+        'taxonomic_category': 'c',
+        'common_or_alternative_name': 'd',
+        'non_public_note': 'x',
+        'public_note': 'z',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_taxonomic_identification': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('taxonomic_name')
         ),
@@ -442,7 +638,7 @@ def reverse_added_entry_taxonomic_identification(self, key, value):
             value.get('common_or_alternative_name')
         ),
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '2': value.get('source_of_taxonomic_identification'),
         '6': value.get('linkage'),

--- a/dojson/contrib/to_marc21/fields/bd76x78x.py
+++ b/dojson/contrib/to_marc21/fields/bd76x78x.py
@@ -21,7 +21,38 @@ def reverse_main_series_entry(self, key, value):
     """Reverse - Main Series Entry."""
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {"Main series": "_", "No display constant generated": "8"}
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'uniform_title': 's',
+        'title': 't',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
         'x': value.get('international_standard_serial_number'),
         'c': value.get('qualifying_information'),
@@ -65,8 +96,40 @@ def reverse_subseries_entry(self, key, value):
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {
         "Has subseries": "_",
-        "No display constant generated": "8"}
+        "No display constant generated": "8"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'uniform_title': 's',
+        'title': 't',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
         'x': value.get('international_standard_serial_number'),
         'c': value.get('qualifying_information'),
@@ -110,8 +173,44 @@ def reverse_original_language_entry(self, key, value):
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {
         "No display constant generated": "8",
-        "Translation of": "_"}
+        "Translation of": "_"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -168,8 +267,44 @@ def reverse_translation_entry(self, key, value):
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {
         "No display constant generated": "8",
-        "Translated as": "_"}
+        "Translated as": "_"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -226,8 +361,44 @@ def reverse_supplement_special_issue_entry(self, key, value):
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {
         "Has supplement": "_",
-        "No display constant generated": "8"}
+        "No display constant generated": "8"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -285,8 +456,44 @@ def reverse_supplement_parent_entry(self, key, value):
     indicator_map2 = {
         "No display constant generated": "8",
         "Parent": "0",
-        "Supplement to": "_"}
+        "Supplement to": "_"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -342,12 +549,42 @@ def reverse_host_item_entry(self, key, value):
     """Reverse - Host Item Entry."""
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {"In": "_", "No display constant generated": "8"}
+
     field_map = {
         'main_entry_heading': 'a',
+        'edition': 'b',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
         'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
         'note': 'n',
+        'other_item_identifier': 'o',
+        'abbreviated_title': 'p',
+        'enumeration_and_first_page': 'q',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'materials_specified': '3',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
     }
+
     order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
         '__order__': tuple(order) if len(order) else None,
         '3': value.get('materials_specified'),
@@ -408,8 +645,44 @@ def reverse_constituent_unit_entry(self, key, value):
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {
         "Constituent unit": "_",
-        "No display constant generated": "8"}
+        "No display constant generated": "8"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -467,7 +740,44 @@ def reverse_other_edition_entry(self, key, value):
     indicator_map2 = {
         "No display constant generated": "8",
         "Other edition available": "_"}
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'language_code': 'e',
+        'country_code': 'f',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -527,7 +837,42 @@ def reverse_additional_physical_form_entry(self, key, value):
     indicator_map2 = {
         "Available in another form": "_",
         "No display constant generated": "8"}
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -583,7 +928,39 @@ def reverse_issued_with_entry(self, key, value):
     """Reverse - Issued With Entry."""
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {"Issued with": "_", "No display constant generated": "8"}
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'uniform_title': 's',
+        'title': 't',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
         'x': value.get('international_standard_serial_number'),
         'c': value.get('qualifying_information'),
@@ -639,8 +1016,44 @@ def reverse_preceding_entry(self, key, value):
         "Formed by the union of ... and ...": "4",
         "Separated from": "7",
         "Supersedes": "2",
-        "Supersedes in part": "3"}
+        "Supersedes in part": "3"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('type_of_relationship')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -704,8 +1117,44 @@ def reverse_succeeding_entry(self, key, value):
         "Merged with ... to form ...": "7",
         "Split into ... and ...": "6",
         "Superseded by": "2",
-        "Superseded in part by": "3"}
+        "Superseded in part by": "3"
+    }
+
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'm',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('type_of_relationship')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -761,7 +1210,45 @@ def reverse_data_source_entry(self, key, value):
     """Reverse - Data Source Entry."""
     indicator_map1 = {"Display note": "0", "Do not display note": "1"}
     indicator_map2 = {"Data source": "_", "No display constant generated": "8"}
+
+    field_map = {
+        'main_entry_heading_(nr)': 'a',
+        'edition_(nr)': 'b',
+        'qualifying_information_(nr)': 'c',
+        'place_publisher_and_date_of_publication_(nr)': 'd',
+        'related_parts_(r)': 'g',
+        'physical_description_(nr)': 'h',
+        'relationship_information_(r)': 'i',
+        'period_of_content_(nr)': 'j',
+        'series_data_for_related_item_(r)': 'k',
+        'material_specific_details_(nr)': 'm',
+        'note_(r)': 'n',
+        'other_item_identifier_(r)': 'o',
+        'abbreviated_title_(nr)': 'p',
+        'report_number_(r)': 'r',
+        'uniform_title_(nr)': 's',
+        'title_(nr)': 't',
+        'standard_technical_report_number_(nr)': 'u',
+        'source_contribution_(nr)': 'v',
+        'record_control_number_(r)': 'w',
+        'international_standard_serial_number_(nr)': 'x',
+        'coden_designation_(nr)': 'y',
+        'international_standard_book_number_(r)': 'z',
+        'relationship_code_(r)': '4',
+        'linkage_(nr)': '6',
+        'control_subfield_(nr)': '7',
+        'field_link_and_sequence_number_(r)': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),
@@ -822,7 +1309,41 @@ def reverse_other_relationship_entry(self, key, value):
     indicator_map2 = {
         "No display constant generated": "8",
         "Related item": "_"}
+    field_map = {
+        'main_entry_heading': 'a',
+        'edition': 'b',
+        'qualifying_information': 'c',
+        'place_publisher_and_date_of_publication': 'd',
+        'related_parts': 'g',
+        'physical_description': 'h',
+        'relationship_information': 'i',
+        'series_data_for_related_item': 'k',
+        'material_specific_details': 'k',
+        'note': 'n',
+        'other_item_identifier': 'o',
+        'report_number': 'r',
+        'uniform_title': 's',
+        'title': 't',
+        'standard_technical_report_number': 'u',
+        'record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'coden_designation': 'y',
+        'international_standard_book_number': 'z',
+        'relationship_code': '4',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_controller')
+    if key[4] in indicator_map2:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '4': utils.reverse_force_list(
             value.get('relationship_code')
         ),

--- a/dojson/contrib/to_marc21/fields/bd80x83x.py
+++ b/dojson/contrib/to_marc21/fields/bd80x83x.py
@@ -19,10 +19,54 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_series_added_entry_personal_name(self, key, value):
     """Reverse - Series Added Entry-Personal Name."""
-    indicator_map1 = {"Family name": "3", "Forename": "0", "Surname": "1"}
+    indicator_map1 = {
+        'Family name': '3',
+        'Forename': '0',
+        'Surname': '1',
+    }
+
+    field_map = {
+        'personal_name': 'a',
+        'numeration': 'b',
+        'titles_and_other_words_associated_with_a_name': 'c',
+        'dates_associated_with_a_name': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'attribution_qualifier': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'fuller_form_of_name': 'q',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'volume_sequential_designation': 'v',
+        'bibliographic_record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_personal_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': utils.reverse_force_list(
@@ -86,12 +130,51 @@ def reverse_series_added_entry_personal_name(self, key, value):
 def reverse_series_added_entry_corporate_name(self, key, value):
     """Reverse - Series Added Entry-Corporate Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
+    field_map = {
+        'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
+        'subordinate_unit': 'b',
+        'location_of_meeting': 'c',
+        'date_of_meeting_or_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_meeting': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'volume_sequential_designation': 'v',
+        'bibliographic_record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': utils.reverse_force_list(
@@ -153,12 +236,49 @@ def reverse_series_added_entry_corporate_name(self, key, value):
 def reverse_series_added_entry_meeting_name(self, key, value):
     """Reverse - Series Added Entry-Meeting Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
+    field_map = {
+        'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
+        'location_of_meeting': 'c',
+        'date_of_meeting': 'd',
+        'subordinate_unit': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'relator_term': 'j',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'name_of_meeting_following_jurisdiction_name': 'q',
+        'version': 's',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'volume_sequential_designation': 'v',
+        'bibliographic_record_control_number': 'w',
+        'international_standard_serial_number': 'x',
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'control_subfield': '7',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': utils.reverse_force_list(
@@ -218,7 +338,7 @@ def reverse_series_added_entry_uniform_title(self, key, value):
         "Number of nonfiling characters": "8"}
     return {
         '0': utils.reverse_force_list(
-            value.get('authority_record_control_number')
+            value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
         '5': utils.reverse_force_list(

--- a/dojson/contrib/to_marc21/fields/bd84188x.py
+++ b/dojson/contrib/to_marc21/fields/bd84188x.py
@@ -51,8 +51,46 @@ def reverse_location(self, key, value):
         "Alternative enumeration": "2",
         "No information provided": "_",
         "Not enumeration": "0",
-        "Primary enumeration": "1"}
+        "Primary enumeration": "1",
+    }
+
+    field_map = {
+        'location': 'a',
+        'sublocation_or_collection': 'b',
+        'shelving_location': 'c',
+        'former_shelving_location': 'd',
+        'address': 'e',
+        'coded_location_qualifier': 'f',
+        'non_coded_location_qualifier': 'g',
+        'classification_part': 'h',
+        'item_part': 'i',
+        'shelving_control_number': 'j',
+        'call_number_prefix': 'k',
+        'shelving_form_of_title': 'l',
+        'call_number_suffix': 'm',
+        'country_code': 'n',
+        'piece_designation': 'p',
+        'piece_physical_condition': 'q',
+        'copyright_article_fee_code': 's',
+        'copy_number': 't',
+        'uniform_resource_identifier': 'u',
+        'nonpublic_note': 'x',
+        'public_note': 'z',
+        'source_of_classification_or_shelving_scheme': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('shelving_scheme')
+    if key[4] in indicator_map2:
+        order.append('shelving_order')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '3': value.get('materials_specified'),
         '2': value.get('source_of_classification_or_shelving_scheme'),
         '6': value.get('linkage'),
@@ -165,6 +203,7 @@ def reverse_electronic_location_and_access(self, key, value):
         order.remove('2')
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         '3': value.get('materials_specified'),
         '2': value.get('access_method')
         if indicator_map1.get(value.get('access_method'), '7') == '7'
@@ -229,7 +268,6 @@ def reverse_electronic_location_and_access(self, key, value):
         ),
         '$ind1': indicator_map1.get(value.get('access_method'), '7'),
         '$ind2': indicator_map2.get(value.get('relationship'), '_'),
-        '__order__': tuple(order) if len(order) else None
     }
 
 

--- a/dojson/contrib/to_marc21/model.py
+++ b/dojson/contrib/to_marc21/model.py
@@ -103,7 +103,7 @@ class Underdo(Overdo):
                 else:
                     raise
 
-        return GroupableOrderedDict(sorted(output, key=lambda i: i[0][:3]))
+        return GroupableOrderedDict(output)
 
 
 to_marc21 = Underdo(entry_point_group='dojson.contrib.to_marc21')

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -95,4 +95,10 @@ def dumps_etree(records, xslt_filename=None):
 def dumps(records, xslt_filename=None, **kwargs):
     """Dump records into a MarcXML file."""
     root = dumps_etree(records=records, xslt_filename=xslt_filename)
-    return etree.tostring(root, **kwargs)
+    return etree.tostring(
+        root,
+        pretty_print=True,
+        xml_declaration=True,
+        encoding='UTF-8',
+        **kwargs
+    )

--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -126,15 +126,24 @@ class Overdo(object):
         handlers = {IgnoreKey: None}
         handlers.update(exception_handlers or {})
 
+        def clean_missing(exc, output, key, value):
+            order = output['__order__']
+            del order[order.index(key)]
+
         if ignore_missing:
-            handlers.setdefault(MissingRule, None)
+            handlers.setdefault(MissingRule, clean_missing)
 
         output = {}
 
         if self.index is None:
             self.build()
 
-        for key, value in iteritems(blob):
+        if isinstance(blob, GroupableOrderedDict):
+            items = blob.iteritems(repeated=True)
+        else:
+            items = iteritems(blob)
+
+        for key, value in items:
             try:
                 result = self.index.query(key)
                 if not result:

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -11,9 +11,9 @@
 
 import codecs
 import functools
-import json
 from collections import Counter, OrderedDict
 
+import simplejson as json
 import six
 
 from .errors import IgnoreKey
@@ -99,7 +99,7 @@ def dump(iterator):
 def map_order(field_map, value):
     """Ordered list of fields to be able to pass the order along.
 
-    .. note:: It returns a tuple as you may want to alter it based on the
+    .. note:: It returns a list as you may want to alter it based on the
        indicators. The final structure should use a tuple for immutability.
 
     Returns an empty list if no `__order__' is found in the value.
@@ -144,7 +144,7 @@ class GroupableOrderedDict(OrderedDict):
                             if c[key] == 0:
                                 tmp.append((key, v))
                             else:
-                                raise Exception("Order and values don't match"
+                                raise Exception("Order and values don't match "
                                                 "on key {0} at position {1}"
                                                 .format(key, c[key]))
                         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,4 +10,4 @@
 
 [pytest]
 pep8ignore = E501
-addopts = --pep8 --ignore=docs --cov=dojson --cov-report=term-missing
+addopts = -vv --pep8 --ignore=docs --cov=dojson --cov-report=term-missing

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,13 @@ extras_require['all'] = []
 for name, reqs in extras_require.items():
     extras_require['all'].extend(reqs)
 
+install_requires = [
+    'click>=5.0.0',
+    'lxml>=3.4',
+    'simplejson>=3.8.1',
+    'six>=1.7.2',
+]
+
 setup(
     name='dojson',
     version=version,
@@ -62,11 +69,6 @@ setup(
         'pytest-runner>=2.6.2',
         'setuptools>=17.1',
     ],
-    install_requires=[
-        'click>=5.0.0',
-        'lxml>=3.4',
-        'six>=1.7.2',
-    ],
     extras_require=extras_require,
     classifiers=[
         'Intended Audience :: Developers',
@@ -82,6 +84,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Development Status :: 1 - Planning',
     ],
+    install_requires=install_requires,
     tests_require=tests_require,
     entry_points={
         'console_scripts': [

--- a/tests/data/test_1.xml
+++ b/tests/data/test_1.xml
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">136</controlfield>
+    <controlfield tag="005">20160203181958.0</controlfield>
+    <controlfield tag="008">030529s1993\\\\ne\a\\\\\b\\\\101\0\eng\d</controlfield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">0444899251</subfield>
+    </datafield>
+    <datafield tag="111" ind1="2" ind2=" ">
+      <subfield code="a">IFIP International Workshop on Protocols for High Speed Networks</subfield>
+      <subfield code="n">(3rd :</subfield>
+      <subfield code="d">1992 :</subfield>
+      <subfield code="c">Stockholm, Sweden)</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Protocols for high-speed networks III.:</subfield>
+      <subfield code="b">proceedings of the IFIP WG 6.1 / WG 6.4  Third International Workshop on Protocols for High Speed Networks, Stockholm, Sweden,  13-15 May, 1992 /</subfield>
+      <subfield code="c">edited by B. Pehrson, P. Gunningberg and S. Pink.</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Amsterdam :</subfield>
+      <subfield code="b">North-Holland,</subfield>
+      <subfield code="c">c.1993.</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">267 p.</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="4">
+      <subfield code="a">Telecommunications - Networks</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="4">
+      <subfield code="a">Transmission quality </subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="4">
+      <subfield code="a">Transmission protocols </subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="4">
+      <subfield code="a">Communications protocols</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Pehrson, Björn</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Gunningberg, Per</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Pink, Stephen</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">IFIP</subfield>
+    </datafield>
+    <datafield tag="852" ind1="8" ind2=" ">
+      <subfield code="b">Library Reading Room</subfield>
+      <subfield code="h">621.39.B6210L</subfield>
+      <subfield code="i">I23</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_10.xml
+++ b/tests/data/test_10.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="243" ind1="1" ind2="0">
+      <subfield code="a">
+Actes du colloque international informatique et société (24-28 septembre 1979; Paris)
+</subfield>
+    </datafield>
+    <datafield tag="247" ind1="0" ind2="0">
+      <subfield code="a">Toimituksia.</subfield>
+      <subfield code="b">Annales.</subfield>
+      <subfield code="n">Sarja/Series A.</subfield>
+      <subfield code="p">III: Geologica-geographica</subfield>
+      <subfield code="f">1-60</subfield>
+    </datafield>
+    <datafield tag="247" ind1="1" ind2="0">
+      <subfield code="a">Panoplist</subfield>
+      <subfield code="g">(varies slightly)</subfield>
+      <subfield code="f">June 1805-May 1808</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_11.xml
+++ b/tests/data/test_11.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="321" ind1=" " ind2=" ">
+      <subfield code="a">Monthly,</subfield>
+    </datafield>
+    <datafield tag="321" ind1=" " ind2=" ">
+      <subfield code="a">Bimonthly,</subfield>
+      <subfield code="b">2003-</subfield>
+    </datafield>
+    <datafield tag="337" ind1=" " ind2=" ">
+      <subfield code="3">book</subfield>
+      <subfield code="a">unmediated</subfield>
+      <subfield code="b">n</subfield>
+      <subfield code="2">rdamedia</subfield>
+    </datafield>
+    <datafield tag="338" ind1=" " ind2=" ">
+      <subfield code="a">volume</subfield>
+      <subfield code="b">nc</subfield>
+      <subfield code="2">rdacarrier</subfield>
+      <subfield code="3">book</subfield>
+    </datafield>
+    <datafield tag="344" ind1=" " ind2=" ">
+      <subfield code="a">digital</subfield>
+      <subfield code="b">optical</subfield>
+      <subfield code="h">Dolby digital 5.1</subfield>
+      <subfield code="2">rda</subfield>
+    </datafield>
+    <datafield tag="344" ind1=" " ind2=" ">
+      <subfield code="a">digital</subfield>
+      <subfield code="g">stereo</subfield>
+      <subfield code="2">rda</subfield>
+    </datafield>
+    <datafield tag="351" ind1=" " ind2=" ">
+      <subfield code="3">abstracts ;</subfield>
+      <subfield code="a">organized by topic on program ;</subfield>
+      <subfield code="b">arranged alphabetically by author</subfield>
+    </datafield>
+    <datafield tag="363" ind1=" " ind2=" ">
+      <subfield code="a">Vol. 17, no. 1(1968)- .</subfield>
+    </datafield>
+    <datafield tag="380" ind1=" " ind2=" ">
+      <subfield code="a">Textbooks</subfield>
+      <subfield code="2">lcsh</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_12.xml
+++ b/tests/data/test_12.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="440" ind1=" " ind2="0">
+      <subfield code="a">Chemistry of functional groups.</subfield>
+      <subfield code="p">Supplement ;</subfield>
+      <subfield code="v">A</subfield>
+    </datafield>
+    <datafield tag="440" ind1=" " ind2="0">
+      <subfield code="a">Electrophoresis ;</subfield>
+    </datafield>
+    <datafield tag="440" ind1=" " ind2="0">
+      <subfield code="a">Neues Jahrbuch für Mineralogie.</subfield>
+      <subfield code="v">v. 166, no. 1</subfield>
+    </datafield>
+    <datafield tag="440" ind1=" " ind2="0">
+      <subfield code="a">Journal de physique.</subfield>
+      <subfield code="p">Colloque ;</subfield>
+      <subfield code="v">C3</subfield>
+    </datafield>
+    <datafield tag="440" ind1=" " ind2="0">
+      <subfield code="a">IEEE transactions on circuits and systems.</subfield>
+      <subfield code="n">I,</subfield>
+      <subfield code="p">Regular papers ;</subfield>
+      <subfield code="v">v. 55, special issue</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_13.xml
+++ b/tests/data/test_13.xml
@@ -1,0 +1,167 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="501" ind1=" " ind2=" ">
+      <subfield code="a">
+With: On the action of gases and vapours on radiant heat / J. Tyndall -- On Bunsen and Kirchhoff's spectrum observations / H.E. Roscoe -- On the telescopic appearance of the Planet Mars / J. Phillips -- Address delivered at the anniversary meeting of the Geological Society of London on the 18th of February, 1859 / J. Phillips -- Anniversary address delivered before the Anthropological Society of London, January 5th, 1864 / J. Hunt
+</subfield>
+    </datafield>
+    <datafield tag="507" ind1=" " ind2=" ">
+      <subfield code="a">Scale ca. 1:80,000</subfield>
+    </datafield>
+    <datafield tag="511" ind1=" " ind2=" ">
+      <subfield code="a">
+Roumiana Bareva, soprano ; Pavel Kourchoumov, tenor ; Stoyan Popov, baritone ; Choir "Morski Zvuci", Varna ; Bulgarian National Radio Symphony Orchestra ; Vasil Stefanov, conductor
+</subfield>
+    </datafield>
+    <datafield tag="513" ind1=" " ind2=" ">
+      <subfield code="a">Annual directory-almanac for trade and industry</subfield>
+    </datafield>
+    <datafield tag="515" ind1=" " ind2=" ">
+      <subfield code="a">
+Vol. 2, no. 4, spring 1975, incorrectly numbered v. 2, no. 3, repeating the numbering of the MARHO newsletter
+</subfield>
+    </datafield>
+    <datafield tag="516" ind1="8" ind2=" ">
+      <subfield code="a">Electronic serial in ASCII and HTML formats</subfield>
+    </datafield>
+    <datafield tag="521" ind1=" " ind2=" ">
+      <subfield code="a">High school and college physics students</subfield>
+    </datafield>
+    <datafield tag="522" ind1=" " ind2=" ">
+      <subfield code="a">
+Covers the National Petroleum Reserve and areas adjacent, including marine areas northwest in the Arctic Ocean
+</subfield>
+    </datafield>
+    <datafield tag="524" ind1=" " ind2=" ">
+      <subfield code="a">
+Preferred Citation: [Identification of item], Robert W. Oliver Papers, 10109-MS, Caltech Archives, California Institute of Technology
+</subfield>
+    </datafield>
+    <datafield tag="526" ind1="0" ind2=" ">
+      <subfield code="a">Accelerated Reader/Renaissance Learning</subfield>
+      <subfield code="b">MG</subfield>
+      <subfield code="c">4.1</subfield>
+      <subfield code="d">12</subfield>
+    </datafield>
+    <datafield tag="530" ind1=" " ind2=" ">
+      <subfield code="a">
+Video lectures from 1999 and thereafter are available online at
+</subfield>
+      <subfield code="u">
+http://nobelprize.org/nobel_prizes/medicine/video_lectures.html
+</subfield>
+    </datafield>
+    <datafield tag="530" ind1=" " ind2=" ">
+      <subfield code="a">
+Also available via World Wide Web through the Kluwer web site;
+</subfield>
+      <subfield code="b">
+and from OCLC FirstSearch Electronic Collections Online;
+</subfield>
+      <subfield code="c">
+Subscription required for access to abstracts and full text
+</subfield>
+    </datafield>
+    <datafield tag="533" ind1=" " ind2=" ">
+      <subfield code="a">Electronic text and image data.</subfield>
+      <subfield code="b">Ann Arbor, Mich. :</subfield>
+      <subfield code="c">
+University of Michigan, Scholarly Publishing Office,
+</subfield>
+      <subfield code="d">2003.</subfield>
+      <subfield code="e">
+Includes both TIFF files and keyword searchable text.
+</subfield>
+      <subfield code="f">([ACLS Humanities E-Book])</subfield>
+      <subfield code="n">Mode of access: Intranet.</subfield>
+      <subfield code="n">
+This volume is made possible by a grant from the Andrew W. Mellon Foundation
+</subfield>
+    </datafield>
+    <datafield tag="534" ind1=" " ind2=" ">
+      <subfield code="p">Electronic reproduction of:</subfield>
+      <subfield code="t">
+Kinetische Konstanten von Radikalreaktionen in Flüssigkeiten.
+</subfield>
+      <subfield code="c">Berlin : Springer, 1983-1985.</subfield>
+      <subfield code="e">5 v. :</subfield>
+      <subfield code="b">ill. ; 28 cm.</subfield>
+      <subfield code="n">
+Contents: Teilband a. Kohlenstoffe-Radikale 1 -- Teilband b. Kohlenstoffzentrierte-Radikale 2 -- Teilband c. Radikale mit N, S, P, und anderen Heteroatomen als Zentralatom : Nitroxyradikale -- Teilband d. Oxyl-, Peroxyl- und verwandte Radikale -- Teilband e. Protonen- und Elektronenaustauschreaktionen : Biradikale.
+</subfield>
+    </datafield>
+    <datafield tag="534" ind1=" " ind2=" ">
+      <subfield code="c">Berkeley : University of California Press, c2003.</subfield>
+      <subfield code="f">(California world history library ; 1)</subfield>
+    </datafield>
+    <datafield tag="534" ind1=" " ind2=" ">
+      <subfield code="p">Reprint. Originally published:</subfield>
+      <subfield code="c">New York : Springer-Verlag, c1982,</subfield>
+      <subfield code="z">9781468493290</subfield>
+    </datafield>
+    <datafield tag="534" ind1=" " ind2=" ">
+      <subfield code="a">Rich, Adrienne,</subfield>
+      <subfield code="c">New York: W. W. Norton &amp; Company, 1995</subfield>
+    </datafield>
+    <datafield tag="535" ind1="1" ind2=" ">
+      <subfield code="a">Original papers in the Library of Congress</subfield>
+    </datafield>
+    <datafield tag="538" ind1=" " ind2=" ">
+      <subfield code="a">Mode of access: World Wide Web</subfield>
+    </datafield>
+    <datafield tag="544" ind1=" " ind2=" ">
+      <subfield code="a">
+Related Collections: Papers of Robert A. Millikan; Papers of Theodore von Karman; Caltech Historical Files (GALCIT); Wind Tunnel Records
+</subfield>
+    </datafield>
+    <datafield tag="545" ind1=" " ind2=" ">
+      <subfield code="a">
+Includes material pertaining to fictional work written under pseudonym John Taine.
+</subfield>
+    </datafield>
+    <datafield tag="546" ind1=" " ind2=" ">
+      <subfield code="a">Contributions in English, French or German</subfield>
+    </datafield>
+    <datafield tag="547" ind1=" " ind2=" ">
+      <subfield code="a">
+Ser. 1 issued under title: The observation of variable stars
+</subfield>
+    </datafield>
+    <datafield tag="550" ind1=" " ind2=" ">
+      <subfield code="a">
+Vols. [1]- prepared by the editors of: Chemical engineering progress
+</subfield>
+    </datafield>
+    <datafield tag="556" ind1="8" ind2=" ">
+      <subfield code="a">Accompanied by a user's manual</subfield>
+    </datafield>
+    <datafield tag="561" ind1="1" ind2=" ">
+      <subfield code="a">From the collection of Allen Acosta.</subfield>
+    </datafield>
+    <datafield tag="567" ind1=" " ind2=" ">
+      <subfield code="a">
+Samples from 104 1⁰ x 2⁰ or 1⁰ x 3⁰ quadrangles in Alaska and 319 1⁰ x 2⁰ quadrangles in the conterminous United States
+</subfield>
+    </datafield>
+    <datafield tag="580" ind1=" " ind2=" ">
+      <subfield code="a">
+Issued as a supplement to: Australian journal of zoology
+</subfield>
+    </datafield>
+    <datafield tag="585" ind1=" " ind2=" ">
+      <subfield code="a">National Book Award Winner</subfield>
+    </datafield>
+    <datafield tag="586" ind1=" " ind2=" ">
+      <subfield code="a">
+Society of American Historians Francis Parkman Prize, 1977
+        </subfield>
+    </datafield>
+    <datafield tag="588" ind1=" " ind2=" ">
+      <subfield code="a">
+To be issued in Hoboken, New Jersey by John Wiley &amp; Sons beginning with volume 94, number 1 2013.
+        </subfield>
+      <subfield code="5">DLC</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_14.xml
+++ b/tests/data/test_14.xml
@@ -1,0 +1,240 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Juvenal.</subfield>
+      <subfield code="t">Works.</subfield>
+      <subfield code="f">1980</subfield>
+      <subfield code="x">Criticism and interpretation</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Chrétien,</subfield>
+      <subfield code="c">de Troyes,</subfield>
+      <subfield code="d">active 12th century.</subfield>
+      <subfield code="t">Chevalier au lyon.</subfield>
+      <subfield code="l">English &amp; French</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Henry</subfield>
+      <subfield code="b">IV,</subfield>
+      <subfield code="c">King of England,</subfield>
+      <subfield code="d">1367-1413,</subfield>
+      <subfield code="k">in fiction, drama, poetry, etc</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Huai-nan tzu,</subfield>
+      <subfield code="d">d. 122 B.C.</subfield>
+      <subfield code="t">Huai-nan tzu.</subfield>
+      <subfield code="n">9.</subfield>
+      <subfield code="p">Chu shu hsün</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">LM</subfield>
+      <subfield code="q">(Leslie Moore),</subfield>
+      <subfield code="d">b. 1888</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Martinus,</subfield>
+      <subfield code="c">Saint, Abp. of Braga,</subfield>
+      <subfield code="d">d. 580.</subfield>
+      <subfield code="t">Formula vitae honestae</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Mary Magdalene,</subfield>
+      <subfield code="c">Saint</subfield>
+      <subfield code="x">Cult</subfield>
+      <subfield code="z">France</subfield>
+      <subfield code="z">Provence</subfield>
+      <subfield code="x">History</subfield>
+      <subfield code="y">Middle Ages, 600-1500</subfield>
+    </datafield>
+    <datafield tag="600" ind1="0" ind2="0">
+      <subfield code="a">Mata Hari,</subfield>
+      <subfield code="d">1876-1917</subfield>
+      <subfield code="v">Fiction</subfield>
+    </datafield>
+    <datafield tag="600" ind1="1" ind2="0">
+      <subfield code="a">Schumann, Robert,</subfield>
+      <subfield code="d">1810-1856.</subfield>
+      <subfield code="t">Fantasien,</subfield>
+      <subfield code="m">piano,</subfield>
+      <subfield code="n">op. 17,</subfield>
+      <subfield code="r">C major</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">United States.</subfield>
+      <subfield code="t">Earthquake Hazards Reduction Act of 1977.</subfield>
+      <subfield code="f">1978</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Cooke, W. Ernest</subfield>
+      <subfield code="d">b. 1963</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Catholic Church</subfield>
+      <subfield code="x">Foreign relations</subfield>
+      <subfield code="z">France</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">United States.</subfield>
+      <subfield code="b">Congress.</subfield>
+      <subfield code="b">Commission on Security and Cooperation in Europe</subfield>
+      <subfield code="v">Periodicals</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">United States.</subfield>
+      <subfield code="t">Declaration of Independence</subfield>
+      <subfield code="x">Juvenile literature</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Cooke, W. Ernest</subfield>
+      <subfield code="d">b. 1963</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Progressive Party (1912).</subfield>
+      <subfield code="b">National Convention</subfield>
+      <subfield code="n">(1st :</subfield>
+      <subfield code="d">1912 :</subfield>
+      <subfield code="c">Chicago)</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Germany.</subfield>
+      <subfield code="t">Treaties, etc.</subfield>
+      <subfield code="g">Soviet Union,</subfield>
+      <subfield code="d">1939 August 23</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">Biblioteca Nacional (Spain).</subfield>
+      <subfield code="k">Manuscript.</subfield>
+      <subfield code="n">8936-8937</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">United States.</subfield>
+      <subfield code="t">Education Amendments of 1972.</subfield>
+      <subfield code="p">Title IX</subfield>
+      <subfield code="x">History</subfield>
+    </datafield>
+    <datafield tag="610" ind1="1" ind2="0">
+      <subfield code="a">United States.</subfield>
+      <subfield code="b">Supreme Court</subfield>
+      <subfield code="x">History</subfield>
+      <subfield code="y">20th century</subfield>
+    </datafield>
+    <datafield tag="610" ind1="2" ind2="7">
+      <subfield code="a">States' Rights Democratic Party.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst00713109</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="7">
+      <subfield code="a">Microsoft Windows (Computer file)</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01367862</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Passion de Jeanne d'Arc.</subfield>
+      <subfield code="h">[Motion picture]</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">
+Vienna Convention for the Protection of the Ozone Layer
+</subfield>
+      <subfield code="d">(1985).</subfield>
+      <subfield code="k">Protocols, etc.,</subfield>
+      <subfield code="d">1987. Sept. 15</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">O.T.</subfield>
+      <subfield code="p">Deuteronomy.</subfield>
+      <subfield code="l">Greek.</subfield>
+      <subfield code="s">Freer Gallery of Art, Washington, D.C.</subfield>
+      <subfield code="g">Mss. (Greek)</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="l">Greek.</subfield>
+      <subfield code="p">N.T.</subfield>
+      <subfield code="f">1886</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">International tables for crystallography.</subfield>
+      <subfield code="n">Volume A</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">Manuscripts.</subfield>
+      <subfield code="l">Latin.</subfield>
+      <subfield code="p">N.T.</subfield>
+      <subfield code="p">Gospels.</subfield>
+      <subfield code="t">Book of Kells</subfield>
+      <subfield code="x">Illustrations</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Bible</subfield>
+      <subfield code="x">Criticism, interpretation, etc.</subfield>
+      <subfield code="z">England</subfield>
+      <subfield code="x">History</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="l">English</subfield>
+      <subfield code="x">History</subfield>
+      <subfield code="y">17th century.</subfield>
+    </datafield>
+    <datafield tag="630" ind1="0" ind2="0">
+      <subfield code="a">MATLAB</subfield>
+      <subfield code="v">Textbooks.</subfield>
+    </datafield>
+    <datafield tag="648" ind1=" " ind2="7">
+      <subfield code="a">1900 - 2099</subfield>
+      <subfield code="2">fast</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="7">
+      <subfield code="a">Europe.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01245064</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">Venus (Planet)</subfield>
+      <subfield code="x">Geology</subfield>
+      <subfield code="v">Maps</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">Ireland</subfield>
+      <subfield code="x">History</subfield>
+      <subfield code="y">Easter Rising, 1916</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">United States</subfield>
+      <subfield code="x">Relations</subfield>
+      <subfield code="z">Japan</subfield>
+    </datafield>
+    <datafield tag="654" ind1=" " ind2=" ">
+      <subfield code="a">Electrical engineering communications</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="7">
+      <subfield code="a">Textbooks.</subfield>
+      <subfield code="2">fast</subfield>
+      <subfield code="0">(OCoLC)fst01423863</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Detective and mystery stories</subfield>
+      <subfield code="v">Fiction</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Foreign language films</subfield>
+      <subfield code="x">Arabic</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">German fiction</subfield>
+      <subfield code="y">20th century</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Foreign films</subfield>
+      <subfield code="z">Switzerland</subfield>
+    </datafield>
+    <datafield tag="662" ind1=" " ind2=" ">
+      <subfield code="a">[1st] (1959)-</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_15.xml
+++ b/tests/data/test_15.xml
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">
+Convention for the Protection of Human Rights and Fundamental Freedoms and Protocol
+</subfield>
+      <subfield code="d">(1950)</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">American Mathematical Society translations.</subfield>
+      <subfield code="g">(Indexes)</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">O.T.</subfield>
+      <subfield code="p">Nehemiah.</subfield>
+      <subfield code="l">English.</subfield>
+      <subfield code="f">1965.</subfield>
+      <subfield code="s">Myers</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Blaue Engel</subfield>
+      <subfield code="h">(motion picture)</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Vedas.</subfield>
+      <subfield code="p">Yajurveda.</subfield>
+      <subfield code="p">Vājasaneyisaṃhitā.</subfield>
+      <subfield code="k">Selections.</subfield>
+      <subfield code="l">French</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Erlanger Forschungen.</subfield>
+      <subfield code="n">Reihe B.</subfield>
+      <subfield code="p">Naturwissenschaften</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">I/EC.</subfield>
+      <subfield code="t">Industrial and engineering chemistry</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2="2">
+      <subfield code="a">God save the King;</subfield>
+      <subfield code="o">arr</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">BioOne (Organization)</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">SpringerLink online journal archive.</subfield>
+      <subfield code="p">Mathematics and statistics</subfield>
+      <subfield code="5">CIT</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="6">880-07</subfield>
+      <subfield code="a">Wen hai.</subfield>
+      <subfield code="l">Tangut</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="i">translation of (work)</subfield>
+      <subfield code="a">Modellbildung und Simulation.</subfield>
+      <subfield code="l">English</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Carleton College (Northfield, Minn.).</subfield>
+      <subfield code="t">Publications ;</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Atmospheric chemistry and physics</subfield>
+      <subfield code="x">1680-7316</subfield>
+    </datafield>
+    <datafield tag="740" ind1="0" ind2=" ">
+      <subfield code="6">880-05</subfield>
+      <subfield code="a">
+Erh pai chung Chung-kuo tʻung su hsiao shuo shu yao
+</subfield>
+    </datafield>
+    <datafield tag="740" ind1="0" ind2="2">
+      <subfield code="a">Martini Buceri Opera omnia.</subfield>
+      <subfield code="n">Series III,</subfield>
+      <subfield code="p">Correspondance</subfield>
+    </datafield>
+    <datafield tag="740" ind1="0" ind2=" ">
+      <subfield code="a">Boris Godunov [original version]</subfield>
+      <subfield code="h">Sound recording</subfield>
+    </datafield>
+    <datafield tag="752" ind1=" " ind2=" ">
+      <subfield code="a">United States</subfield>
+      <subfield code="b">New York</subfield>
+      <subfield code="c">New York</subfield>
+      <subfield code="d">New York</subfield>
+    </datafield>
+    <datafield tag="753" ind1=" " ind2=" ">
+      <subfield code="a">CD-ROM drive</subfield>
+      <subfield code="b">ISO 9660-formatted standard CD-ROM</subfield>
+    </datafield>
+    <datafield tag="753" ind1=" " ind2=" ">
+      <subfield code="a">PC</subfield>
+      <subfield code="c">MS-DOS with Microsoft extensions</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_16.xml
+++ b/tests/data/test_16.xml
@@ -1,0 +1,96 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="800" ind1="0" ind2=" ">
+      <subfield code="a">Gilbert,</subfield>
+      <subfield code="c">of Hoyland.</subfield>
+      <subfield code="t">Works.</subfield>
+      <subfield code="l">English ;</subfield>
+      <subfield code="v">v. 1-3</subfield>
+    </datafield>
+    <datafield tag="800" ind1="0" ind2=" ">
+      <subfield code="a">Ṭabarī,</subfield>
+      <subfield code="d">838?-923.</subfield>
+      <subfield code="t">Taʼrīkh al-rusul wa-al-mulūk.</subfield>
+      <subfield code="l">English ;</subfield>
+      <subfield code="v">v. 35</subfield>
+    </datafield>
+    <datafield tag="800" ind1="0" ind2=" ">
+      <subfield code="a">Aristophanes.</subfield>
+      <subfield code="t">Works.</subfield>
+      <subfield code="l">English &amp; Greek.</subfield>
+      <subfield code="f">1980 ;</subfield>
+      <subfield code="v">v. 4</subfield>
+    </datafield>
+    <datafield tag="800" ind1="1" ind2=" ">
+      <subfield code="a">Liszt, Franz,</subfield>
+      <subfield code="d">1811-1886.</subfield>
+      <subfield code="t">Piano music.</subfield>
+      <subfield code="k">Selections (Bolet) ;</subfield>
+      <subfield code="v">v. 5</subfield>
+    </datafield>
+    <datafield tag="800" ind1="1" ind2=" ">
+      <subfield code="a">Wagner, Richard,</subfield>
+      <subfield code="d">1813-1883.</subfield>
+      <subfield code="t">Ring des Nibelungen.</subfield>
+      <subfield code="p">Walküre</subfield>
+    </datafield>
+    <datafield tag="800" ind1="1" ind2=" ">
+      <subfield code="a">Clark, C. H. Douglas</subfield>
+      <subfield code="q">(Cecil Henry Douglas),</subfield>
+      <subfield code="d">1890-</subfield>
+      <subfield code="t">
+Comprehensive treatise of atomic and molecular structure.
+</subfield>
+      <subfield code="v">v. 2</subfield>
+    </datafield>
+    <datafield tag="800" ind1="1" ind2=" ">
+      <subfield code="a">Shakespeare, William,</subfield>
+      <subfield code="d">1564-1616.</subfield>
+      <subfield code="t">Works.</subfield>
+      <subfield code="f">1984.</subfield>
+      <subfield code="s">Cambridge University Press</subfield>
+    </datafield>
+    <datafield tag="810" ind1="1" ind2=" ">
+      <subfield code="a">University of California.</subfield>
+      <subfield code="t">University of California publications.</subfield>
+      <subfield code="p">English studies ;</subfield>
+      <subfield code="v">8</subfield>
+    </datafield>
+    <datafield tag="810" ind1="1" ind2=" ">
+      <subfield code="a">United States.</subfield>
+      <subfield code="b">Congress</subfield>
+      <subfield code="n">(82d, 1st session :</subfield>
+      <subfield code="d">1951).</subfield>
+      <subfield code="b">Senate.</subfield>
+      <subfield code="t">Report</subfield>
+      <subfield code="v">82d Congress ; no. 1039</subfield>
+    </datafield>
+    <datafield tag="810" ind1="2" ind2=" ">
+      <subfield code="a">International Primatological Society.</subfield>
+      <subfield code="b">Congress</subfield>
+      <subfield code="n">(10th :</subfield>
+      <subfield code="d">1984 :</subfield>
+      <subfield code="c">Nairobi, Kenya)</subfield>
+      <subfield code="t">
+Selected proceedings of the Tenth Congress of the International Primatological Society ;
+</subfield>
+      <subfield code="v">v. 3</subfield>
+    </datafield>
+    <datafield tag="811" ind1="2" ind2=" ">
+      <subfield code="a">Eastern Analytical Symposium</subfield>
+      <subfield code="n">(17th :</subfield>
+      <subfield code="d">1977 :</subfield>
+      <subfield code="c">New York).</subfield>
+      <subfield code="t">1977 Eastern Analytical Symposium series</subfield>
+    </datafield>
+    <datafield tag="811" ind1="2" ind2=" ">
+      <subfield code="a">International Geological Congress.</subfield>
+      <subfield code="e">
+International Subcommission on Stratigraphic Classification.
+</subfield>
+      <subfield code="t">Report ;</subfield>
+      <subfield code="v">no. 5</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_2.xml
+++ b/tests/data/test_2.xml
@@ -1,0 +1,57 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">413092</controlfield>
+    <controlfield tag="005">20150923221003.0</controlfield>
+    <controlfield tag="008">750804s1931\\\\nyu\\\\\\\\\\\00010\eng\\</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+      <subfield code="a">31034955</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">.b10472952</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)1507739</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DLC</subfield>
+      <subfield code="c">FQG</subfield>
+      <subfield code="d">FDA</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">CIT</subfield>
+    </datafield>
+    <datafield tag="100" ind1="1" ind2=" ">
+      <subfield code="a">Winchell, Alexander Newton,</subfield>
+      <subfield code="d">1874-1958</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="4">
+      <subfield code="a">The microscopic characters of artificial inorganic solid substances or artificial minerals,</subfield>
+      <subfield code="c">by Alexander Newton Winchell, with a chapter on the universal stage by Richard Conrad Emmons.</subfield>
+    </datafield>
+    <datafield tag="250" ind1=" " ind2=" ">
+      <subfield code="a">2d ed</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">New York</subfield>
+      <subfield code="b">J. Wiley &amp; sons, inc.</subfield>
+      <subfield code="a">London</subfield>
+      <subfield code="b">Chapman &amp; Hall, ltd.</subfield>
+      <subfield code="c">[c1931]</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">xvii, 403 p.</subfield>
+      <subfield code="b">incl. illus., tables. diagrs.</subfield>
+      <subfield code="c">24 cm</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">"First edition...published in 1927 as Bo. 4 of the University of Wisconsin studies in science [under title "The optic and microscopic characters of artifical minerals"]. Part I on ʻPrinciples and methods, ̓which did not appear in the first edition of this work, consists in large part of revised selections from the author's ʻElements of optical mineralogy, ̓part I, 3d edition."--Pref</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Mineralogy, Determinative</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Emmons, Richard Conrad,</subfield>
+      <subfield code="d">1893-</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_3.xml
+++ b/tests/data/test_3.xml
@@ -1,0 +1,134 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">404855</controlfield>
+    <controlfield tag="005">20151017082215.0</controlfield>
+    <controlfield tag="008">750228c19509999dcuar1\\\\\\\f0\\\\0eng\\</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+      <subfield code="a">47032975 //r512</subfield>
+    </datafield>
+    <datafield tag="022" ind1="0" ind2=" ">
+      <subfield code="a">0193-1180</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">.b10375697</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)1193149</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DLC</subfield>
+      <subfield code="c">UDI</subfield>
+      <subfield code="d">COO</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">m.c.</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">HUL</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">m/c</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">AGL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+      <subfield code="a">n-us---</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+      <subfield code="a">HC106.5</subfield>
+      <subfield code="b">.A272</subfield>
+    </datafield>
+    <datafield tag="086" ind1="0" ind2=" ">
+      <subfield code="a">Pr 40.9:</subfield>
+    </datafield>
+    <datafield tag="086" ind1="0" ind2=" ">
+      <subfield code="a">Pr 41.9:</subfield>
+    </datafield>
+    <datafield tag="110" ind1="1" ind2=" ">
+      <subfield code="a">United States.</subfield>
+      <subfield code="b">President</subfield>
+    </datafield>
+    <datafield tag="210" ind1="0" ind2=" ">
+      <subfield code="a">Econ. rep. Pres. transm. Congr</subfield>
+    </datafield>
+    <datafield tag="222" ind1=" " ind2="0">
+      <subfield code="a">Economic report of the President transmitted to the Congress</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Economic report of the President transmitted to the Congress</subfield>
+    </datafield>
+    <datafield tag="250" ind1=" " ind2=" ">
+      <subfield code="a">[Dept. ed.]</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Washington :</subfield>
+      <subfield code="b">G.P.O. :</subfield>
+      <subfield code="b">For sale by Supt. of Docs., U.S. G.P.O.,</subfield>
+      <subfield code="c">1950-</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">v. :</subfield>
+      <subfield code="b">ill ;</subfield>
+      <subfield code="c">24 cm</subfield>
+    </datafield>
+    <datafield tag="310" ind1=" " ind2=" ">
+      <subfield code="a">Annual</subfield>
+    </datafield>
+    <datafield tag="362" ind1="0" ind2=" ">
+      <subfield code="a">Jan. 6, 1950-</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">Reports for 1950-1953 include: The annual economic review by the Council of Economic Advisers (July issue has title: The economic situation at midyear); 1954-   include: The annual report of the Council of Economic Advisers (title varies slightly)</subfield>
+    </datafield>
+    <datafield tag="510" ind1="0" ind2=" ">
+      <subfield code="a">Predicasts</subfield>
+    </datafield>
+    <datafield tag="525" ind1=" " ind2=" ">
+      <subfield code="a">Vols. for 1950-&lt;1952&gt; accompanied by a supplementary report, dated July, with title: The midyear economic report</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">United States</subfield>
+      <subfield code="x">Economic policy</subfield>
+      <subfield code="x">Periodicals</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">United States</subfield>
+      <subfield code="x">Economic conditions</subfield>
+      <subfield code="y">1945-</subfield>
+      <subfield code="x">Periodicals</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Annual economic review</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Midyear economic report</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Annual report of the Council of Economic Advisers</subfield>
+    </datafield>
+    <datafield tag="775" ind1="1" ind2=" ">
+      <subfield code="a">United States.  President.</subfield>
+      <subfield code="t">Economic report of the President transmitted to the Congress (Doc. ed.)</subfield>
+      <subfield code="w">(DLC)sn 87042042</subfield>
+      <subfield code="w">(OCoLC)8198980</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="a">United States.  President.</subfield>
+      <subfield code="t">Economic report of the President to the Congress</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_4.xml
+++ b/tests/data/test_4.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">748306</controlfield>
+    <controlfield tag="005">20150923234828.0</controlfield>
+    <controlfield tag="006">m\\\\\o\\d\\\\\\\\</controlfield>
+    <controlfield tag="007">cr\cn|</controlfield>
+    <controlfield tag="008">110809s2011\\\\enk\\\\\ob\\\\001\0\eng\d</controlfield>
+    <datafield tag="016" ind1="7" ind2=" ">
+      <subfield code="a">015799976</subfield>
+      <subfield code="2">Uk</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">9781849733472 (electronic bk.)</subfield>
+    </datafield>
+    <datafield tag="020" ind1=" " ind2=" ">
+      <subfield code="a">1849733473 (electronic bk.)</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)746035477</subfield>
+    </datafield>
+    <datafield tag="037" ind1=" " ind2=" ">
+      <subfield code="a">T3517</subfield>
+      <subfield code="b">Royal Society of Chemistry</subfield>
+      <subfield code="n">http://www.rsc.org/spr</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">UKRSC</subfield>
+      <subfield code="b">eng</subfield>
+      <subfield code="c">UKRSC</subfield>
+      <subfield code="d">UKMGB</subfield>
+      <subfield code="d">OCLCQ</subfield>
+      <subfield code="d">N$T</subfield>
+      <subfield code="d">OCLCF</subfield>
+    </datafield>
+    <datafield tag="050" ind1=" " ind2="4">
+      <subfield code="a">TP248.25.M46</subfield>
+      <subfield code="b">M46 2011</subfield>
+    </datafield>
+    <datafield tag="245" ind1="0" ind2="0">
+      <subfield code="a">Membrane engineering for the treatment of gases.</subfield>
+      <subfield code="n">Volume 1,</subfield>
+      <subfield code="p">Gas-separation problems with membranes</subfield>
+      <subfield code="h">[electronic resource] /</subfield>
+      <subfield code="c">editors: Enrico Drioli, Giuseppe Barbieri</subfield>
+    </datafield>
+    <datafield tag="246" ind1="3" ind2="0">
+      <subfield code="a">Gas-separation problems with membranes</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Cambridge :</subfield>
+      <subfield code="b">Royal Society of Chemistry,</subfield>
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">1 online resource (xix, 297 p.)</subfield>
+    </datafield>
+    <datafield tag="504" ind1=" " ind2=" ">
+      <subfield code="a">Includes bibliographical references and index</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">Membranes already have important applications in artificial organs, the processing of biotechnological products, food manufacture, waste water treatment, and seawater desalination. Their uses in gaseous mixture separations are, however, far from achieving their full potential. Separation of air components, natural gas dehumidification and sweeting, separation and recovery of CO2 from biogas, and H2 from refinery gases are all examples of current industrial applications. The use of membranes for reducing the greenhouse effect and improving energy efficiency has also been suggested. New process intensification strategies in the petrochemical industry have opened up another growth area for gas separation membrane systems and membrane reactors. This two volume set presents the state-of-the-art in membrane engineering for the separation of gases. It addresses future developments in carbon capture and utilization, H2 production and purification, and O2/N2 separation. Topics covered include the: applications of membrane gas separation in the petrochemical industry; implementation of membrane processes for post-combustion capture; commercial applications of membranes in gas separations; simulation of membrane systems for CO2 capture; design and development of membrane reactors for industrial applications; Pd-based membranes in hydrogen production; modelling and simulation of membrane reactors for hydrogen production and purification; novel hybrid membrane/pressure swing adsorption process for gas separation; molecular dynamics as a new tool for membrane design, and physical aging of membranes for gas separations.Volume 1 focuses predominantly on problems relating to membranes</subfield>
+    </datafield>
+    <datafield tag="650" ind1=" " ind2="0">
+      <subfield code="a">Gas separation membranes</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Electronic books</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Drioli, E</subfield>
+    </datafield>
+    <datafield tag="700" ind1="1" ind2=" ">
+      <subfield code="a">Barbieri, Giuseppe</subfield>
+    </datafield>
+    <datafield tag="730" ind1="0" ind2=" ">
+      <subfield code="a">Royal Society of Chemistry eBooks</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2="0">
+      <subfield code="u">https://clsproxy.library.caltech.edu/login?url=http://dx.doi.org/10.1039/9781849733472</subfield>
+      <subfield code="z">&lt;a href="https://clsproxy.library.caltech.edu/login?url=http://dx.doi.org/10.1039/9781849733472" TARGET="_blank"&gt;&lt;img src="http://sfx.caltech.edu:8088/images/sfx.gif" alt="Caltech Connect"&gt;&lt;/a&gt;</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_5.xml
+++ b/tests/data/test_5.xml
@@ -1,0 +1,134 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">404855</controlfield>
+    <controlfield tag="005">20151017082215.0</controlfield>
+    <controlfield tag="008">750228c19509999dcuar1\\\\\\\f0\\\\0eng\\</controlfield>
+    <datafield tag="010" ind1=" " ind2=" ">
+      <subfield code="a">47032975 //r512</subfield>
+    </datafield>
+    <datafield tag="022" ind1="0" ind2=" ">
+      <subfield code="a">0193-1180</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">.b10375697</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">(OCoLC)1193149</subfield>
+    </datafield>
+    <datafield tag="040" ind1=" " ind2=" ">
+      <subfield code="a">DLC</subfield>
+      <subfield code="c">UDI</subfield>
+      <subfield code="d">COO</subfield>
+      <subfield code="d">DLC</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">m.c.</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">AIP</subfield>
+      <subfield code="d">HUL</subfield>
+      <subfield code="d">NSD</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">m/c</subfield>
+      <subfield code="d">OCL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">AGL</subfield>
+      <subfield code="d">GPO</subfield>
+      <subfield code="d">NST</subfield>
+    </datafield>
+    <datafield tag="043" ind1=" " ind2=" ">
+      <subfield code="a">n-us---</subfield>
+    </datafield>
+    <datafield tag="050" ind1="0" ind2="0">
+      <subfield code="a">HC106.5</subfield>
+      <subfield code="b">.A272</subfield>
+    </datafield>
+    <datafield tag="086" ind1="0" ind2=" ">
+      <subfield code="a">Pr 40.9:</subfield>
+    </datafield>
+    <datafield tag="086" ind1="0" ind2=" ">
+      <subfield code="a">Pr 41.9:</subfield>
+    </datafield>
+    <datafield tag="110" ind1="1" ind2=" ">
+      <subfield code="a">United States.</subfield>
+      <subfield code="b">President</subfield>
+    </datafield>
+    <datafield tag="210" ind1="0" ind2=" ">
+      <subfield code="a">Econ. rep. Pres. transm. Congr</subfield>
+    </datafield>
+    <datafield tag="222" ind1=" " ind2="0">
+      <subfield code="a">Economic report of the President transmitted to the Congress</subfield>
+    </datafield>
+    <datafield tag="245" ind1="1" ind2="0">
+      <subfield code="a">Economic report of the President transmitted to the Congress</subfield>
+    </datafield>
+    <datafield tag="250" ind1=" " ind2=" ">
+      <subfield code="a">[Dept. ed.]</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="a">Washington :</subfield>
+      <subfield code="b">G.P.O. :</subfield>
+      <subfield code="b">For sale by Supt. of Docs., U.S. G.P.O.,</subfield>
+      <subfield code="c">1950-</subfield>
+    </datafield>
+    <datafield tag="300" ind1=" " ind2=" ">
+      <subfield code="a">v. :</subfield>
+      <subfield code="b">ill ;</subfield>
+      <subfield code="c">24 cm</subfield>
+    </datafield>
+    <datafield tag="310" ind1=" " ind2=" ">
+      <subfield code="a">Annual</subfield>
+    </datafield>
+    <datafield tag="362" ind1="0" ind2=" ">
+      <subfield code="a">Jan. 6, 1950-</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">Reports for 1950-1953 include: The annual economic review by the Council of Economic Advisers (July issue has title: The economic situation at midyear); 1954-   include: The annual report of the Council of Economic Advisers (title varies slightly)</subfield>
+    </datafield>
+    <datafield tag="510" ind1="0" ind2=" ">
+      <subfield code="a">Predicasts</subfield>
+    </datafield>
+    <datafield tag="525" ind1=" " ind2=" ">
+      <subfield code="a">Vols. for 1950-&lt;1952&gt; accompanied by a supplementary report, dated July, with title: The midyear economic report</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">United States</subfield>
+      <subfield code="x">Economic policy</subfield>
+      <subfield code="x">Periodicals</subfield>
+    </datafield>
+    <datafield tag="651" ind1=" " ind2="0">
+      <subfield code="a">United States</subfield>
+      <subfield code="x">Economic conditions</subfield>
+      <subfield code="y">1945-</subfield>
+      <subfield code="x">Periodicals</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Annual economic review</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Midyear economic report</subfield>
+    </datafield>
+    <datafield tag="710" ind1="2" ind2=" ">
+      <subfield code="a">Council of Economic Advisers (U.S.).</subfield>
+      <subfield code="t">Annual report of the Council of Economic Advisers</subfield>
+    </datafield>
+    <datafield tag="775" ind1="1" ind2=" ">
+      <subfield code="a">United States.  President.</subfield>
+      <subfield code="t">Economic report of the President transmitted to the Congress (Doc. ed.)</subfield>
+      <subfield code="w">(DLC)sn 87042042</subfield>
+      <subfield code="w">(OCoLC)8198980</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="a">United States.  President.</subfield>
+      <subfield code="t">Economic report of the President to the Congress</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_6.xml
+++ b/tests/data/test_6.xml
@@ -1,6 +1,9 @@
-<?xml version="1.0"?>
+<?xml version='1.0' encoding='UTF-8'?>
 <collection xmlns="http://www.loc.gov/MARC21/slim">
   <record>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Electronic books.</subfield>
+    </datafield>
     <datafield tag="760" ind1="0" ind2="8">
       <subfield code="i">This work also included as part of</subfield>
       <subfield code="a">
@@ -15,7 +18,7 @@
     </datafield>
     <datafield tag="760" ind1="0" ind2=" ">
       <subfield code="t">
-        Bibliothe&#x300;que des Ecoles franc&#x327;aises d'Athe&#x300;nes et de Rome. 3e se&#x301;rie : Registres et lettres des papes du XIVe sie&#x300;cle
+        Bibliothèque des Ecoles françaises d'Athènes et de Rome. 3e série : Registres et lettres des papes du XIVe siècle
       </subfield>
       <subfield code="g">4</subfield>
     </datafield>
@@ -44,11 +47,7 @@
     </datafield>
     <datafield tag="765" ind1="0" ind2=" ">
       <subfield code="t">Astrofizika</subfield>
-      <subfield code="l">English</subfield>
       <subfield code="w">(OCoLC)1829309</subfield>
-    </datafield>
-    <datafield tag="655" ind1=" " ind2="0">
-      <subfield code="a">Electronic books.</subfield>
     </datafield>
     <datafield tag="765" ind1="1" ind2=" ">
       <subfield code="t">Doklady Akademii nauk SSSR</subfield>
@@ -101,9 +100,14 @@
         Issued as a special section of Analytica chimica acta,v. 1-5 called also v. 95, 103, 112, 122, 133 of Analytica chimica acta.
       </subfield>
     </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="t">Astrophysical journal. Supplement series</subfield>
+      <subfield code="x">0067-0049</subfield>
+      <subfield code="w">(DLC) 56037588</subfield>
+      <subfield code="w">(OCoLC)2413276</subfield>
+    </datafield>
     <datafield tag="772" ind1="0" ind2="0">
       <subfield code="a">$tEarthquake engineering and structural dynamics ;</subfield>
-      <subfield code="v">v. 14, no. 5</subfield>
     </datafield>
     <datafield tag="772" ind1="0" ind2="0">
       <subfield code="t">Earthquake engineering and structural dynamics</subfield>
@@ -167,7 +171,7 @@
     </datafield>
     <datafield tag="775" ind1="0" ind2=" ">
       <subfield code="t">
-        La Chine est-elle un "grand pays"? : son influence sur les marche&#x301;s mondiaux
+        La Chine est-elle un "grand pays"? : son influence sur les marchés mondiaux
       </subfield>
       <subfield code="z">9264256091</subfield>
     </datafield>
@@ -231,12 +235,6 @@
       <subfield code="w">(DLC) 2013042745</subfield>
       <subfield code="w">(OCoLC)861895302</subfield>
     </datafield>
-    <datafield tag="770" ind1="0" ind2=" ">
-      <subfield code="t">Astrophysical journal. Supplement series</subfield>
-      <subfield code="x">0067-0049</subfield>
-      <subfield code="w">(DLC) 56037588</subfield>
-      <subfield code="w">(OCoLC)2413276</subfield>
-    </datafield>
     <datafield tag="777" ind1="0" ind2=" ">
       <subfield code="a">
         International Conference on Medicine and biological Engineering
@@ -294,9 +292,6 @@
     <datafield tag="785" ind1="0" ind2="0">
       <subfield code="t">Metallurgical and materials transactions.</subfield>
       <subfield code="n">B,</subfield>
-      <subfield code="p">
-        Process metallurgy and materials processing science
-      </subfield>
       <subfield code="x">1073-5615</subfield>
       <subfield code="w">(DLC)xn93004155</subfield>
       <subfield code="w">(OCoLC)29464178</subfield>

--- a/tests/data/test_7.xml
+++ b/tests/data/test_7.xml
@@ -1,0 +1,143 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <controlfield tag="001">1</controlfield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">Test Description</subfield>
+    </datafield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">lsid</subfield>
+      <subfield code="a">urn:lsid:ubio.org:namebank:11815</subfield>
+      <subfield code="q">alternateIdentifier</subfield>
+    </datafield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">ads</subfield>
+      <subfield code="a">2011ApJS..192...18K</subfield>
+      <subfield code="q">alternateIdentifier</subfield>
+    </datafield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">doi</subfield>
+      <subfield code="a">10.1234/alternate.doi</subfield>
+      <subfield code="q">alternateIdentifier</subfield>
+    </datafield>
+    <datafield tag="711" ind1=" " ind2=" ">
+      <subfield code="c">Harvard-Smithsonian Center for Astrophysics</subfield>
+      <subfield code="a">The 13th Biennial HITRAN Conference</subfield>
+      <subfield code="g">HITRAN13</subfield>
+      <subfield code="d">23-25 June, 2014</subfield>
+      <subfield code="n">VI</subfield>
+      <subfield code="p">1</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">4</subfield>
+    </datafield>
+    <datafield tag="536" ind1=" " ind2=" ">
+      <subfield code="c">1234</subfield>
+      <subfield code="a">Grant Title</subfield>
+    </datafield>
+    <datafield tag="536" ind1=" " ind2=" ">
+      <subfield code="c">4321</subfield>
+      <subfield code="a">Title Grant</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="4">ths</subfield>
+      <subfield code="a">Smith, Jane</subfield>
+      <subfield code="0">(orcid)0000-0002-1825-0097</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="4">ths</subfield>
+      <subfield code="a">Kowalski, Jane</subfield>
+      <subfield code="0">(gnd)170118215</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="a">kw1</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="a">kw2</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="a">kw3</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="c">2014-02-27</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="a">Doe, Jane</subfield>
+      <subfield code="0">(orcid)0000-0002-1825-0097</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="a">Smith, John</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="a">Nowak, Jack</subfield>
+      <subfield code="0">(gnd)170118215</subfield>
+    </datafield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">9876</subfield>
+    </datafield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.1234/foo.bar</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="4">oth</subfield>
+      <subfield code="a">Smith, Other</subfield>
+      <subfield code="0">(orcid)0000-0002-1825-0097</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u"></subfield>
+      <subfield code="4">oth</subfield>
+      <subfield code="a">Hansen, Viggo</subfield>
+    </datafield>
+    <datafield tag="700" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="4">dtm</subfield>
+      <subfield code="a">Kowalski, Manager</subfield>
+      <subfield code="0">(gnd)170118215</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="u">http://zenodo.org</subfield>
+      <subfield code="a">Creative Commons</subfield>
+    </datafield>
+    <datafield tag="650" ind1="1" ind2="7">
+      <subfield code="a">cc-by</subfield>
+      <subfield code="2">opendefinition.org</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Test title</subfield>
+    </datafield>
+    <datafield tag="650" ind1="1" ind2=" ">
+      <subfield code="a">test_term</subfield>
+      <subfield code="0">(gnd)170118215</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">notes</subfield>
+    </datafield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="u">CERN</subfield>
+      <subfield code="a">Doe, John</subfield>
+      <subfield code="0">(gnd)170118215</subfield>
+      <subfield code="0">(orcid)0000-0002-1694-233X</subfield>
+    </datafield>
+    <datafield tag="773" ind1=" " ind2=" ">
+      <subfield code="a">10.1234/foo.bar</subfield>
+      <subfield code="i">cites</subfield>
+      <subfield code="n">doi</subfield>
+    </datafield>
+    <datafield tag="773" ind1=" " ind2=" ">
+      <subfield code="a">1234.4321</subfield>
+      <subfield code="i">cites</subfield>
+      <subfield code="n">arxiv</subfield>
+    </datafield>
+    <datafield tag="542" ind1=" " ind2=" ">
+      <subfield code="l">open</subfield>
+    </datafield>
+    <datafield tag="347" ind1=" " ind2=" "/>
+  </record>
+</collection>

--- a/tests/data/test_8.xml
+++ b/tests/data/test_8.xml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="015" ind1=" " ind2=" ">
+      <subfield code="a">011220910</subfield>
+      <subfield code="2">dnb</subfield>
+    </datafield>
+    <datafield tag="016" ind1="7" ind2=" ">
+      <subfield code="a">CAT10911698</subfield>
+      <subfield code="2">DNAL</subfield>
+    </datafield>
+    <datafield tag="017" ind1=" " ind2=" ">
+      <subfield code="a">DLE-20120307-13801</subfield>
+      <subfield code="b">FR</subfield>
+    </datafield>
+    <datafield tag="028" ind1="2" ind2="2">
+      <subfield code="a">44601</subfield>
+      <subfield code="b">G. Schirmer</subfield>
+    </datafield>
+    <datafield tag="033" ind1="1" ind2="0">
+      <subfield code="a">19911119</subfield>
+      <subfield code="a">19920423</subfield>
+      <subfield code="b">4034</subfield>
+      <subfield code="c">D2</subfield>
+    </datafield>
+    <datafield tag="034" ind1="0" ind2=" ">
+      <subfield code="a">a</subfield>
+      <subfield code="b">12000</subfield>
+      <subfield code="b">3200000</subfield>
+      <subfield code="d">W1484000</subfield>
+      <subfield code="e">W1482000</subfield>
+      <subfield code="f">N0702000</subfield>
+      <subfield code="g">N0701000</subfield>
+    </datafield>
+    <datafield tag="042" ind1=" " ind2=" ">
+      <subfield code="a">pcc</subfield>
+      <subfield code="a">nsdp</subfield>
+    </datafield>
+    <datafield tag="044" ind1=" " ind2=" ">
+      <subfield code="a">cau</subfield>
+      <subfield code="a">gw</subfield>
+      <subfield code="a">fr</subfield>
+      <subfield code="a">au</subfield>
+    </datafield>
+    <datafield tag="044" ind1=" " ind2=" ">
+      <subfield code="a">xxu</subfield>
+      <subfield code="c">usa</subfield>
+    </datafield>
+    <datafield tag="046" ind1=" " ind2=" ">
+      <subfield code="k">2009</subfield>
+    </datafield>
+    <datafield tag="046" ind1=" " ind2=" ">
+      <subfield code="j">Tue Aug 02 08:13:10 EDT 2011</subfield>
+    </datafield>
+    <datafield tag="046" ind1=" " ind2=" ">
+      <subfield code="a">CIT6</subfield>
+    </datafield>
+    <datafield tag="047" ind1=" " ind2="#">
+      <subfield code="a">00281313</subfield>
+    </datafield>
+    <datafield tag="052" ind1=" " ind2=" ">
+      <subfield code="a">3182</subfield>
+      <subfield code="b">J8</subfield>
+      <subfield code="b">T5</subfield>
+    </datafield>
+    <datafield tag="060" ind1="1" ind2="4">
+      <subfield code="a">QV 350</subfield>
+      <subfield code="b">S224 2015</subfield>
+    </datafield>
+    <datafield tag="066" ind1=" " ind2=" ">
+      <subfield code="c">(S</subfield>
+    </datafield>
+    <datafield tag="070" ind1="0" ind2=" ">
+      <subfield code="a">QC981.8.G56</subfield>
+      <subfield code="b">H69 2014</subfield>
+    </datafield>
+    <datafield tag="074" ind1=" " ind2=" ">
+      <subfield code="a">856-B-9 (MF)</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/test_9.xml
+++ b/tests/data/test_9.xml
@@ -1,0 +1,65 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="100" ind1="0" ind2=" ">
+      <subfield code="a">Francis,</subfield>
+      <subfield code="c">of Assisi, Saint,</subfield>
+      <subfield code="d">1182-1226.</subfield>
+      <subfield code="t">Legend.</subfield>
+      <subfield code="p">Fioretti.</subfield>
+      <subfield code="l">English</subfield>
+    </datafield>
+    <datafield tag="100" ind1="0" ind2=" ">
+      <subfield code="a">M. Madeleva</subfield>
+      <subfield code="q">(Mary Madeleva),</subfield>
+      <subfield code="c">Sister,</subfield>
+      <subfield code="d">1887-1964</subfield>
+    </datafield>
+    <datafield tag="100" ind1="0" ind2=" ">
+      <subfield code="a">John</subfield>
+      <subfield code="b">XXIII,</subfield>
+      <subfield code="c">Pope,</subfield>
+      <subfield code="d">1881-1963</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">
+Scientific reports (Australasian Antarctic Expedition (1911-1914)).
+</subfield>
+      <subfield code="n">Series C,</subfield>
+      <subfield code="p">Zoology and botany</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">N.T.</subfield>
+      <subfield code="p">John III, 16.</subfield>
+      <subfield code="l">Polyglot.</subfield>
+      <subfield code="d">1965</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">O.T.</subfield>
+      <subfield code="p">Song of Solomon.</subfield>
+      <subfield code="l">English.</subfield>
+      <subfield code="s">Pope.</subfield>
+      <subfield code="f">1977</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">Bible.</subfield>
+      <subfield code="p">O.T.</subfield>
+      <subfield code="p">Historical books.</subfield>
+      <subfield code="l">English.</subfield>
+      <subfield code="k">Selections.</subfield>
+      <subfield code="f">1957.</subfield>
+      <subfield code="s">Pfeiffer</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">Bulletin</subfield>
+      <subfield code="h">[1894-1908] (South Dakota Geological Survey)</subfield>
+    </datafield>
+    <datafield tag="130" ind1="0" ind2=" ">
+      <subfield code="a">Talmud.</subfield>
+      <subfield code="t">Minor tractates.</subfield>
+      <subfield code="l">English</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/demo_marc21_full.xml
+++ b/tests/demo_marc21_full.xml
@@ -1,0 +1,352 @@
+<?xml version="1.0"?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="760" ind1="0" ind2="8">
+      <subfield code="i">This work also included as part of</subfield>
+      <subfield code="a">
+        Complete dictionary of scientific biography [electronic resource]
+      </subfield>
+    </datafield>
+    <datafield tag="760" ind1="0" ind2="8">
+      <subfield code="a">Hartfuss, Hans-Jurgen.</subfield>
+      <subfield code="t">Fusion plasma diagnostics with mm-waves.</subfield>
+      <subfield code="d">Weiheim : Wiley-Vch, 2013</subfield>
+      <subfield code="w">(OCoLC)828140540</subfield>
+    </datafield>
+    <datafield tag="760" ind1="0" ind2=" ">
+      <subfield code="t">
+        Bibliothe&#x300;que des Ecoles franc&#x327;aises d'Athe&#x300;nes et de Rome. 3e se&#x301;rie : Registres et lettres des papes du XIVe sie&#x300;cle
+      </subfield>
+      <subfield code="g">4</subfield>
+    </datafield>
+    <datafield tag="760" ind1="0" ind2=" ">
+      <subfield code="t">Publication (Field Columbian Museum)</subfield>
+      <subfield code="x">0097-5745</subfield>
+      <subfield code="w">(OCoLC)3506292</subfield>
+    </datafield>
+    <datafield tag="760" ind1="1" ind2=" ">
+      <subfield code="t">Special publication</subfield>
+      <subfield code="c">(California. Division of Mines and Geology)</subfield>
+      <subfield code="x">0147-6211</subfield>
+      <subfield code="w">(OCoLC)2828679</subfield>
+    </datafield>
+    <datafield tag="762" ind1="0" ind2=" ">
+      <subfield code="t">
+        Commentationes physico-mathematicae. Dissertationes
+      </subfield>
+      <subfield code="x">0358-9307</subfield>
+      <subfield code="g">1980-</subfield>
+      <subfield code="w">(OCoLC)8191871</subfield>
+    </datafield>
+    <datafield tag="762" ind1="0" ind2=" ">
+      <subfield code="t">Oil division paper.</subfield>
+      <subfield code="c">no. 1- 1957- (irregular)</subfield>
+    </datafield>
+    <datafield tag="765" ind1="0" ind2=" ">
+      <subfield code="t">Astrofizika</subfield>
+      <subfield code="l">English</subfield>
+      <subfield code="w">(OCoLC)1829309</subfield>
+    </datafield>
+    <datafield tag="655" ind1=" " ind2="0">
+      <subfield code="a">Electronic books.</subfield>
+    </datafield>
+    <datafield tag="765" ind1="1" ind2=" ">
+      <subfield code="t">Doklady Akademii nauk SSSR</subfield>
+      <subfield code="x">0002-3264</subfield>
+      <subfield code="w">(OCoLC)1478791</subfield>
+    </datafield>
+    <datafield tag="767" ind1="0" ind2=" ">
+      <subfield code="a">Chinese journal of geophysics</subfield>
+      <subfield code="x">0898-9591</subfield>
+    </datafield>
+    <datafield tag="767" ind1="0" ind2=" ">
+      <subfield code="t">Instruments and experimental techniques</subfield>
+      <subfield code="c">(New York)</subfield>
+      <subfield code="x">0020-4412</subfield>
+    </datafield>
+    <datafield tag="767" ind1="0" ind2=" ">
+      <subfield code="t">Mathematics of the USSR. Sbornik</subfield>
+      <subfield code="g">1967-1993</subfield>
+      <subfield code="x">0025-5734</subfield>
+      <subfield code="w">(DLC) 93646066</subfield>
+      <subfield code="w">(OCoLC)1681277</subfield>
+    </datafield>
+    <datafield tag="767" ind1="0" ind2=" ">
+      <subfield code="t">Soviet astronomy</subfield>
+      <subfield code="h">(Russian)</subfield>
+    </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="a">National Society for the Study of Communication.</subfield>
+      <subfield code="t">
+        Directory of the National Society for the Study of Communication
+      </subfield>
+      <subfield code="g">1966</subfield>
+    </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="t">Clinical science. Supplement</subfield>
+      <subfield code="c">(1979)</subfield>
+      <subfield code="x">0144-9664</subfield>
+    </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="t">Health information for international travel</subfield>
+      <subfield code="g">1974-1980</subfield>
+      <subfield code="x">0095-3539</subfield>
+      <subfield code="w">(DLC) 77649068</subfield>
+      <subfield code="w">(OCoLC)2905736</subfield>
+    </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="t">Computer techniques and optimization,</subfield>
+      <subfield code="x">0378-4304;</subfield>
+      <subfield code="n">
+        Issued as a special section of Analytica chimica acta,v. 1-5 called also v. 95, 103, 112, 122, 133 of Analytica chimica acta.
+      </subfield>
+    </datafield>
+    <datafield tag="772" ind1="0" ind2="0">
+      <subfield code="a">$tEarthquake engineering and structural dynamics ;</subfield>
+      <subfield code="v">v. 14, no. 5</subfield>
+    </datafield>
+    <datafield tag="772" ind1="0" ind2="0">
+      <subfield code="t">Earthquake engineering and structural dynamics</subfield>
+      <subfield code="g">Vol. 14 (1986), p. 297-315</subfield>
+      <subfield code="w">(OCoLC) 1785750</subfield>
+    </datafield>
+    <datafield tag="772" ind1="0" ind2="0">
+      <subfield code="t">Bollettino di geodesia e scienze affini</subfield>
+      <subfield code="x">0006-6710</subfield>
+      <subfield code="w">(OCoLC)8691758</subfield>
+    </datafield>
+    <datafield tag="772" ind1="0" ind2="8">
+      <subfield code="i">augmentation of (expression) :</subfield>
+      <subfield code="a">Loudon, G. Marc.</subfield>
+      <subfield code="t">Organic chemistry,</subfield>
+      <subfield code="b">sixth edition.</subfield>
+      <subfield code="w">(OCoLC)907161629</subfield>
+    </datafield>
+    <datafield tag="773" ind1="0" ind2=" ">
+      <subfield code="a">
+        International Geological Congress (8th : 1900 : Paris)
+      </subfield>
+      <subfield code="t">Comptes rendus ...</subfield>
+      <subfield code="d">Paris, 1901.</subfield>
+      <subfield code="g">v. 2, p. 1003-1302.</subfield>
+      <subfield code="w">(OCoLC)6578829</subfield>
+    </datafield>
+    <datafield tag="773" ind1="0" ind2=" ">
+      <subfield code="t">ACLS Humanities E-Book.</subfield>
+      <subfield code="n">URL: http://www.humanitiesebook.org/</subfield>
+    </datafield>
+    <datafield tag="773" ind1="0" ind2=" ">
+      <subfield code="t">Chemistry Central journal</subfield>
+      <subfield code="g">Vol. 3, suppl. 1</subfield>
+      <subfield code="x">1752-153X</subfield>
+      <subfield code="w">(OCoLC)85809995</subfield>
+    </datafield>
+    <datafield tag="774" ind1="1" ind2=" ">
+      <subfield code="t">Atmospheric chemistry and physics discussions</subfield>
+      <subfield code="x">1680-7367</subfield>
+    </datafield>
+    <datafield tag="775" ind1="1" ind2=" ">
+      <subfield code="a">United States. Supreme Court.</subfield>
+      <subfield code="t">
+        Report of cases argued and decided in the United States.
+      </subfield>
+      <subfield code="b">Complete edition</subfield>
+      <subfield code="g">book 15-44; 1854-99</subfield>
+    </datafield>
+    <datafield tag="775" ind1="0" ind2="8">
+      <subfield code="i">Digest ed.:</subfield>
+      <subfield code="t">Space weather quarterly</subfield>
+      <subfield code="x">1539-4964</subfield>
+      <subfield code="w">(DLC) 2002214124</subfield>
+      <subfield code="w">(OCoLC)49520121</subfield>
+    </datafield>
+    <datafield tag="775" ind1="0" ind2=" ">
+      <subfield code="t">Observateur de l'OCDE</subfield>
+      <subfield code="f">fre</subfield>
+      <subfield code="w">(OCoLC)4110819</subfield>
+    </datafield>
+    <datafield tag="775" ind1="0" ind2=" ">
+      <subfield code="t">
+        La Chine est-elle un "grand pays"? : son influence sur les marche&#x301;s mondiaux
+      </subfield>
+      <subfield code="z">9264256091</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Original:</subfield>
+      <subfield code="a">Pratchett, Terry.</subfield>
+      <subfield code="t">Snuff.</subfield>
+      <subfield code="b">1st ed.</subfield>
+      <subfield code="d">New York : Harper, c2011</subfield>
+      <subfield code="z">9780062011848</subfield>
+      <subfield code="w">(DLC) 2011033117</subfield>
+      <subfield code="w">(OCoLC)703206404</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Print version:</subfield>
+      <subfield code="t">
+        Journal of inorganic and organometallic polymers and materials
+      </subfield>
+      <subfield code="c">(print)</subfield>
+      <subfield code="x">1574-1443</subfield>
+      <subfield code="w">(DLC) 2005242077</subfield>
+      <subfield code="w">(OCoLC)59821324</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Also issued in print:</subfield>
+      <subfield code="t">Protein engineering</subfield>
+      <subfield code="g">print version</subfield>
+      <subfield code="x">0269-2139</subfield>
+      <subfield code="w">(DLC) 87654079</subfield>
+      <subfield code="w">(OCoLC)15234798</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Print version:</subfield>
+      <subfield code="t">
+        From C-H to C-C bonds : cross-dehydrogenative-coupling.
+      </subfield>
+      <subfield code="d">
+        Cambridge, England : The Royal Society of Chemistry, c2014
+      </subfield>
+      <subfield code="h">xiv, 316 pages</subfield>
+      <subfield code="k">RSC green chemistry series ; 26.</subfield>
+      <subfield code="x">1757-7039</subfield>
+      <subfield code="z">9781849737975</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Online version:</subfield>
+      <subfield code="a">Pynchon, Thomas.</subfield>
+      <subfield code="s">Gravity's rainbow. Italian.</subfield>
+      <subfield code="d">Roma : Pynchon, 1997, c1996</subfield>
+      <subfield code="w">(OCoLC)664314138</subfield>
+    </datafield>
+    <datafield tag="776" ind1="0" ind2="8">
+      <subfield code="i">Print version:</subfield>
+      <subfield code="t">Wnt signaling in devel&gt;856 40</subfield>
+      <subfield code="u">http://alltitles.ebrary.com/Doc?id=10842275</subfield>
+      <subfield code="z">
+        An electronic book accessible through the Wopment and disease.
+      </subfield>
+      <subfield code="d">Hoboken, New Jersey : John Wiley  &amp; Sons, [2014]</subfield>
+      <subfield code="z">9781118444160</subfield>
+      <subfield code="w">(DLC) 2013042745</subfield>
+      <subfield code="w">(OCoLC)861895302</subfield>
+    </datafield>
+    <datafield tag="770" ind1="0" ind2=" ">
+      <subfield code="t">Astrophysical journal. Supplement series</subfield>
+      <subfield code="x">0067-0049</subfield>
+      <subfield code="w">(DLC) 56037588</subfield>
+      <subfield code="w">(OCoLC)2413276</subfield>
+    </datafield>
+    <datafield tag="777" ind1="0" ind2=" ">
+      <subfield code="a">
+        International Conference on Medicine and biological Engineering
+      </subfield>
+      <subfield code="t">Proceedings</subfield>
+      <subfield code="g">8th, 1969</subfield>
+    </datafield>
+    <datafield tag="777" ind1="0" ind2=" ">
+      <subfield code="t">Rights</subfield>
+      <subfield code="c">(New York, N.Y. 1953)</subfield>
+      <subfield code="x">0035-5283</subfield>
+      <subfield code="w">(OCoLC)1764346</subfield>
+      <subfield code="w">(DLC) 60046015</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="a">Institution of Electrical Engineers.</subfield>
+      <subfield code="t">Journal of the Institution of Electrical Engineers</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="a">South Australia.</subfield>
+      <subfield code="b">Department of Mines.</subfield>
+      <subfield code="t">Annual report</subfield>
+      <subfield code="x">0810-6215</subfield>
+      <subfield code="w">(DLC)sn 83003173</subfield>
+      <subfield code="w">(OCoLC)8012939</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="t">Automatic control</subfield>
+      <subfield code="c">(New York. 1969)</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="t">Korean journal of crop science</subfield>
+      <subfield code="g">1998-</subfield>
+    </datafield>
+    <datafield tag="780" ind1="0" ind2="0">
+      <subfield code="s">
+        Quarterly review (Utah Geological and Mineralogical Survey)
+      </subfield>
+      <subfield code="x">0275-1666</subfield>
+    </datafield>
+    <datafield tag="785" ind1="1" ind2="1">
+      <subfield code="a">Transactions of the Metallurgical Society of AIME</subfield>
+      <subfield code="g">1958-69</subfield>
+      <subfield code="x">0543-5722</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="0">
+      <subfield code="t">JOM</subfield>
+      <subfield code="g">v. 26, no. 12-v. 28, no. 12;</subfield>
+      <subfield code="x">0098-4558</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="0">
+      <subfield code="t">Journal of the Air  &amp; Waste management Association</subfield>
+      <subfield code="h">[1995+]</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="0">
+      <subfield code="t">Metallurgical and materials transactions.</subfield>
+      <subfield code="n">B,</subfield>
+      <subfield code="p">
+        Process metallurgy and materials processing science
+      </subfield>
+      <subfield code="x">1073-5615</subfield>
+      <subfield code="w">(DLC)xn93004155</subfield>
+      <subfield code="w">(OCoLC)29464178</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="0">
+      <subfield code="s">Survey notes (Utah Geological and Mineral Survey)</subfield>
+      <subfield code="x">0362-6288</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="0">
+      <subfield code="t">Journal of physics D. Applied physics</subfield>
+      <subfield code="x">0022-3727</subfield>
+      <subfield code="z">(OCoLC) 1772505</subfield>
+    </datafield>
+    <datafield tag="785" ind1="0" ind2="6">
+      <subfield code="t">
+        IEEE transactions on components, packaging, and manufacturing technology. Part C, Manufacturing
+      </subfield>
+      <subfield code="c">x1083-4400</subfield>
+    </datafield>
+    <datafield tag="787" ind1="0" ind2="8">
+      <subfield code="a">Kaufman, Matthew H.</subfield>
+      <subfield code="t">Atlas of mouse development.</subfield>
+      <subfield code="b">Rev.ed.</subfield>
+      <subfield code="d">London ; San Diego : Academic Press, 1994</subfield>
+      <subfield code="z">0124020356</subfield>
+      <subfield code="w">(OCoLC)36433001</subfield>
+    </datafield>
+    <datafield tag="787" ind1="0" ind2="8">
+      <subfield code="a">Theiler, Karl.</subfield>
+      <subfield code="t">House mouse.</subfield>
+      <subfield code="d">New York : Springer-Verlag, c1989</subfield>
+      <subfield code="z">0387059407</subfield>
+      <subfield code="w">(DLC) 88024888</subfield>
+      <subfield code="w">(OCoLC)18412018</subfield>
+    </datafield>
+    <datafield tag="787" ind1="0" ind2="8">
+      <subfield code="i">Electronic access:</subfield>
+      <subfield code="t">Dictionnaire historique et critique</subfield>
+      <subfield code="c">(1740 Amsterdam edition)</subfield>
+      <subfield code="w">(OCoLC)40279884</subfield>
+    </datafield>
+    <datafield tag="787" ind1="0" ind2=" ">
+      <subfield code="t">Journal of antibiotics. Series B</subfield>
+      <subfield code="g">1953-67</subfield>
+      <subfield code="w">(OCoLC)1778527</subfield>
+    </datafield>
+    <datafield tag="787" ind1="0" ind2="8">
+      <subfield code="i">California building standard in print:</subfield>
+      <subfield code="t">California code of regulations.</subfield>
+      <subfield code="n">Title 24</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/demo_marc21_to_dc.converted.xml
+++ b/tests/demo_marc21_to_dc.converted.xml
@@ -1,1 +1,6 @@
-<dc:collection xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd"><dc:dc><dc:creator>Donges, Jonathan F</dc:creator></dc:dc></dc:collection>
+<?xml version='1.0' encoding='UTF-8'?>
+<dc:collection xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <dc:dc>
+    <dc:creator>Donges, Jonathan F</dc:creator>
+  </dc:dc>
+</dc:collection>

--- a/tests/demo_marc21_to_dc.xml
+++ b/tests/demo_marc21_to_dc.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <record>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">Donges, Jonathan F</subfield>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,8 +9,11 @@
 
 """Test suite for DoJSON."""
 
-import json
+import codecs
+import os
 
+import pytest
+import simplejson as json
 from click.testing import CliRunner
 
 from dojson import cli
@@ -18,12 +21,58 @@ from dojson.contrib.marc21.utils import create_record
 from test_core import RECORD_999_FIELD, RECORD_SIMPLE
 
 
+@pytest.mark.parametrize('file_name', [
+    'test_1.xml',
+    'test_2.xml',
+    'test_3.xml',
+    'test_4.xml',
+    'test_5.xml',
+    'test_6.xml',
+    'test_7.xml',
+    'test_8.xml',
+    'test_9.xml',
+    'test_11.xml',
+    'test_12.xml',
+    'test_13.xml',
+    'test_14.xml',
+    'test_15.xml',
+    'test_16.xml',
+])
+def test_xml_to_marc21_to_xml(file_name):
+    """Test xslt dump."""
+    path = os.path.dirname(__file__)
+    # Open explicitly as UTF-8 for Python 2.7 compatibility
+    with codecs.open(
+            '{0}/data/{1}'.format(path, file_name),
+            'r',
+            'utf-8') as myfile:
+        expect = myfile.read()
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli, [
+            '-i', '{0}/data/{1}'.format(path, file_name),
+            '-l', 'marcxml',
+            '-d', 'marcxml',
+            'do', 'marc21',
+            'do', 'to_marc21',
+        ]
+    )
+
+    assert expect.strip('\n') == result.output.strip('\n')
+    assert result.exit_code == 0
+
+
 def test_cli_do_marc21_from_xml():
     """Test MARC21 loading from XML."""
     expected = [{
-        'main_entry_personal_name': {
-            'personal_name': 'Donges, Jonathan F'
-        }
+        '__order__': ['main_entry_personal_name'],
+        'main_entry_personal_name': [
+            {
+                '__order__': ['personal_name'],
+                'personal_name': 'Donges, Jonathan F',
+            }
+        ],
     }]
 
     runner = CliRunner()
@@ -53,10 +102,10 @@ def test_cli_do_marc21_from_xml():
             cli.cli,
             ['-i', 'record.xml', '-l', 'marcxml', 'do', '--strict', 'marc21']
         )
-        assert -1 == result.exit_code
+        assert 0 == result.exit_code
 
 
-def test_cli_do_marc21_from_xml_unknown_fieds():
+def test_cli_do_marc21_from_xml_unknown_fields():
     """Test MARC21 loading from XML containing unknown fields."""
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -69,13 +118,13 @@ def test_cli_do_marc21_from_xml_unknown_fieds():
         )
         assert "999__" == result.output.strip()
         assert 1 == result.exit_code
-
         result = runner.invoke(
             cli.cli,
             ['-i', 'record_999.xml', '-l', 'marcxml', 'do', 'marc21']
         )
+
         data = json.loads(result.output)
-        assert {} == data[0]
+        assert {'__order__': []} == data[0]
         assert 0 == result.exit_code
 
 
@@ -83,9 +132,13 @@ def test_cli_do_marc21_from_json():
     """Test MARC21 loading from XML."""
     expected = [{
         '$schema': '/schema.json',
-        'main_entry_personal_name': {
-            'personal_name': 'Donges, Jonathan F'
-        }
+        '__order__': ['main_entry_personal_name'],
+        'main_entry_personal_name': [
+            {
+                '__order__': ['personal_name'],
+                'personal_name': 'Donges, Jonathan F',
+            }
+        ],
     }]
 
     runner = CliRunner()

--- a/tests/test_contrib_to_marc21_utils.py
+++ b/tests/test_contrib_to_marc21_utils.py
@@ -35,8 +35,8 @@ def test_xslt_not_found():
 def test_xslt_dump():
     """Test xslt dump."""
     path = os.path.dirname(__file__)
-    with open("{0}/demo_marc21_to_dc.converted.xml".format(path)) as myfile:
-        expect = myfile.read().replace('\n', '')
+    with open('{0}/demo_marc21_to_dc.converted.xml'.format(path)) as myfile:
+        expect = myfile.read()
     data = list(load('{0}/demo_marc21_to_dc.xml'.format(path)))
     output = dumps(
         data,
@@ -52,7 +52,7 @@ def test_entry_points():
     ))[0].load()
     path = os.path.dirname(__file__)
     with open("{0}/demo_marc21_to_dc.converted.xml".format(path)) as myfile:
-        expect = myfile.read().replace('\n', '')
+        expect = myfile.read()
     data = list(load('{0}/demo_marc21_to_dc.xml'.format(path)))
     output = dump(data,
                   xslt_filename='{0}/demo_marc21_to_dc.xslt'.format(path))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,8 +9,9 @@
 
 """Test suite for DoJSON."""
 
-import json
+import os
 
+import simplejson as json
 from lxml import etree, objectify
 from six import BytesIO
 
@@ -214,7 +215,15 @@ def test_simple_record_from_xml():
 
     blob = create_record(RECORD_SIMPLE)
     data = marc21.do(blob)
-    expected = {'main_entry_personal_name': {'personal_name': 'Donges, Jonathan F'}}
+    expected = {
+        '__order__': ['main_entry_personal_name'],
+        'main_entry_personal_name': [
+            {
+                '__order__': ('personal_name',),
+                'personal_name': 'Donges, Jonathan F',
+            }
+        ],
+    }
 
     assert data == expected
 
@@ -374,6 +383,7 @@ def test_marc21_856_indicators():
             </datafield>
             ''',
             {
+                '__order__': ['electronic_location_and_access'],
                 'electronic_location_and_access': [
                     {
                         '__order__': ('file_size', 'uniform_resource_identifier', 'public_note', 'access_method'),
@@ -396,6 +406,7 @@ def test_marc21_856_indicators():
             </datafield>
             ''',
             {
+                '__order__': ['electronic_location_and_access'],
                 'electronic_location_and_access': [
                     {
                         '__order__': ('file_size', 'uniform_resource_identifier', 'public_note', 'access_method'),


### PR DESCRIPTION
- FIX Order of datafields with the same code is now kept.
- FIX Ordering of the subfields of bd76x78x and 70x75x are now kept.
- Improves demo_marc21_full.xml specification conformity.

Co-authored-by: Jiri Kuncar jiri.kuncar@cern.ch
Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
