### PR TITLE
dojson: bd1xx field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -14,7 +14,7 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('main_entry_personal_name', '^100[103_].')
+@marc21.over('main_entry_personal_name', '^100[013_]_')
 @utils.for_each_value
 @utils.filter_values
 def main_entry_personal_name(self, key, value):

--- a/dojson/contrib/to_marc21/fields/bd1xx.py
+++ b/dojson/contrib/to_marc21/fields/bd1xx.py
@@ -49,9 +49,6 @@ def reverse_main_entry_personal_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_personal_name_entry_element')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('personal_name'),
@@ -128,9 +125,6 @@ def reverse_main_entry_corporate_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_corporate_name_entry_element')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
@@ -206,9 +200,6 @@ def reverse_main_entry_meeting_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_meeting_name_entry_element')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
@@ -278,9 +269,6 @@ def reverse_main_entry_uniform_title(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in nonfiling_characters:
-        order.append('nonfiling_characters')
 
     return {
         '__order__': tuple(order) if len(order) else None,

--- a/tests/data/library_of_congress/bd1xx.xml
+++ b/tests/data/library_of_congress/bd1xx.xml
@@ -272,7 +272,6 @@
       <subfield code="a">Gyrowetz, Adalbert,</subfield>
       <subfield code="d">1763-1850.</subfield>
       <subfield code="t">Serenades,</subfield>
-      <subfield code="m">clarinets (2), horns (2), bassoon,</subfield>
       <subfield code="n">op. 3 (AndrÃ©)</subfield>
     </datafield>
   </record>
@@ -452,12 +451,12 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="100" ind1="1" ind2="0">
+    <datafield tag="100" ind1="1" ind2=" ">
       <subfield code="a">Gershkoff, Ira.</subfield>
     </datafield>
   </record>
   <record>
-    <datafield tag="100" ind1="2" ind2=" ">
+    <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">Krishna Moorthy, K.</subfield>
       <subfield code="q">(Krishma),</subfield>
       <subfield code="d">1927-</subfield>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'test_cds_marc21.xml',
     'handcrafted/bd01x09x.xml',
     'library_of_congress/bd01x09x.xml',
+    'library_of_congress/bd1xx.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd1xx fields. (closes #91)
- Reaches 100% test coverage for bd1xx fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
