### PR TITLE
dojson: bd25x28x field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -19,11 +19,33 @@ from ..model import marc21
 @utils.filter_values
 def abbreviated_title(self, key, value):
     """Abbreviated Title."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
+    }
+
     indicator_map2 = {
-        "#": "Abbreviated key title",
-        "0": "Other abbreviated title"}
+        '_': 'Abbreviated key title',
+        '0': 'Other abbreviated title',
+    }
+
+    field_map = {
+        'a': 'abbreviated_title',
+        'b': 'qualifying_information',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in indicator_map2:
+        order.append('type')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'abbreviated_title': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -43,25 +65,29 @@ def abbreviated_title(self, key, value):
 @utils.filter_values
 def key_title(self, key, value):
     """Key Title."""
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'a': 'key_title',
+        'b': 'qualifying_information',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'key_title': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
         'qualifying_information': value.get('b'),
         'linkage': value.get('6'),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
@@ -69,21 +95,41 @@ def key_title(self, key, value):
 @utils.filter_values
 def uniform_title(self, key, value):
     """Uniform Title."""
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map1 = {
-        "0": "Not printed or displayed",
-        "1": "Printed or displayed"}
-    indicator_map2 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+        '0': 'Not printed or displayed',
+        '1': 'Printed or displayed',
+    }
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        '0': 'authority_record_control_number_or_standard_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('uniform_title_printed_or_displayed')
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
@@ -115,29 +161,44 @@ def uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
 @marc21.over(
-    'translation_of_title_by_cataloging_agency', '^242[10_][_1032547698]')
+    'translation_of_title_by_cataloging_agency', '^242[10_][_0123456789]')
 @utils.for_each_value
 @utils.filter_values
 def translation_of_title_by_cataloging_agency(self, key, value):
     """Translation of Title by Cataloging Agency."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
+    }
+
+    field_map = {
+        'a': 'title',
+        'b': 'remainder_of_title',
+        'c': 'statement_of_responsibility_etc.',
+        'h': 'medium',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        'y': 'language_code_of_translated_title',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'statement_of_responsibility': value.get('c'),
         'remainder_of_title': value.get('b'),
@@ -154,7 +215,7 @@ def translation_of_title_by_cataloging_agency(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
@@ -162,11 +223,12 @@ def translation_of_title_by_cataloging_agency(self, key, value):
 @utils.filter_values
 def collective_uniform_title(self, key, value):
     """Collective Uniform Title."""
-    indicator_map1 = {
-        "0": "Not printed or displayed",
-        "1": "Printed or displayed",
-    }
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'Not printed or displayed',
+        '1': 'Printed or displayed',
+    }
 
     field_map = {
         'a': 'uniform_title',
@@ -190,12 +252,8 @@ def collective_uniform_title(self, key, value):
 
     if key[3] in indicator_map1:
         order.append('uniform_title_printed_or_displayed')
-
-    order.append('nonfiling_characters')
     if key[4] in valid_nonfiling_characters:
-        nonfiling_characters = key[4]
-    else:
-        nonfiling_characters = '_'
+        order.append('nonfiling_characters')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -227,7 +285,7 @@ def collective_uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': nonfiling_characters,
+        'nonfiling_characters': key[4],
     }
 
 
@@ -235,19 +293,13 @@ def collective_uniform_title(self, key, value):
 @utils.filter_values
 def title_statement(self, key, value):
     """Title Statement."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {
-        "0": "0",
-        "1": "1",
-        "2": "2",
-        "3": "3",
-        "4": "4",
-        "5": "5",
-        "6": "6",
-        "7": "7",
-        "8": "8",
-        "9": "9",
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
     }
+
     field_map = {
         '6': 'linkage',
         '8': 'field_link_and_sequence_number',
@@ -266,10 +318,11 @@ def title_statement(self, key, value):
     order = utils.map_order(field_map, value)
     if key[3] in indicator_map1:
         order.append('title_added_entry')
-    if key[4] in indicator_map2:
+    if key[4] in valid_nonfiling_characters:
         order.append('nonfiling_characters')
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'statement_of_responsibility': value.get('c'),
         'remainder_of_title': value.get('b'),
@@ -291,8 +344,7 @@ def title_statement(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
-        '__order__': tuple(order) if len(order) else None,
+        'nonfiling_characters': key[4],
     }
 
 
@@ -302,22 +354,49 @@ def title_statement(self, key, value):
 def varying_form_of_title(self, key, value):
     """Varying Form of Title."""
     indicator_map1 = {
-        "0": "Note, no added entry",
-        "1": "Note, added entry",
-        "2": "No note, no added entry",
-        "3": "No note, added entry"}
+        '0': 'Note, no added entry',
+        '1': 'Note, added entry',
+        '2': 'No note, no added entry',
+        '3': 'No note, added entry',
+    }
+
     indicator_map2 = {
-        "#": "No type specified",
-        "0": "Portion of title",
-        "1": "Parallel title",
-        "2": "Distinctive title",
-        "3": "Other title",
-        "4": "Cover title",
-        "5": "Added title page title",
-        "6": "Caption title",
-        "7": "Running title",
-        "8": "Spine title"}
+        '_': 'No type specified',
+        '0': 'Portion of title',
+        '1': 'Parallel title',
+        '2': 'Distinctive title',
+        '3': 'Other title',
+        '4': 'Cover title',
+        '5': 'Added title page title',
+        '6': 'Caption title',
+        '7': 'Running title',
+        '8': 'Spine title',
+    }
+
+    field_map = {
+        'a': 'title_proper_short_title',
+        'b': 'remainder_of_title',
+        'f': 'date_or_sequential_designation',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'i': 'display_text',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_added_entry_controller')
+
+    if key[4] in indicator_map2:
+        order.append('type_of_title')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title_proper_short_title': value.get('a'),
         'remainder_of_title': value.get('b'),
         'miscellaneous_information': value.get('g'),

--- a/dojson/contrib/marc21/fields/bd25x28x.py
+++ b/dojson/contrib/marc21/fields/bd25x28x.py
@@ -19,7 +19,18 @@ from ..model import marc21
 @utils.filter_values
 def edition_statement(self, key, value):
     """Edition Statement."""
+    field_map = {
+        'a': 'edition_statement',
+        'b': 'remainder_of_edition_statement',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'edition_statement': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -34,7 +45,16 @@ def edition_statement(self, key, value):
 @utils.filter_values
 def musical_presentation_statement(self, key, value):
     """Musical Presentation Statement."""
+    field_map = {
+        'a': 'musical_presentation_statement',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'musical_presentation_statement': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -48,7 +68,22 @@ def musical_presentation_statement(self, key, value):
 @utils.filter_values
 def cartographic_mathematical_data(self, key, value):
     """Cartographic Mathematical Data."""
+    field_map = {
+        'a': 'statement_of_scale',
+        'b': 'statement_of_projection',
+        'c': 'statement_of_coordinates',
+        'd': 'statement_of_zone',
+        'e': 'statement_of_equinox',
+        'f': 'outer_g_ring_coordinate_pairs',
+        'g': 'exclusion_g_ring_coordinate_pairs',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'statement_of_scale': value.get('a'),
         'statement_of_coordinates': value.get('c'),
         'statement_of_projection': value.get('b'),
@@ -67,7 +102,16 @@ def cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def computer_file_characteristics(self, key, value):
     """Computer File Characteristics."""
+    field_map = {
+        'a': 'computer_file_characteristics',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'computer_file_characteristics': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -81,7 +125,17 @@ def computer_file_characteristics(self, key, value):
 @utils.filter_values
 def country_of_producing_entity(self, key, value):
     """Country of Producing Entity."""
+    field_map = {
+        'a': 'country_of_producing_entity',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'country_of_producing_entity': utils.force_list(
             value.get('a')
         ),
@@ -98,7 +152,17 @@ def country_of_producing_entity(self, key, value):
 @utils.filter_values
 def philatelic_issue_data(self, key, value):
     """Philatelic Issue Data."""
+    field_map = {
+        'a': 'issuing_jurisdiction',
+        'b': 'denomination',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'issuing_jurisdiction': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -114,9 +178,9 @@ def philatelic_issue_data(self, key, value):
 def publication_distribution_imprint(self, key, value):
     """Publication, Distribution, etc. (Imprint)."""
     indicator_map1 = {
-        "#": "Not applicable/No information provided/Earliest available publisher",
-        "2": "Intervening publisher",
-        "3": "Current/latest publisher",
+        '_': 'Not applicable/No information provided/Earliest available publisher',
+        '2': 'Intervening publisher',
+        '3': 'Current/latest publisher',
     }
 
     field_map = {
@@ -169,7 +233,20 @@ def publication_distribution_imprint(self, key, value):
 @utils.filter_values
 def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
     """Imprint Statement for Films (Pre-AACR 1 Revised)."""
+    field_map = {
+        'a': 'producing_company',
+        'b': 'releasing_company',
+        'd': 'date_of_production_release',
+        'e': 'contractual_producer',
+        'f': 'place_of_production_release',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'producing_company': utils.force_list(
             value.get('a')
         ),
@@ -196,7 +273,20 @@ def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
 @utils.filter_values
 def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
     """Imprint Statement for Sound Recordings (Pre-AACR 1)."""
+    field_map = {
+        'a': 'place_of_production_release',
+        'b': 'publisher_or_trade_name',
+        'c': 'date_of_production_release',
+        'k': 'serial_identification',
+        'l': 'matrix_and_or_take_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'place_of_production_release': value.get('a'),
         'date_of_production_release': value.get('c'),
         'publisher_or_trade_name': value.get('b'),
@@ -213,7 +303,16 @@ def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
 @utils.filter_values
 def projected_publication_date(self, key, value):
     """Projected Publication Date."""
+    field_map = {
+        'a': 'projected_publication_date',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'projected_publication_date': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -230,16 +329,37 @@ def production_publication_distribution_manufacture_and_copyright_notice(
         self, key, value):
     """Production, Publication, Distribution, Manufacture, and Copyright Notice."""
     indicator_map1 = {
-        "#": "Not applicable/No information provided/Earliest",
-        "2": "Intervening",
-        "3": "Current/latest"}
+        '_': 'Not applicable/No information provided/Earliest',
+        '2': 'Intervening',
+        '3': 'Current/latest',
+    }
+
     indicator_map2 = {
-        "0": "Production",
-        "1": "Publication",
-        "2": "Distribution",
-        "3": "Manufacture",
-        "4": "Copyright notice date"}
+        '0': 'Production',
+        '1': 'Publication',
+        '2': 'Distribution',
+        '3': 'Manufacture',
+        '4': 'Copyright notice date',
+    }
+
+    field_map = {
+        'a': 'place_of_production_publication_distribution_manufacture',
+        'b': 'name_of_producer_publisher_distributor_manufacturer',
+        'c': 'date_of_production_publication_distribution_manufacture_or_copyright_notice',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('sequence_of_statements')
+    if key[4] in indicator_map2:
+        order.append('function_of_entity')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'place_of_production_publication_distribution_manufacture': utils.force_list(
             value.get('a')
         ),

--- a/dojson/contrib/to_marc21/fields/bd20x24x.py
+++ b/dojson/contrib/to_marc21/fields/bd20x24x.py
@@ -19,11 +19,28 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_abbreviated_title(self, key, value):
     """Reverse - Abbreviated Title."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
+    }
+
     indicator_map2 = {
-        "Abbreviated key title": "_",
-        "Other abbreviated title": "0"}
+        'Abbreviated key title': '_',
+        'Other abbreviated title': '0',
+    }
+
+    field_map = {
+        'abbreviated_title': 'a',
+        'qualifying_information': 'b',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('abbreviated_title'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -43,10 +60,19 @@ def reverse_abbreviated_title(self, key, value):
 @utils.filter_values
 def reverse_key_title(self, key, value):
     """Reverse - Key Title."""
-    indicator_map2 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'key_title': 'a',
+        'qualifying_information': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('key_title'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -54,7 +80,7 @@ def reverse_key_title(self, key, value):
         'b': value.get('qualifying_information'),
         '6': value.get('linkage'),
         '$ind1': '_',
-        '$ind2': indicator_map2.get(value.get('nonfiling_characters'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -62,11 +88,36 @@ def reverse_key_title(self, key, value):
 @utils.filter_values
 def reverse_uniform_title(self, key, value):
     """Reverse - Uniform Title."""
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map1 = {
-        "Not printed or displayed": "0",
-        "Printed or displayed": "1"}
-    indicator_map2 = {"Number of nonfiling characters": "8"}
+        'Not printed or displayed': '0',
+        'Printed or displayed': '1',
+    }
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'authority_record_control_number_or_standard_number': '0',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
         'p': utils.reverse_force_list(
             value.get('name_of_part_section_of_a_work')),
@@ -93,9 +144,7 @@ def reverse_uniform_title(self, key, value):
         '$ind1': indicator_map1.get(
             value.get('uniform_title_printed_or_displayed'),
             '_'),
-        '$ind2': indicator_map2.get(
-            value.get('nonfiling_characters'),
-            '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -104,11 +153,29 @@ def reverse_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_translation_of_title_by_cataloging_agency(self, key, value):
     """Reverse - Translation of Title by Cataloging Agency."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
-    indicator_map2 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
+    }
+
+    field_map = {
+        'title': 'a',
+        'remainder_of_title': 'b',
+        'statement_of_responsibility_etc.': 'c',
+        'medium': 'h',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'language_code_of_translated_title': 'y',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'c': value.get('statement_of_responsibility'),
         'b': value.get('remainder_of_title'),
@@ -125,7 +192,7 @@ def reverse_translation_of_title_by_cataloging_agency(self, key, value):
             value.get('field_link_and_sequence_number')
         ),
         '$ind1': indicator_map1.get(value.get('title_added_entry'), '_'),
-        '$ind2': indicator_map2.get(value.get('nonfiling_characters'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -133,11 +200,12 @@ def reverse_translation_of_title_by_cataloging_agency(self, key, value):
 @utils.filter_values
 def reverse_collective_uniform_title(self, key, value):
     """Reverse - Collective Uniform Title."""
-    indicator_map1 = {
-        "Not printed or displayed": "0",
-        "Printed or displayed": "1",
-    }
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'Not printed or displayed': '0',
+        'Printed or displayed': '1',
+    }
 
     field_map = {
         'uniform_title': 'a',
@@ -158,9 +226,6 @@ def reverse_collective_uniform_title(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('uniform_title_printed_or_displayed')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -188,7 +253,7 @@ def reverse_collective_uniform_title(self, key, value):
         '$ind1': indicator_map1.get(
             value.get('uniform_title_printed_or_displayed'),
             '_'),
-        '$ind2': value.get('nonfiling_characters', '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -196,19 +261,13 @@ def reverse_collective_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_title_statement(self, key, value):
     """Reverse - Title Statement."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
-    indicator_map2 = {
-        "0": "0",
-        "1": "1",
-        "2": "2",
-        "3": "3",
-        "4": "4",
-        "5": "5",
-        "6": "6",
-        "7": "7",
-        "8": "8",
-        "9": "9",
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
     }
+
     field_map = {
         'title': 'a',
         'remainder_of_title': 'b',
@@ -222,15 +281,12 @@ def reverse_title_statement(self, key, value):
         'version': 's',
         'linkage': '6',
         'field_link_and_sequence_number': '8',
-        'title_added_entry': None,
-        'nonfiling_characters': None
     }
 
-    ind1 = indicator_map1.get(value.get('title_added_entry'), '_')
-    ind2 = indicator_map2.get(value.get('nonfiling_characters'), '_')
     order = utils.map_order(field_map, value)
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'c': value.get('statement_of_responsibility'),
         'b': value.get('remainder_of_title'),
@@ -251,9 +307,8 @@ def reverse_title_statement(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': ind1,
-        '$ind2': ind2,
-        '__order__': tuple(order) if len(order) else None
+        '$ind1': indicator_map1.get(value.get('title_added_entry'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -263,22 +318,43 @@ def reverse_title_statement(self, key, value):
 def reverse_varying_form_of_title(self, key, value):
     """Reverse - Varying Form of Title."""
     indicator_map1 = {
-        "No note, added entry": "3",
-        "No note, no added entry": "2",
-        "Note, added entry": "1",
-        "Note, no added entry": "0"}
+        'Note, no added entry': '0',
+        'Note, added entry': '1',
+        'No note, no added entry': '2',
+        'No note, added entry': '3',
+    }
+
     indicator_map2 = {
-        "Added title page title": "5",
-        "Caption title": "6",
-        "Cover title": "4",
-        "Distinctive title": "2",
-        "No type specified": "_",
-        "Other title": "3",
-        "Parallel title": "1",
-        "Portion of title": "0",
-        "Running title": "7",
-        "Spine title": "8"}
+        'No type specified': '_',
+        'Portion of title': '0',
+        'Parallel title': '1',
+        'Distinctive title': '2',
+        'Other title': '3',
+        'Cover title': '4',
+        'Added title page title': '5',
+        'Caption title': '6',
+        'Running title': '7',
+        'Spine title': '8',
+    }
+
+    field_map = {
+        'title_proper_short_title': 'a',
+        'remainder_of_title': 'b',
+        'date_or_sequential_designation': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'display_text': 'i',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title_proper_short_title'),
         'b': value.get('remainder_of_title'),
         'g': value.get('miscellaneous_information'),
@@ -330,11 +406,6 @@ def reverse_former_title(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('title_added_entry')
-    if key[4] in indicator_map2:
-        order.append('note_controller')
 
     return {
         '__order__': tuple(order) if len(order) else None,

--- a/dojson/contrib/to_marc21/fields/bd25x28x.py
+++ b/dojson/contrib/to_marc21/fields/bd25x28x.py
@@ -19,7 +19,18 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_edition_statement(self, key, value):
     """Reverse - Edition Statement."""
+    field_map = {
+        'edition_statement': 'a',
+        'remainder_of_edition_statement': 'b',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('edition_statement'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -36,7 +47,16 @@ def reverse_edition_statement(self, key, value):
 @utils.filter_values
 def reverse_musical_presentation_statement(self, key, value):
     """Reverse - Musical Presentation Statement."""
+    field_map = {
+        'musical_presentation_statement': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('musical_presentation_statement'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -52,7 +72,22 @@ def reverse_musical_presentation_statement(self, key, value):
 @utils.filter_values
 def reverse_cartographic_mathematical_data(self, key, value):
     """Reverse - Cartographic Mathematical Data."""
+    field_map = {
+        'statement_of_scale': 'a',
+        'statement_of_projection': 'b',
+        'statement_of_coordinates': 'c',
+        'statement_of_zone': 'd',
+        'statement_of_equinox': 'e',
+        'outer_g_ring_coordinate_pairs': 'f',
+        'exclusion_g_ring_coordinate_pairs': 'g',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('statement_of_scale'),
         'c': value.get('statement_of_coordinates'),
         'b': value.get('statement_of_projection'),
@@ -73,7 +108,16 @@ def reverse_cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def reverse_computer_file_characteristics(self, key, value):
     """Reverse - Computer File Characteristics."""
+    field_map = {
+        'computer_file_characteristics': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('computer_file_characteristics'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -89,7 +133,17 @@ def reverse_computer_file_characteristics(self, key, value):
 @utils.filter_values
 def reverse_country_of_producing_entity(self, key, value):
     """Reverse - Country of Producing Entity."""
+    field_map = {
+        'country_of_producing_entity': 'a',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('country_of_producing_entity')
         ),
@@ -108,7 +162,17 @@ def reverse_country_of_producing_entity(self, key, value):
 @utils.filter_values
 def reverse_philatelic_issue_data(self, key, value):
     """Reverse - Philatelic Issue Data."""
+    field_map = {
+        'issuing_jurisdiction': 'a',
+        'denomination': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('issuing_jurisdiction'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -126,9 +190,9 @@ def reverse_philatelic_issue_data(self, key, value):
 def reverse_publication_distribution_imprint(self, key, value):
     """Reverse - Publication, Distribution, etc. (Imprint)."""
     indicator_map1 = {
-        "Current/latest publisher": "3",
-        "Intervening publisher": "2",
-        "Not applicable/No information provided/Earliest available publisher": "_",
+        'Not applicable/No information provided/Earliest available publisher': '_',
+        'Intervening publisher': '2',
+        'Current/latest publisher': '3',
     }
 
     field_map = {
@@ -144,9 +208,6 @@ def reverse_publication_distribution_imprint(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('sequence_of_publishing_statements')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -177,7 +238,20 @@ def reverse_publication_distribution_imprint(self, key, value):
 @utils.filter_values
 def reverse_imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
     """Reverse - Imprint Statement for Films (Pre-AACR 1 Revised)."""
+    field_map = {
+        'producing_company': 'a',
+        'releasing_company': 'b',
+        'date_of_production_release': 'd',
+        'contractual_producer': 'e',
+        'place_of_production_release': 'f',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('producing_company')
         ),
@@ -204,12 +278,22 @@ def reverse_imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
 
 @to_marc21.over('262', '^imprint_statement_for_sound_recordings_pre_aacr_1$')
 @utils.filter_values
-def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(
-        self,
-        key,
-        value):
+def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
     """Reverse - Imprint Statement for Sound Recordings (Pre-AACR 1)."""
+    field_map = {
+        'place_of_production_release': 'a',
+        'publisher_or_trade_name': 'b',
+        'date_of_production_release': 'c',
+        'serial_identification': 'k',
+        'matrix_and_or_take_number': 'l',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('place_of_production_release'),
         'c': value.get('date_of_production_release'),
         'b': value.get('publisher_or_trade_name'),
@@ -228,7 +312,16 @@ def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(
 @utils.filter_values
 def reverse_projected_publication_date(self, key, value):
     """Reverse - Projected Publication Date."""
+    field_map = {
+        'projected_publication_date': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('projected_publication_date'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -249,15 +342,32 @@ def reverse_production_publication_distribution_manufacture_and_copyright_notice
         key,
         value):
     """Reverse - Production, Publication, Distribution, Manufacture, and Copyright Notice."""
-    indicator_map1 = {"Current/latest": "3", "Intervening": "2",
-                      "Not applicable/No information provided/Earliest": "_"}
+    indicator_map1 = {
+        'Not applicable/No information provided/Earliest': '_',
+        'Intervening': '2',
+        'Current/latest': '3',
+    }
     indicator_map2 = {
-        "Copyright notice date": "4",
-        "Distribution": "2",
-        "Manufacture": "3",
-        "Production": "0",
-        "Publication": "1"}
+        'Production': '0',
+        'Publication': '1',
+        'Distribution': '2',
+        'Manufacture': '3',
+        'Copyright notice date': '4',
+    }
+
+    field_map = {
+        'place_of_production_publication_distribution_manufacture': 'a',
+        'name_of_producer_publisher_distributor_manufacturer': 'b',
+        'date_of_production_publication_distribution_manufacture_or_copyright_notice': 'c',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get(
                 'place_of_production_publication_distribution_manufacture')

--- a/tests/data/library_of_congress/bd20x24x.xml
+++ b/tests/data/library_of_congress/bd20x24x.xml
@@ -262,14 +262,7 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="240" ind1="1" ind2="0">
-      <subfield code="b">Kaffee-Kantate</subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="240" ind1="1" ind2="0">
-      <subfield code="t">Our town</subfield>
-    </datafield>
+    <datafield tag="240" ind1="1" ind2="0"/>
   </record>
   <record>
     <datafield tag="240" ind1="1" ind2="4">

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'handcrafted/bd01x09x.xml',
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
+    'library_of_congress/bd20x24x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
     'library_of_congress/bd20x24x.xml',
+    'library_of_congress/bd25x28x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd25x28x fields. (closes #93)
- Reaches 100% test coverage for bd25x28x fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
