### PR TITLE
dojson: bd3xx field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -19,11 +19,33 @@ from ..model import marc21
 @utils.filter_values
 def abbreviated_title(self, key, value):
     """Abbreviated Title."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
+    }
+
     indicator_map2 = {
-        "#": "Abbreviated key title",
-        "0": "Other abbreviated title"}
+        '_': 'Abbreviated key title',
+        '0': 'Other abbreviated title',
+    }
+
+    field_map = {
+        'a': 'abbreviated_title',
+        'b': 'qualifying_information',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in indicator_map2:
+        order.append('type')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'abbreviated_title': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -43,25 +65,29 @@ def abbreviated_title(self, key, value):
 @utils.filter_values
 def key_title(self, key, value):
     """Key Title."""
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'a': 'key_title',
+        'b': 'qualifying_information',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'key_title': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
         'qualifying_information': value.get('b'),
         'linkage': value.get('6'),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
@@ -69,21 +95,41 @@ def key_title(self, key, value):
 @utils.filter_values
 def uniform_title(self, key, value):
     """Uniform Title."""
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map1 = {
-        "0": "Not printed or displayed",
-        "1": "Printed or displayed"}
-    indicator_map2 = {
-        "0": "Number of nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+        '0': 'Not printed or displayed',
+        '1': 'Printed or displayed',
+    }
+
+    field_map = {
+        'a': 'uniform_title',
+        'd': 'date_of_treaty_signing',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'm': 'medium_of_performance_for_music',
+        'n': 'number_of_part_section_of_a_work',
+        'o': 'arranged_statement_for_music',
+        'p': 'name_of_part_section_of_a_work',
+        'r': 'key_for_music',
+        's': 'version',
+        '0': 'authority_record_control_number_or_standard_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('uniform_title_printed_or_displayed')
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
@@ -115,29 +161,44 @@ def uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
 @marc21.over(
-    'translation_of_title_by_cataloging_agency', '^242[10_][_1032547698]')
+    'translation_of_title_by_cataloging_agency', '^242[10_][_0123456789]')
 @utils.for_each_value
 @utils.filter_values
 def translation_of_title_by_cataloging_agency(self, key, value):
     """Translation of Title by Cataloging Agency."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {
-        "0": "No nonfiling characters",
-        "1": "Number of nonfiling characters",
-        "2": "Number of nonfiling characters",
-        "3": "Number of nonfiling characters",
-        "4": "Number of nonfiling characters",
-        "5": "Number of nonfiling characters",
-        "6": "Number of nonfiling characters",
-        "7": "Number of nonfiling characters",
-        "8": "Number of nonfiling characters",
-        "9": "Number of nonfiling characters"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
+    }
+
+    field_map = {
+        'a': 'title',
+        'b': 'remainder_of_title',
+        'c': 'statement_of_responsibility_etc.',
+        'h': 'medium',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        'y': 'language_code_of_translated_title',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('title_added_entry')
+    if key[4] in valid_nonfiling_characters:
+        order.append('nonfiling_characters')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'statement_of_responsibility': value.get('c'),
         'remainder_of_title': value.get('b'),
@@ -154,7 +215,7 @@ def translation_of_title_by_cataloging_agency(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
+        'nonfiling_characters': key[4],
     }
 
 
@@ -162,11 +223,12 @@ def translation_of_title_by_cataloging_agency(self, key, value):
 @utils.filter_values
 def collective_uniform_title(self, key, value):
     """Collective Uniform Title."""
-    indicator_map1 = {
-        "0": "Not printed or displayed",
-        "1": "Printed or displayed",
-    }
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'Not printed or displayed',
+        '1': 'Printed or displayed',
+    }
 
     field_map = {
         'a': 'uniform_title',
@@ -190,12 +252,8 @@ def collective_uniform_title(self, key, value):
 
     if key[3] in indicator_map1:
         order.append('uniform_title_printed_or_displayed')
-
-    order.append('nonfiling_characters')
     if key[4] in valid_nonfiling_characters:
-        nonfiling_characters = key[4]
-    else:
-        nonfiling_characters = '_'
+        order.append('nonfiling_characters')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -227,7 +285,7 @@ def collective_uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': nonfiling_characters,
+        'nonfiling_characters': key[4],
     }
 
 
@@ -235,19 +293,13 @@ def collective_uniform_title(self, key, value):
 @utils.filter_values
 def title_statement(self, key, value):
     """Title Statement."""
-    indicator_map1 = {"0": "No added entry", "1": "Added entry"}
-    indicator_map2 = {
-        "0": "0",
-        "1": "1",
-        "2": "2",
-        "3": "3",
-        "4": "4",
-        "5": "5",
-        "6": "6",
-        "7": "7",
-        "8": "8",
-        "9": "9",
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        '0': 'No added entry',
+        '1': 'Added entry',
     }
+
     field_map = {
         '6': 'linkage',
         '8': 'field_link_and_sequence_number',
@@ -266,10 +318,11 @@ def title_statement(self, key, value):
     order = utils.map_order(field_map, value)
     if key[3] in indicator_map1:
         order.append('title_added_entry')
-    if key[4] in indicator_map2:
+    if key[4] in valid_nonfiling_characters:
         order.append('nonfiling_characters')
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
         'statement_of_responsibility': value.get('c'),
         'remainder_of_title': value.get('b'),
@@ -291,8 +344,7 @@ def title_statement(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': indicator_map2.get(key[4]),
-        '__order__': tuple(order) if len(order) else None,
+        'nonfiling_characters': key[4],
     }
 
 
@@ -302,22 +354,49 @@ def title_statement(self, key, value):
 def varying_form_of_title(self, key, value):
     """Varying Form of Title."""
     indicator_map1 = {
-        "0": "Note, no added entry",
-        "1": "Note, added entry",
-        "2": "No note, no added entry",
-        "3": "No note, added entry"}
+        '0': 'Note, no added entry',
+        '1': 'Note, added entry',
+        '2': 'No note, no added entry',
+        '3': 'No note, added entry',
+    }
+
     indicator_map2 = {
-        "#": "No type specified",
-        "0": "Portion of title",
-        "1": "Parallel title",
-        "2": "Distinctive title",
-        "3": "Other title",
-        "4": "Cover title",
-        "5": "Added title page title",
-        "6": "Caption title",
-        "7": "Running title",
-        "8": "Spine title"}
+        '_': 'No type specified',
+        '0': 'Portion of title',
+        '1': 'Parallel title',
+        '2': 'Distinctive title',
+        '3': 'Other title',
+        '4': 'Cover title',
+        '5': 'Added title page title',
+        '6': 'Caption title',
+        '7': 'Running title',
+        '8': 'Spine title',
+    }
+
+    field_map = {
+        'a': 'title_proper_short_title',
+        'b': 'remainder_of_title',
+        'f': 'date_or_sequential_designation',
+        'g': 'miscellaneous_information',
+        'h': 'medium',
+        'i': 'display_text',
+        'n': 'number_of_part_section_of_a_work',
+        'p': 'name_of_part_section_of_a_work',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('note_added_entry_controller')
+
+    if key[4] in indicator_map2:
+        order.append('type_of_title')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'title_proper_short_title': value.get('a'),
         'remainder_of_title': value.get('b'),
         'miscellaneous_information': value.get('g'),

--- a/dojson/contrib/marc21/fields/bd25x28x.py
+++ b/dojson/contrib/marc21/fields/bd25x28x.py
@@ -19,7 +19,18 @@ from ..model import marc21
 @utils.filter_values
 def edition_statement(self, key, value):
     """Edition Statement."""
+    field_map = {
+        'a': 'edition_statement',
+        'b': 'remainder_of_edition_statement',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'edition_statement': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -34,7 +45,16 @@ def edition_statement(self, key, value):
 @utils.filter_values
 def musical_presentation_statement(self, key, value):
     """Musical Presentation Statement."""
+    field_map = {
+        'a': 'musical_presentation_statement',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'musical_presentation_statement': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -48,7 +68,22 @@ def musical_presentation_statement(self, key, value):
 @utils.filter_values
 def cartographic_mathematical_data(self, key, value):
     """Cartographic Mathematical Data."""
+    field_map = {
+        'a': 'statement_of_scale',
+        'b': 'statement_of_projection',
+        'c': 'statement_of_coordinates',
+        'd': 'statement_of_zone',
+        'e': 'statement_of_equinox',
+        'f': 'outer_g_ring_coordinate_pairs',
+        'g': 'exclusion_g_ring_coordinate_pairs',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'statement_of_scale': value.get('a'),
         'statement_of_coordinates': value.get('c'),
         'statement_of_projection': value.get('b'),
@@ -67,7 +102,16 @@ def cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def computer_file_characteristics(self, key, value):
     """Computer File Characteristics."""
+    field_map = {
+        'a': 'computer_file_characteristics',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'computer_file_characteristics': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -81,7 +125,17 @@ def computer_file_characteristics(self, key, value):
 @utils.filter_values
 def country_of_producing_entity(self, key, value):
     """Country of Producing Entity."""
+    field_map = {
+        'a': 'country_of_producing_entity',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'country_of_producing_entity': utils.force_list(
             value.get('a')
         ),
@@ -98,7 +152,17 @@ def country_of_producing_entity(self, key, value):
 @utils.filter_values
 def philatelic_issue_data(self, key, value):
     """Philatelic Issue Data."""
+    field_map = {
+        'a': 'issuing_jurisdiction',
+        'b': 'denomination',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'issuing_jurisdiction': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -114,9 +178,9 @@ def philatelic_issue_data(self, key, value):
 def publication_distribution_imprint(self, key, value):
     """Publication, Distribution, etc. (Imprint)."""
     indicator_map1 = {
-        "#": "Not applicable/No information provided/Earliest available publisher",
-        "2": "Intervening publisher",
-        "3": "Current/latest publisher",
+        '_': 'Not applicable/No information provided/Earliest available publisher',
+        '2': 'Intervening publisher',
+        '3': 'Current/latest publisher',
     }
 
     field_map = {
@@ -169,7 +233,20 @@ def publication_distribution_imprint(self, key, value):
 @utils.filter_values
 def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
     """Imprint Statement for Films (Pre-AACR 1 Revised)."""
+    field_map = {
+        'a': 'producing_company',
+        'b': 'releasing_company',
+        'd': 'date_of_production_release',
+        'e': 'contractual_producer',
+        'f': 'place_of_production_release',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'producing_company': utils.force_list(
             value.get('a')
         ),
@@ -196,7 +273,20 @@ def imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
 @utils.filter_values
 def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
     """Imprint Statement for Sound Recordings (Pre-AACR 1)."""
+    field_map = {
+        'a': 'place_of_production_release',
+        'b': 'publisher_or_trade_name',
+        'c': 'date_of_production_release',
+        'k': 'serial_identification',
+        'l': 'matrix_and_or_take_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'place_of_production_release': value.get('a'),
         'date_of_production_release': value.get('c'),
         'publisher_or_trade_name': value.get('b'),
@@ -213,7 +303,16 @@ def imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
 @utils.filter_values
 def projected_publication_date(self, key, value):
     """Projected Publication Date."""
+    field_map = {
+        'a': 'projected_publication_date',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'projected_publication_date': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -230,16 +329,37 @@ def production_publication_distribution_manufacture_and_copyright_notice(
         self, key, value):
     """Production, Publication, Distribution, Manufacture, and Copyright Notice."""
     indicator_map1 = {
-        "#": "Not applicable/No information provided/Earliest",
-        "2": "Intervening",
-        "3": "Current/latest"}
+        '_': 'Not applicable/No information provided/Earliest',
+        '2': 'Intervening',
+        '3': 'Current/latest',
+    }
+
     indicator_map2 = {
-        "0": "Production",
-        "1": "Publication",
-        "2": "Distribution",
-        "3": "Manufacture",
-        "4": "Copyright notice date"}
+        '0': 'Production',
+        '1': 'Publication',
+        '2': 'Distribution',
+        '3': 'Manufacture',
+        '4': 'Copyright notice date',
+    }
+
+    field_map = {
+        'a': 'place_of_production_publication_distribution_manufacture',
+        'b': 'name_of_producer_publisher_distributor_manufacturer',
+        'c': 'date_of_production_publication_distribution_manufacture_or_copyright_notice',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('sequence_of_statements')
+    if key[4] in indicator_map2:
+        order.append('function_of_entity')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'place_of_production_publication_distribution_manufacture': utils.force_list(
             value.get('a')
         ),

--- a/dojson/contrib/marc21/fields/bd3xx.py
+++ b/dojson/contrib/marc21/fields/bd3xx.py
@@ -14,7 +14,7 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('physical_description', '^300..')
+@marc21.over('physical_description', '^300__')
 @utils.for_each_value
 @utils.filter_values
 def physical_description(self, key, value):
@@ -38,16 +38,16 @@ def physical_description(self, key, value):
         'extent': utils.force_list(
             value.get('a')
         ),
+        'other_physical_details': value.get('b'),
         'dimensions': utils.force_list(
             value.get('c')
         ),
-        'other_physical_details': value.get('b'),
         'accompanying_material': value.get('e'),
-        'size_of_unit': utils.force_list(
-            value.get('g')
-        ),
         'type_of_unit': utils.force_list(
             value.get('f')
+        ),
+        'size_of_unit': utils.force_list(
+            value.get('g')
         ),
         'materials_specified': value.get('3'),
         'linkage': value.get('6'),
@@ -57,53 +57,89 @@ def physical_description(self, key, value):
     }
 
 
-@marc21.over('playing_time', '^306..')
+@marc21.over('playing_time', '^306__')
 @utils.filter_values
 def playing_time(self, key, value):
     """Playing Time."""
+    field_map = {
+        'a': 'playing_time',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'playing_time': utils.force_list(
             value.get('a')
         ),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('hours', '^307[8_].')
+@marc21.over('hours', '^307[8_]_')
 @utils.for_each_value
 @utils.filter_values
 def hours(self, key, value):
     """Hours, Etc.."""
-    indicator_map1 = {"#": "Hours", "8": "No display constant generated"}
+    indicator_map1 = {
+        '_': 'Hours',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'hours',
+        'b': 'additional_information',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'hours': value.get('a'),
+        'additional_information': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'additional_information': value.get('b'),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('current_publication_frequency', '^310..')
+@marc21.over('current_publication_frequency', '^310__')
 @utils.filter_values
 def current_publication_frequency(self, key, value):
     """Current Publication Frequency."""
+    field_map = {
+        'a': 'current_publication_frequency',
+        'b': 'date_of_current_publication_frequency',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'current_publication_frequency': value.get('a'),
+        'date_of_current_publication_frequency': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'date_of_current_publication_frequency': value.get('b'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('former_publication_frequency', '^321..')
+@marc21.over('former_publication_frequency', '^321__')
 @utils.for_each_value
 @utils.filter_values
 def former_publication_frequency(self, key, value):
@@ -120,28 +156,42 @@ def former_publication_frequency(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'former_publication_frequency': value.get('a'),
+        'dates_of_former_publication_frequency': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'dates_of_former_publication_frequency': value.get('b'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('content_type', '^336..')
+@marc21.over('content_type', '^336__')
 @utils.for_each_value
 @utils.filter_values
 def content_type(self, key, value):
     """Content Type."""
+    field_map = {
+        'a': 'content_type_term',
+        'b': 'content_type_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'content_type_term': utils.force_list(
             value.get('a')
         ),
         'content_type_code': utils.force_list(
             value.get('b')
         ),
-        'materials_specified': value.get('3'),
+        'authority_record_control_number_or_standard_number': utils.force_list(value.get('0')),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -149,7 +199,7 @@ def content_type(self, key, value):
     }
 
 
-@marc21.over('media_type', '^337..')
+@marc21.over('media_type', '^337__')
 @utils.for_each_value
 @utils.filter_values
 def media_type(self, key, value):
@@ -177,8 +227,8 @@ def media_type(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -186,7 +236,7 @@ def media_type(self, key, value):
     }
 
 
-@marc21.over('carrier_type', '^338..')
+@marc21.over('carrier_type', '^338__')
 @utils.for_each_value
 @utils.filter_values
 def carrier_type(self, key, value):
@@ -214,8 +264,8 @@ def carrier_type(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -223,56 +273,80 @@ def carrier_type(self, key, value):
     }
 
 
-@marc21.over('physical_medium', '^340..')
+@marc21.over('physical_medium', '^340__')
 @utils.for_each_value
 @utils.filter_values
 def physical_medium(self, key, value):
     """Physical Medium."""
+    field_map = {
+        'a': 'material_base_and_configuration',
+        'b': 'dimensions',
+        'c': 'materials_applied_to_surface',
+        'd': 'information_recording_technique',
+        'e': 'support',
+        'f': 'production_rate_ratio',
+        'h': 'location_within_medium',
+        'i': 'technical_specifications_of_medium',
+        'j': 'generation',
+        'k': 'layout',
+        'm': 'book_format',
+        'n': 'font_size',
+        'o': 'polarity',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'material_base_and_configuration': utils.force_list(
             value.get('a')
+        ),
+        'dimensions': utils.force_list(
+            value.get('b'),
         ),
         'materials_applied_to_surface': utils.force_list(
             value.get('c')
         ),
-        'dimensions': utils.force_list(
-            value.get('b')
+        'information_recording_technique': utils.force_list(
+            value.get('d')
         ),
         'support': utils.force_list(
             value.get('e')
         ),
-        'information_recording_technique': utils.force_list(
-            value.get('d')
-        ),
         'production_rate_ratio': utils.force_list(
             value.get('f')
-        ),
-        'technical_specifications_of_medium': utils.force_list(
-            value.get('i')
         ),
         'location_within_medium': utils.force_list(
             value.get('h')
         ),
-        'layout': utils.force_list(
-            value.get('k')
+        'technical_specifications_of_medium': utils.force_list(
+            value.get('i')
         ),
         'generation': utils.force_list(
             value.get('j')
         ),
+        'layout': utils.force_list(
+            value.get('k')
+        ),
         'book_format': utils.force_list(
             value.get('m')
-        ),
-        'polarity': utils.force_list(
-            value.get('o')
         ),
         'font_size': utils.force_list(
             value.get('n')
         ),
+        'polarity': utils.force_list(
+            value.get('o')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -280,77 +354,135 @@ def physical_medium(self, key, value):
     }
 
 
-@marc21.over('geospatial_reference_data', '^342[10_][_103254768]')
+@marc21.over('geospatial_reference_data', '^342[_01][_012345678]')
 @utils.for_each_value
 @utils.filter_values
 def geospatial_reference_data(self, key, value):
     """Geospatial Reference Data."""
     indicator_map1 = {
-        "0": "Horizontal coordinate system",
-        "1": "Vertical coordinate system"}
+        '0': 'Horizontal coordinate system',
+        '1': 'Vertical coordinate system',
+    }
+
     indicator_map2 = {
-        "0": "Geographic",
-        "1": "Map projection",
-        "2": "Grid coordinate system",
-        "3": "Local planar",
-        "4": "Local",
-        "5": "Geodetic model",
-        "6": "Altitude",
-        "7": "Method specified in $2",
-        "8": "Depth"}
+        '0': 'Geographic',
+        '1': 'Map projection',
+        '2': 'Grid coordinate system',
+        '3': 'Local planar',
+        '4': 'Local',
+        '5': 'Geodetic model',
+        '6': 'Altitude',
+        '7': 'Method specified in $2',
+        '8': 'Depth',
+    }
+
+    field_map = {
+        'a': 'name',
+        'b': 'coordinate_units_or_distance_units',
+        'c': 'latitude_resolution',
+        'd': 'longitude_resolution',
+        'e': 'standard_parallel_or_oblique_line_latitude',
+        'f': 'oblique_line_longitude',
+        'g': 'longitude_of_central_meridian_or_projection_center',
+        'h': 'latitude_of_projection_center_or_projection_origin',
+        'i': 'false_easting',
+        'j': 'false_northing',
+        'k': 'scale_factor',
+        'l': 'height_of_perspective_point_above_surface',
+        'm': 'azimuthal_angle',
+        'n': 'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole',
+        'o': 'landsat_number_and_path_number',
+        'p': 'zone_identifier',
+        'q': 'ellipsoid_name',
+        'r': 'semi_major_axis',
+        's': 'denominator_of_flattening_ratio',
+        't': 'vertical_resolution',
+        'u': 'vertical_encoding_method',
+        'v': 'local_planar_local_or_other_projection_or_grid_description',
+        'w': 'local_planar_or_local_georeference_information',
+        '2': 'reference_method_used',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('geospatial_reference_dimension')
+    if key[4] in indicator_map2:
+        order.append('geospatial_reference_method')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
+        'name': value.get('a'),
+        'coordinate_units_or_distance_units': value.get('b'),
+        'latitude_resolution': value.get('c'),
+        'longitude_resolution': value.get('d'),
+        'standard_parallel_or_oblique_line_latitude': utils.force_list(
+            value.get('e')
+        ),
+        'oblique_line_longitude': utils.force_list(
+            value.get('f')
+        ),
+        'longitude_of_central_meridian_or_projection_center': value.get('g'),
+        'latitude_of_projection_center_or_projection_origin': value.get('h'),
+        'false_easting': value.get('i'),
+        'false_northing': value.get('j'),
+        'scale_factor': value.get('k'),
+        'height_of_perspective_point_above_surface': value.get('l'),
+        'azimuthal_angle': value.get('m'),
+        'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': value.get('n'),
+        'landsat_number_and_path_number': value.get('o'),
+        'zone_identifier': value.get('p'),
+        'ellipsoid_name': value.get('q'),
+        'semi_major_axis': value.get('r'),
+        'denominator_of_flattening_ratio': value.get('s'),
+        'vertical_resolution': value.get('t'),
+        'vertical_encoding_method': value.get('u'),
+        'local_planar_local_or_other_projection_or_grid_description': value.get('v'),
+        'local_planar_or_local_georeference_information': value.get('w'),
         'reference_method_used': value.get('2'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'name': value.get('a'),
-        'latitude_resolution': value.get('c'),
-        'coordinate_units_or_distance_units': value.get('b'),
-        'standard_parallel_or_oblique_line_latitude': utils.force_list(
-            value.get('e')
-        ),
-        'longitude_resolution': value.get('d'),
-        'longitude_of_central_meridian_or_projection_center': value.get('g'),
-        'oblique_line_longitude': utils.force_list(
-            value.get('f')
-        ),
-        'false_easting': value.get('i'),
-        'latitude_of_projection_center_or_projection_origin': value.get('h'),
-        'scale_factor': value.get('k'),
-        'false_northing': value.get('j'),
-        'azimuthal_angle': value.get('m'),
-        'height_of_perspective_point_above_surface': value.get('l'),
-        'landsat_number_and_path_number': value.get('o'),
-        'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': value.get('n'),
-        'ellipsoid_name': value.get('q'),
-        'zone_identifier': value.get('p'),
-        'denominator_of_flattening_ratio': value.get('s'),
-        'semi_major_axis': value.get('r'),
-        'vertical_encoding_method': value.get('u'),
-        'vertical_resolution': value.get('t'),
-        'local_planar_or_local_georeference_information': value.get('w'),
-        'local_planar_local_or_other_projection_or_grid_description': value.get('v'),
         'geospatial_reference_dimension': indicator_map1.get(key[3]),
         'geospatial_reference_method': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('planar_coordinate_data', '^343..')
+@marc21.over('planar_coordinate_data', '^343__')
 @utils.for_each_value
 @utils.filter_values
 def planar_coordinate_data(self, key, value):
     """Planar Coordinate Data."""
+    field_map = {
+        'a': 'planar_coordinate_encoding_method',
+        'b': 'planar_distance_units',
+        'c': 'abscissa_resolution',
+        'd': 'ordinate_resolution',
+        'e': 'distance_resolution',
+        'f': 'bearing_resolution',
+        'g': 'bearing_units',
+        'h': 'bearing_reference_direction',
+        'i': 'bearing_reference_meridian',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'planar_coordinate_encoding_method': value.get('a'),
-        'abscissa_resolution': value.get('c'),
         'planar_distance_units': value.get('b'),
-        'distance_resolution': value.get('e'),
+        'abscissa_resolution': value.get('c'),
         'ordinate_resolution': value.get('d'),
-        'bearing_units': value.get('g'),
+        'distance_resolution': value.get('e'),
         'bearing_resolution': value.get('f'),
-        'bearing_reference_meridian': value.get('i'),
+        'bearing_units': value.get('g'),
         'bearing_reference_direction': value.get('h'),
+        'bearing_reference_meridian': value.get('i'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -358,7 +490,7 @@ def planar_coordinate_data(self, key, value):
     }
 
 
-@marc21.over('sound_characteristics', '^344..')
+@marc21.over('sound_characteristics', '^344__')
 @utils.for_each_value
 @utils.filter_values
 def sound_characteristics(self, key, value):
@@ -386,23 +518,23 @@ def sound_characteristics(self, key, value):
         'type_of_recording': utils.force_list(
             value.get('a')
         ),
-        'playing_speed': utils.force_list(
-            value.get('c')
-        ),
         'recording_medium': utils.force_list(
             value.get('b')
         ),
-        'track_configuration': utils.force_list(
-            value.get('e')
+        'playing_speed': utils.force_list(
+            value.get('c')
         ),
         'groove_characteristic': utils.force_list(
             value.get('d')
         ),
-        'configuration_of_playback_channels': utils.force_list(
-            value.get('g')
+        'track_configuration': utils.force_list(
+            value.get('e')
         ),
         'tape_configuration': utils.force_list(
             value.get('f')
+        ),
+        'configuration_of_playback_channels': utils.force_list(
+            value.get('g')
         ),
         'special_playback_characteristics': utils.force_list(
             value.get('h')
@@ -410,8 +542,8 @@ def sound_characteristics(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -419,12 +551,25 @@ def sound_characteristics(self, key, value):
     }
 
 
-@marc21.over('projection_characteristics_of_moving_image', '^345..')
+@marc21.over('projection_characteristics_of_moving_image', '^345__')
 @utils.for_each_value
 @utils.filter_values
 def projection_characteristics_of_moving_image(self, key, value):
     """Projection Characteristics of Moving Image."""
+    field_map = {
+        'a': 'presentation_format',
+        'b': 'projection_speed',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'presentation_format': utils.force_list(
             value.get('a')
         ),
@@ -434,8 +579,8 @@ def projection_characteristics_of_moving_image(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -443,12 +588,25 @@ def projection_characteristics_of_moving_image(self, key, value):
     }
 
 
-@marc21.over('video_characteristics', '^346..')
+@marc21.over('video_characteristics', '^346__')
 @utils.for_each_value
 @utils.filter_values
 def video_characteristics(self, key, value):
     """Video Characteristics."""
+    field_map = {
+        'a': 'video_format',
+        'b': 'broadcast_standard',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'video_format': utils.force_list(
             value.get('a')
         ),
@@ -458,8 +616,8 @@ def video_characteristics(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -467,39 +625,83 @@ def video_characteristics(self, key, value):
     }
 
 
-@marc21.over('digital_file_characteristics', '^347..')
+@marc21.over('digital_file_characteristics', '^347__')
 @utils.for_each_value
 @utils.filter_values
 def digital_file_characteristics(self, key, value):
     """Digital File Characteristics."""
+    field_map = {
+        'a': 'file_type',
+        'b': 'encoding_format',
+        'c': 'file_size',
+        'd': 'resolution',
+        'e': 'regional_encoding',
+        'f': 'encoded_bitrate',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'file_type': utils.force_list(
             value.get('a')
-        ),
-        'file_size': utils.force_list(
-            value.get('c')
         ),
         'encoding_format': utils.force_list(
             value.get('b')
         ),
-        'regional_encoding': utils.force_list(
-            value.get('e')
+        'file_size': utils.force_list(
+            value.get('c')
         ),
         'resolution': utils.force_list(
             value.get('d')
         ),
-        'transmission_speed': utils.force_list(
-            value.get('f')
+        'regional_encoding': utils.force_list(
+            value.get('e')
         ),
+        'encoded_bitrate': utils.force_list(value.get('f')),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
+    }
+
+
+@marc21.over('format_of_notated_music', '^348__')
+@utils.for_each_value
+@utils.filter_values
+def reverse_digital_file_characteristics(self, key, value):
+    """Reverse - Digital File Characteristics."""
+    field_map = {
+        'a': 'format_of_notated_music_term',
+        'b': 'format_of_notated_music_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'format_of_notated_music_term': utils.force_list(value.get('a')),
+        'format_of_notated_music_code': utils.force_list(value.get('b')),
+        'authority_record_control_number_or_standard_number': utils.force_list(value.get('0')),
+        'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
     }
 
 
@@ -524,10 +726,10 @@ def organization_and_arrangement_of_materials(self, key, value):
         'organization': utils.force_list(
             value.get('a')
         ),
-        'hierarchical_level': value.get('c'),
         'arrangement': utils.force_list(
             value.get('b')
         ),
+        'hierarchical_level': value.get('c'),
         'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
@@ -541,18 +743,35 @@ def organization_and_arrangement_of_materials(self, key, value):
 @utils.filter_values
 def digital_graphic_representation(self, key, value):
     """Digital Graphic Representation."""
+    field_map = {
+        'a': 'direct_reference_method',
+        'b': 'object_type',
+        'c': 'object_count',
+        'd': 'row_count',
+        'e': 'column_count',
+        'f': 'vertical_count',
+        'g': 'vpf_topology_level',
+        'i': 'indirect_reference_description',
+        'q': 'format_of_the_digital_image',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'direct_reference_method': value.get('a'),
-        'object_count': utils.force_list(
-            value.get('c')
-        ),
         'object_type': utils.force_list(
             value.get('b')
         ),
-        'column_count': value.get('e'),
+        'object_count': utils.force_list(
+            value.get('c')
+        ),
         'row_count': value.get('d'),
-        'vpf_topology_level': value.get('g'),
+        'column_count': value.get('e'),
         'vertical_count': value.get('f'),
+        'vpf_topology_level': value.get('g'),
         'indirect_reference_description': value.get('i'),
         'format_of_the_digital_image': value.get('q'),
         'linkage': value.get('6'),
@@ -562,31 +781,53 @@ def digital_graphic_representation(self, key, value):
     }
 
 
-@marc21.over('security_classification_control', '^355[1032548_].')
+@marc21.over('security_classification_control', '^355[_0123458]_')
 @utils.for_each_value
 @utils.filter_values
 def security_classification_control(self, key, value):
     """Security Classification Control."""
     indicator_map1 = {
-        "0": "Document",
-        "1": "Title",
-        "2": "Abstract",
-        "3": "Contents note",
-        "4": "Author",
-        "5": "Record",
-        "8": "None of the above"}
+        '0': 'Document',
+        '1': 'Title',
+        '2': 'Abstract',
+        '3': 'Contents note',
+        '4': 'Author',
+        '5': 'Record',
+        '8': 'None of the above',
+    }
+
+    field_map = {
+        'a': 'security_classification',
+        'b': 'handling_instructions',
+        'c': 'external_dissemination_information',
+        'd': 'downgrading_or_declassification_event',
+        'e': 'classification_system',
+        'f': 'country_of_origin_code',
+        'g': 'downgrading_date',
+        'h': 'declassification_date',
+        'j': 'authorization',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('controlled_element')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'security_classification': value.get('a'),
-        'external_dissemination_information': utils.force_list(
-            value.get('c')
-        ),
         'handling_instructions': utils.force_list(
             value.get('b')
         ),
-        'classification_system': value.get('e'),
+        'external_dissemination_information': utils.force_list(
+            value.get('c')
+        ),
         'downgrading_or_declassification_event': value.get('d'),
-        'downgrading_date': value.get('g'),
+        'classification_system': value.get('e'),
         'country_of_origin_code': value.get('f'),
+        'downgrading_date': value.get('g'),
         'declassification_date': value.get('h'),
         'authorization': utils.force_list(
             value.get('j')
@@ -599,17 +840,29 @@ def security_classification_control(self, key, value):
     }
 
 
-@marc21.over('originator_dissemination_control', '^357..')
+@marc21.over('originator_dissemination_control', '^357__')
 @utils.filter_values
 def originator_dissemination_control(self, key, value):
     """Originator Dissemination Control."""
+    field_map = {
+        'a': 'originator_control_term',
+        'b': 'originating_agency',
+        'c': 'authorized_recipients_of_material',
+        'g': 'other_restrictions',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'originator_control_term': value.get('a'),
-        'authorized_recipients_of_material': utils.force_list(
-            value.get('c')
-        ),
         'originating_agency': utils.force_list(
             value.get('b')
+        ),
+        'authorized_recipients_of_material': utils.force_list(
+            value.get('c')
         ),
         'other_restrictions': utils.force_list(
             value.get('g')
@@ -622,79 +875,153 @@ def originator_dissemination_control(self, key, value):
 
 
 @marc21.over(
-    'dates_of_publication_and_or_sequential_designation', '^362[10_].')
+    'dates_of_publication_and_or_sequential_designation', '^362[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def dates_of_publication_and_or_sequential_designation(self, key, value):
     """Dates of Publication and/or Sequential Designation."""
-    indicator_map1 = {"0": "Formatted style", "1": "Unformatted note"}
+    indicator_map1 = {
+        '0': 'Formatted style',
+        '1': 'Unformatted note',
+    }
+
+    field_map = {
+        'a': 'dates_of_publication_and_or_sequential_designation',
+        'z': 'source_of_information',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('format_of_date')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'dates_of_publication_and_or_sequential_designation': value.get('a'),
+        'source_of_information': value.get('z'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'source_of_information': value.get('z'),
-        'linkage': value.get('6'),
         'format_of_date': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('normalized_date_and_sequential_designation', '^363[10_][10_]')
+@marc21.over('normalized_date_and_sequential_designation', '^363[_01][_01]')
 @utils.for_each_value
 @utils.filter_values
 def normalized_date_and_sequential_designation(self, key, value):
     """Normalized Date and Sequential Designation."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Starting information",
-        "1": "Ending information"}
-    indicator_map2 = {"#": "Not specified", "0": "Closed", "1": "Open"}
+        '_': 'No information provided',
+        '0': 'Starting information',
+        '1': 'Ending information',
+    }
+    indicator_map2 = {
+        '_': 'Not specified',
+        '0': 'Closed',
+        '1': 'Open',
+    }
+
+    field_map = {
+        'a': 'first_level_of_enumeration',
+        'b': 'second_level_of_enumeration',
+        'c': 'third_level_of_enumeration',
+        'd': 'fourth_level_of_enumeration',
+        'e': 'fifth_level_of_enumeration',
+        'f': 'sixth_level_of_enumeration',
+        'g': 'alternative_numbering_scheme_first_level_of',
+        'h': 'alternative_numbering_scheme_second_level_of',
+        'i': 'first_level_of_chronology',
+        'j': 'second_level_of_chronology',
+        'k': 'third_level_of_chronology',
+        'l': 'fourth_level_of_chronology',
+        'm': 'alternative_numbering_scheme_chronology',
+        'u': 'first_level_textual_designation',
+        'v': 'first_level_of_chronology_issuance',
+        'x': 'nonpublic_note',
+        'z': 'public_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('start_end_designator')
+    if key[4] in indicator_map2:
+        order.append('state_of_issuance')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'first_level_of_enumeration': value.get('a'),
+        'second_level_of_enumeration': value.get('b'),
+        'third_level_of_enumeration': value.get('c'),
+        'fourth_level_of_enumeration': value.get('d'),
+        'fifth_level_of_enumeration': value.get('e'),
+        'sixth_level_of_enumeration': value.get('f'),
+        'alternative_numbering_scheme_first_level_of_enumeration': value.get('g'),
+        'alternative_numbering_scheme_second_level_of_enumeration': value.get('h'),
+        'first_level_of_chronology': value.get('i'),
+        'second_level_of_chronology': value.get('j'),
+        'third_level_of_chronology': value.get('k'),
+        'fourth_level_of_chronology': value.get('l'),
+        'alternative_numbering_scheme_chronology': value.get('m'),
+        'first_level_textual_designation': value.get('u'),
+        'first_level_of_chronology_issuance': value.get('v'),
         'nonpublic_note': utils.force_list(
             value.get('x')
         ),
-        'third_level_of_enumeration': value.get('c'),
-        'second_level_of_enumeration': value.get('b'),
-        'fifth_level_of_enumeration': value.get('e'),
-        'fourth_level_of_enumeration': value.get('d'),
-        'alternative_numbering_scheme_first_level_of_enumeration': value.get('g'),
-        'sixth_level_of_enumeration': value.get('f'),
-        'first_level_of_chronology': value.get('i'),
-        'alternative_numbering_scheme_second_level_of_enumeration': value.get('h'),
-        'third_level_of_chronology': value.get('k'),
-        'second_level_of_chronology': value.get('j'),
-        'alternative_numbering_scheme_chronology': value.get('m'),
-        'fourth_level_of_chronology': value.get('l'),
-        'first_level_textual_designation': value.get('u'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': value.get('8'),
         'public_note': utils.force_list(
             value.get('z')
         ),
-        'first_level_of_chronology_issuance': value.get('v'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': value.get('8'),
         'start_end_designator': indicator_map1.get(key[3]),
         'state_of_issuance': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('trade_price', '^365..')
+@marc21.over('trade_price', '^365__')
 @utils.for_each_value
 @utils.filter_values
 def trade_price(self, key, value):
     """Trade Price."""
+    field_map = {
+        'a': 'price_type_code',
+        'b': 'price_amount',
+        'c': 'currency_code',
+        'd': 'unit_of_pricing',
+        'e': 'price_note',
+        'f': 'price_effective_from',
+        'g': 'price_effective_until',
+        'h': 'tax_rate_1',
+        'i': 'tax_rate_2',
+        'j': 'iso_country_code',
+        'k': 'marc_country_code',
+        'm': 'identification_of_pricing_entity',
+        '2': 'source_of_price_type_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'price_type_code': value.get('a'),
-        'currency_code': value.get('c'),
         'price_amount': value.get('b'),
-        'price_note': value.get('e'),
+        'currency_code': value.get('c'),
         'unit_of_pricing': value.get('d'),
-        'price_effective_until': value.get('g'),
+        'price_note': value.get('e'),
         'price_effective_from': value.get('f'),
-        'tax_rate_2': value.get('i'),
+        'price_effective_until': value.get('g'),
         'tax_rate_1': value.get('h'),
-        'marc_country_code': value.get('k'),
+        'tax_rate_2': value.get('i'),
         'iso_country_code': value.get('j'),
+        'marc_country_code': value.get('k'),
         'identification_of_pricing_entity': value.get('m'),
         'source_of_price_type_code': value.get('2'),
         'linkage': value.get('6'),
@@ -704,21 +1031,40 @@ def trade_price(self, key, value):
     }
 
 
-@marc21.over('trade_availability_information', '^366..')
+@marc21.over('trade_availability_information', '^366__')
 @utils.for_each_value
 @utils.filter_values
 def trade_availability_information(self, key, value):
     """Trade Availability Information."""
+    field_map = {
+        'a': 'publishers_compressed_title_identification',
+        'b': 'detailed_date_of_publication',
+        'c': 'availability_status_code',
+        'd': 'expected_next_availability_date',
+        'e': 'note',
+        'f': 'publishers_discount_category',
+        'g': 'date_made_out_of_print',
+        'j': 'iso_country_code',
+        'k': 'marc_country_code',
+        'm': 'identification_of_agency',
+        '2': 'source_of_availability_status_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'publishers_compressed_title_identification': value.get('a'),
-        'availability_status_code': value.get('c'),
         'detailed_date_of_publication': value.get('b'),
-        'note': value.get('e'),
+        'availability_status_code': value.get('c'),
         'expected_next_availability_date': value.get('d'),
-        'date_made_out_of_print': value.get('g'),
+        'note': value.get('e'),
         'publisher_s_discount_category': value.get('f'),
-        'marc_country_code': value.get('k'),
+        'date_made_out_of_print': value.get('g'),
         'iso_country_code': value.get('j'),
+        'marc_country_code': value.get('k'),
         'identification_of_agency': value.get('m'),
         'source_of_availability_status_code': value.get('2'),
         'linkage': value.get('6'),
@@ -728,27 +1074,89 @@ def trade_availability_information(self, key, value):
     }
 
 
-@marc21.over('associated_language', '^377..')
+@marc21.over('associated_place', '^370__')
+@utils.for_each_value
+@utils.filter_values
+def associated_place(self, key, value):
+    field_map = {
+        'c': 'associated_country',
+        'f': 'other_associated_place',
+        'g': 'place_of_origin_of_work',
+        's': 'start_period',
+        't': 'end_period',
+        'u': 'uniform_resource_identifier',
+        'v': 'source_of_information',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'associated_country': utils.force_list(value.get('c')),
+        'other_associated_place': utils.force_list(value.get('f')),
+        'place_of_origin_of_work': utils.force_list(value.get('g')),
+        'start_period': value.get('s'),
+        'end_period': value.get('t'),
+        'uniform_resource_identifier': utils.force_list(value.get('u')),
+        'source_of_information': utils.force_list(value.get('v')),
+        'authority_record_control_number_or_standard_number': utils.force_list(value.get('0')),
+        'source_of_term': value.get('2'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
+    }
+
+
+@marc21.over('associated_language', '^377_[_7]')
 @utils.for_each_value
 @utils.filter_values
 def associated_language(self, key, value):
     """Associated Language."""
+    indicator_map2 = {
+        '_': 'MARC language code',
+        '7': 'Source specified in subfield $2',
+    }
+
+    field_map = {
+        'a': 'language_code',
+        'l': 'language_term',
+        '2': 'source',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[4] in indicator_map2:
+        order.append('source_of_code')
+
+    if key[4] != '7':
+        try:
+            order.remove('source')
+        except ValueError:
+            pass
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'language_code': utils.force_list(
             value.get('a')
         ),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'source': value.get('2'),
         'language_term': utils.force_list(
             value.get('l')
         ),
+        'source': value.get('2'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
+        'source_of_code': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('form_of_work', '^380..')
+@marc21.over('form_of_work', '^380__')
 @utils.for_each_value
 @utils.filter_values
 def form_of_work(self, key, value):
@@ -772,23 +1180,39 @@ def form_of_work(self, key, value):
             value.get('0')
         ),
         'source_of_term': value.get('2'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
 @marc21.over(
-    'other_distinguishing_characteristics_of_work_or_expression', '^381..')
+    'other_distinguishing_characteristics_of_work_or_expression', '^381__')
 @utils.for_each_value
 @utils.filter_values
 def other_distinguishing_characteristics_of_work_or_expression(
         self, key, value):
     """Other Distinguishing Characteristics of Work or Expression."""
+    field_map = {
+        'a': 'other_distinguishing_characteristic',
+        'u': 'uniform_resource_identifier',
+        'v': 'source_of_information',
+        '0': 'record_control_number',
+        '2': 'source_of_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'other_distinguishing_characteristic': utils.force_list(
             value.get('a')
+        ),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
         'source_of_information': utils.force_list(
             value.get('v')
@@ -797,9 +1221,6 @@ def other_distinguishing_characteristics_of_work_or_expression(
             value.get('0')
         ),
         'source_of_term': value.get('2'),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -807,20 +1228,47 @@ def other_distinguishing_characteristics_of_work_or_expression(
     }
 
 
-@marc21.over('medium_of_performance', '^382[10_][10_]')
+@marc21.over('medium_of_performance', '^382[_01][_01]')
 @utils.for_each_value
 @utils.filter_values
 def medium_of_performance(self, key, value):
     """Medium of Performance."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Medium of performance",
-        "1": "Partial medium of performance"}
+        '_': 'No information provided',
+        '0': 'Medium of performance',
+        '1': 'Partial medium of performance',
+    }
+
     indicator_map2 = {
-        "#": "No information provided",
-        "0": "Not intended for access",
-        "1": "Intended for access"}
+        '_': 'No information provided',
+        '0': 'Not intended for access',
+        '1': 'Intended for access',
+    }
+
+    field_map = {
+        'a': 'medium_of_performance',
+        'b': 'soloist',
+        'd': 'doubling_instrument',
+        'e': 'number_of_ensembles',
+        'n': 'number_of_performers_of_the_same_medium',
+        'p': 'alternative_medium_of_performance',
+        's': 'total_number_of_performers',
+        'v': 'note',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+    if key[4] in indicator_map2:
+        order.append('access_control')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'medium_of_performance': utils.force_list(
             value.get('a')
         ),
@@ -830,20 +1278,21 @@ def medium_of_performance(self, key, value):
         'doubling_instrument': utils.force_list(
             value.get('d')
         ),
+        'number_of_ensembles': utils.force_list(value.get('e')),
+        'number_of_performers_of_the_same_medium': utils.force_list(
+            value.get('n')
+        ),
         'alternative_medium_of_performance': utils.force_list(
             value.get('p')
+        ),
+        'total_number_of_performers': utils.force_list(
+            value.get('s')
         ),
         'note': utils.force_list(
             value.get('v')
         ),
-        'number_of_performers_of_the_same_medium': utils.force_list(
-            value.get('n')
-        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
-        ),
-        'total_number_of_performers': utils.force_list(
-            value.get('s')
         ),
         'source_of_term': value.get('2'),
         'linkage': value.get('6'),
@@ -855,7 +1304,7 @@ def medium_of_performance(self, key, value):
     }
 
 
-@marc21.over('numeric_designation_of_musical_work', '^383..')
+@marc21.over('numeric_designation_of_musical_work', '^383__')
 @utils.for_each_value
 @utils.filter_values
 def numeric_designation_of_musical_work(self, key, value):
@@ -878,14 +1327,14 @@ def numeric_designation_of_musical_work(self, key, value):
         'serial_number': utils.force_list(
             value.get('a')
         ),
-        'thematic_index_number': utils.force_list(
-            value.get('c')
-        ),
         'opus_number': utils.force_list(
             value.get('b')
         ),
-        'publisher_associated_with_opus_number': value.get('e'),
+        'thematic_index_number': utils.force_list(
+            value.get('c')
+        ),
         'thematic_index_code': value.get('d'),
+        'publisher_associated_with_opus_number': value.get('e'),
         'source': value.get('2'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
@@ -894,30 +1343,59 @@ def numeric_designation_of_musical_work(self, key, value):
     }
 
 
-@marc21.over('key', '^384[10_].')
+@marc21.over('key', '^384[_01]_')
 @utils.filter_values
 def key(self, key, value):
     """Key."""
     indicator_map1 = {
-        "#": "Relationship to original unknown ",
-        "0": "Original key ",
-        "1": "Transposed key "}
+        '_': 'Relationship to original unknown',
+        '0': 'Original key',
+        '1': 'Transposed key',
+    }
+
+    field_map = {
+        'a': 'key',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('key_type')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'key': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'key_type': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('audience_characteristics', '^385..')
+@marc21.over('audience_characteristics', '^385__')
 @utils.for_each_value
 @utils.filter_values
 def audience_characteristics(self, key, value):
     """Audience Characteristics."""
+    field_map = {
+        'a': 'audience_term',
+        'b': 'audience_code',
+        'm': 'demographic_group_term',
+        'n': 'demographic_group_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'audience_term': utils.force_list(
             value.get('a')
         ),
@@ -929,8 +1407,8 @@ def audience_characteristics(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -938,12 +1416,27 @@ def audience_characteristics(self, key, value):
     }
 
 
-@marc21.over('creator_contributor_characteristics', '^386..')
+@marc21.over('creator_contributor_characteristics', '^386__')
 @utils.for_each_value
 @utils.filter_values
 def creator_contributor_characteristics(self, key, value):
     """Creator/Contributor Characteristics."""
+    field_map = {
+        'a': 'creator_contributor_term',
+        'b': 'creator_contributor_code',
+        'm': 'demographic_group_term',
+        'n': 'demographic_group_code',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'creator_contributor_term': utils.force_list(
             value.get('a')
         ),
@@ -955,10 +1448,47 @@ def creator_contributor_characteristics(self, key, value):
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
+    }
+
+
+@marc21.over('time_period_of_creation', '^388[_12]_')
+@utils.for_each_value
+@utils.filter_values
+def creator_contributor_characteristics(self, key, value):
+    """Creator/Contributor Characteristics."""
+    indicator_map1 = {
+        '_': 'No information provided',
+        '1': 'Creation of work',
+        '2': 'Creation of aggregate work',
+    }
+
+    field_map = {
+        'a': 'time_period_of_creation_term',
+        '0': 'authority_record_control_number_or_standard_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_time_period')
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'time_period_of_creation_term': utils.force_list(value.get('a')),
+        'authority_record_control_number_or_standard_number': utils.force_list(value.get('0')),
+        'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list('8'),
+        'type_of_time_period': indicator_map1.get(key[3]),
     }

--- a/dojson/contrib/to_marc21/fields/bd20x24x.py
+++ b/dojson/contrib/to_marc21/fields/bd20x24x.py
@@ -19,11 +19,28 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_abbreviated_title(self, key, value):
     """Reverse - Abbreviated Title."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
+    }
+
     indicator_map2 = {
-        "Abbreviated key title": "_",
-        "Other abbreviated title": "0"}
+        'Abbreviated key title': '_',
+        'Other abbreviated title': '0',
+    }
+
+    field_map = {
+        'abbreviated_title': 'a',
+        'qualifying_information': 'b',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('abbreviated_title'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -43,10 +60,19 @@ def reverse_abbreviated_title(self, key, value):
 @utils.filter_values
 def reverse_key_title(self, key, value):
     """Reverse - Key Title."""
-    indicator_map2 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    field_map = {
+        'key_title': 'a',
+        'qualifying_information': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('key_title'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -54,7 +80,7 @@ def reverse_key_title(self, key, value):
         'b': value.get('qualifying_information'),
         '6': value.get('linkage'),
         '$ind1': '_',
-        '$ind2': indicator_map2.get(value.get('nonfiling_characters'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -62,11 +88,36 @@ def reverse_key_title(self, key, value):
 @utils.filter_values
 def reverse_uniform_title(self, key, value):
     """Reverse - Uniform Title."""
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map1 = {
-        "Not printed or displayed": "0",
-        "Printed or displayed": "1"}
-    indicator_map2 = {"Number of nonfiling characters": "8"}
+        'Not printed or displayed': '0',
+        'Printed or displayed': '1',
+    }
+
+    field_map = {
+        'uniform_title': 'a',
+        'date_of_treaty_signing': 'd',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'medium_of_performance_for_music': 'm',
+        'number_of_part_section_of_a_work': 'n',
+        'arranged_statement_for_music': 'o',
+        'name_of_part_section_of_a_work': 'p',
+        'key_for_music': 'r',
+        'version': 's',
+        'authority_record_control_number_or_standard_number': '0',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
         'p': utils.reverse_force_list(
             value.get('name_of_part_section_of_a_work')),
@@ -93,9 +144,7 @@ def reverse_uniform_title(self, key, value):
         '$ind1': indicator_map1.get(
             value.get('uniform_title_printed_or_displayed'),
             '_'),
-        '$ind2': indicator_map2.get(
-            value.get('nonfiling_characters'),
-            '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -104,11 +153,29 @@ def reverse_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_translation_of_title_by_cataloging_agency(self, key, value):
     """Reverse - Translation of Title by Cataloging Agency."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
-    indicator_map2 = {
-        "No nonfiling characters": "0",
-        "Number of nonfiling characters": "8"}
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
+    }
+
+    field_map = {
+        'title': 'a',
+        'remainder_of_title': 'b',
+        'statement_of_responsibility_etc.': 'c',
+        'medium': 'h',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'language_code_of_translated_title': 'y',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'c': value.get('statement_of_responsibility'),
         'b': value.get('remainder_of_title'),
@@ -125,7 +192,7 @@ def reverse_translation_of_title_by_cataloging_agency(self, key, value):
             value.get('field_link_and_sequence_number')
         ),
         '$ind1': indicator_map1.get(value.get('title_added_entry'), '_'),
-        '$ind2': indicator_map2.get(value.get('nonfiling_characters'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -133,11 +200,12 @@ def reverse_translation_of_title_by_cataloging_agency(self, key, value):
 @utils.filter_values
 def reverse_collective_uniform_title(self, key, value):
     """Reverse - Collective Uniform Title."""
-    indicator_map1 = {
-        "Not printed or displayed": "0",
-        "Printed or displayed": "1",
-    }
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'Not printed or displayed': '0',
+        'Printed or displayed': '1',
+    }
 
     field_map = {
         'uniform_title': 'a',
@@ -158,9 +226,6 @@ def reverse_collective_uniform_title(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('uniform_title_printed_or_displayed')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -188,7 +253,7 @@ def reverse_collective_uniform_title(self, key, value):
         '$ind1': indicator_map1.get(
             value.get('uniform_title_printed_or_displayed'),
             '_'),
-        '$ind2': value.get('nonfiling_characters', '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -196,19 +261,13 @@ def reverse_collective_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_title_statement(self, key, value):
     """Reverse - Title Statement."""
-    indicator_map1 = {"Added entry": "1", "No added entry": "0"}
-    indicator_map2 = {
-        "0": "0",
-        "1": "1",
-        "2": "2",
-        "3": "3",
-        "4": "4",
-        "5": "5",
-        "6": "6",
-        "7": "7",
-        "8": "8",
-        "9": "9",
+    valid_nonfiling_characters = [str(x) for x in range(10)]
+
+    indicator_map1 = {
+        'No added entry': '0',
+        'Added entry': '1',
     }
+
     field_map = {
         'title': 'a',
         'remainder_of_title': 'b',
@@ -222,15 +281,12 @@ def reverse_title_statement(self, key, value):
         'version': 's',
         'linkage': '6',
         'field_link_and_sequence_number': '8',
-        'title_added_entry': None,
-        'nonfiling_characters': None
     }
 
-    ind1 = indicator_map1.get(value.get('title_added_entry'), '_')
-    ind2 = indicator_map2.get(value.get('nonfiling_characters'), '_')
     order = utils.map_order(field_map, value)
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
         'c': value.get('statement_of_responsibility'),
         'b': value.get('remainder_of_title'),
@@ -251,9 +307,8 @@ def reverse_title_statement(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': ind1,
-        '$ind2': ind2,
-        '__order__': tuple(order) if len(order) else None
+        '$ind1': indicator_map1.get(value.get('title_added_entry'), '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 
@@ -263,22 +318,43 @@ def reverse_title_statement(self, key, value):
 def reverse_varying_form_of_title(self, key, value):
     """Reverse - Varying Form of Title."""
     indicator_map1 = {
-        "No note, added entry": "3",
-        "No note, no added entry": "2",
-        "Note, added entry": "1",
-        "Note, no added entry": "0"}
+        'Note, no added entry': '0',
+        'Note, added entry': '1',
+        'No note, no added entry': '2',
+        'No note, added entry': '3',
+    }
+
     indicator_map2 = {
-        "Added title page title": "5",
-        "Caption title": "6",
-        "Cover title": "4",
-        "Distinctive title": "2",
-        "No type specified": "_",
-        "Other title": "3",
-        "Parallel title": "1",
-        "Portion of title": "0",
-        "Running title": "7",
-        "Spine title": "8"}
+        'No type specified': '_',
+        'Portion of title': '0',
+        'Parallel title': '1',
+        'Distinctive title': '2',
+        'Other title': '3',
+        'Cover title': '4',
+        'Added title page title': '5',
+        'Caption title': '6',
+        'Running title': '7',
+        'Spine title': '8',
+    }
+
+    field_map = {
+        'title_proper_short_title': 'a',
+        'remainder_of_title': 'b',
+        'date_or_sequential_designation': 'f',
+        'miscellaneous_information': 'g',
+        'medium': 'h',
+        'display_text': 'i',
+        'number_of_part_section_of_a_work': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('title_proper_short_title'),
         'b': value.get('remainder_of_title'),
         'g': value.get('miscellaneous_information'),
@@ -330,11 +406,6 @@ def reverse_former_title(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('title_added_entry')
-    if key[4] in indicator_map2:
-        order.append('note_controller')
 
     return {
         '__order__': tuple(order) if len(order) else None,

--- a/dojson/contrib/to_marc21/fields/bd25x28x.py
+++ b/dojson/contrib/to_marc21/fields/bd25x28x.py
@@ -19,7 +19,18 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_edition_statement(self, key, value):
     """Reverse - Edition Statement."""
+    field_map = {
+        'edition_statement': 'a',
+        'remainder_of_edition_statement': 'b',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('edition_statement'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -36,7 +47,16 @@ def reverse_edition_statement(self, key, value):
 @utils.filter_values
 def reverse_musical_presentation_statement(self, key, value):
     """Reverse - Musical Presentation Statement."""
+    field_map = {
+        'musical_presentation_statement': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('musical_presentation_statement'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -52,7 +72,22 @@ def reverse_musical_presentation_statement(self, key, value):
 @utils.filter_values
 def reverse_cartographic_mathematical_data(self, key, value):
     """Reverse - Cartographic Mathematical Data."""
+    field_map = {
+        'statement_of_scale': 'a',
+        'statement_of_projection': 'b',
+        'statement_of_coordinates': 'c',
+        'statement_of_zone': 'd',
+        'statement_of_equinox': 'e',
+        'outer_g_ring_coordinate_pairs': 'f',
+        'exclusion_g_ring_coordinate_pairs': 'g',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('statement_of_scale'),
         'c': value.get('statement_of_coordinates'),
         'b': value.get('statement_of_projection'),
@@ -73,7 +108,16 @@ def reverse_cartographic_mathematical_data(self, key, value):
 @utils.filter_values
 def reverse_computer_file_characteristics(self, key, value):
     """Reverse - Computer File Characteristics."""
+    field_map = {
+        'computer_file_characteristics': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('computer_file_characteristics'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -89,7 +133,17 @@ def reverse_computer_file_characteristics(self, key, value):
 @utils.filter_values
 def reverse_country_of_producing_entity(self, key, value):
     """Reverse - Country of Producing Entity."""
+    field_map = {
+        'country_of_producing_entity': 'a',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('country_of_producing_entity')
         ),
@@ -108,7 +162,17 @@ def reverse_country_of_producing_entity(self, key, value):
 @utils.filter_values
 def reverse_philatelic_issue_data(self, key, value):
     """Reverse - Philatelic Issue Data."""
+    field_map = {
+        'issuing_jurisdiction': 'a',
+        'denomination': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('issuing_jurisdiction'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -126,9 +190,9 @@ def reverse_philatelic_issue_data(self, key, value):
 def reverse_publication_distribution_imprint(self, key, value):
     """Reverse - Publication, Distribution, etc. (Imprint)."""
     indicator_map1 = {
-        "Current/latest publisher": "3",
-        "Intervening publisher": "2",
-        "Not applicable/No information provided/Earliest available publisher": "_",
+        'Not applicable/No information provided/Earliest available publisher': '_',
+        'Intervening publisher': '2',
+        'Current/latest publisher': '3',
     }
 
     field_map = {
@@ -144,9 +208,6 @@ def reverse_publication_distribution_imprint(self, key, value):
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in indicator_map1:
-        order.append('sequence_of_publishing_statements')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -177,7 +238,20 @@ def reverse_publication_distribution_imprint(self, key, value):
 @utils.filter_values
 def reverse_imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
     """Reverse - Imprint Statement for Films (Pre-AACR 1 Revised)."""
+    field_map = {
+        'producing_company': 'a',
+        'releasing_company': 'b',
+        'date_of_production_release': 'd',
+        'contractual_producer': 'e',
+        'place_of_production_release': 'f',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('producing_company')
         ),
@@ -204,12 +278,22 @@ def reverse_imprint_statement_for_films_pre_aacr_1_revised(self, key, value):
 
 @to_marc21.over('262', '^imprint_statement_for_sound_recordings_pre_aacr_1$')
 @utils.filter_values
-def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(
-        self,
-        key,
-        value):
+def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(self, key, value):
     """Reverse - Imprint Statement for Sound Recordings (Pre-AACR 1)."""
+    field_map = {
+        'place_of_production_release': 'a',
+        'publisher_or_trade_name': 'b',
+        'date_of_production_release': 'c',
+        'serial_identification': 'k',
+        'matrix_and_or_take_number': 'l',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('place_of_production_release'),
         'c': value.get('date_of_production_release'),
         'b': value.get('publisher_or_trade_name'),
@@ -228,7 +312,16 @@ def reverse_imprint_statement_for_sound_recordings_pre_aacr_1(
 @utils.filter_values
 def reverse_projected_publication_date(self, key, value):
     """Reverse - Projected Publication Date."""
+    field_map = {
+        'projected_publication_date': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('projected_publication_date'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -249,15 +342,32 @@ def reverse_production_publication_distribution_manufacture_and_copyright_notice
         key,
         value):
     """Reverse - Production, Publication, Distribution, Manufacture, and Copyright Notice."""
-    indicator_map1 = {"Current/latest": "3", "Intervening": "2",
-                      "Not applicable/No information provided/Earliest": "_"}
+    indicator_map1 = {
+        'Not applicable/No information provided/Earliest': '_',
+        'Intervening': '2',
+        'Current/latest': '3',
+    }
     indicator_map2 = {
-        "Copyright notice date": "4",
-        "Distribution": "2",
-        "Manufacture": "3",
-        "Production": "0",
-        "Publication": "1"}
+        'Production': '0',
+        'Publication': '1',
+        'Distribution': '2',
+        'Manufacture': '3',
+        'Copyright notice date': '4',
+    }
+
+    field_map = {
+        'place_of_production_publication_distribution_manufacture': 'a',
+        'name_of_producer_publisher_distributor_manufacturer': 'b',
+        'date_of_production_publication_distribution_manufacture_or_copyright_notice': 'c',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get(
                 'place_of_production_publication_distribution_manufacture')

--- a/dojson/contrib/to_marc21/fields/bd3xx.py
+++ b/dojson/contrib/to_marc21/fields/bd3xx.py
@@ -53,7 +53,16 @@ def reverse_physical_description(self, key, value):
 @utils.filter_values
 def reverse_playing_time(self, key, value):
     """Reverse - Playing Time."""
+    field_map = {
+        'playing_time': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('playing_time')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '6': utils.reverse_force_list(value.get('linkage')),
@@ -67,8 +76,22 @@ def reverse_playing_time(self, key, value):
 @utils.filter_values
 def reverse_hours(self, key, value):
     """Reverse - Hours, Etc.."""
-    indicator_map1 = {"Hours": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Hours': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'hours': 'a',
+        'additional_information': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('hours')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         'b': utils.reverse_force_list(value.get('additional_information')),
@@ -82,7 +105,17 @@ def reverse_hours(self, key, value):
 @utils.filter_values
 def reverse_current_publication_frequency(self, key, value):
     """Reverse - Current Publication Frequency."""
+    field_map = {
+        'current_publication_frequency': 'a',
+        'date_of_current_publication_frequency': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('current_publication_frequency')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         'b': utils.reverse_force_list(value.get('date_of_current_publication_frequency')),
@@ -122,11 +155,25 @@ def reverse_former_publication_frequency(self, key, value):
 @utils.filter_values
 def reverse_content_type(self, key, value):
     """Reverse - Content Type."""
+    field_map = {
+        'content_type_term': 'a',
+        'content_type_code': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('content_type_term')),
         'b': utils.reverse_force_list(value.get('content_type_code')),
-        '3': utils.reverse_force_list(value.get('materials_specified')),
+        '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
         '2': utils.reverse_force_list(value.get('source')),
+        '3': utils.reverse_force_list(value.get('materials_specified')),
         '6': utils.reverse_force_list(value.get('linkage')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': '_',
@@ -201,7 +248,31 @@ def reverse_carrier_type(self, key, value):
 @utils.filter_values
 def reverse_physical_medium(self, key, value):
     """Reverse - Physical Medium."""
+    field_map = {
+        'material_base_and_configuration': 'a',
+        'dimensions': 'b',
+        'materials_applied_to_surface': 'c',
+        'information_recording_technique': 'd',
+        'support': 'e',
+        'production_rate_ratio': 'f',
+        'location_within_medium': 'h',
+        'technical_specifications_of_medium': 'i',
+        'generation': 'j',
+        'layout': 'k',
+        'book_format': 'm',
+        'font_size': 'n',
+        'polarity': 'o',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('material_base_and_configuration')),
         'c': utils.reverse_force_list(value.get('materials_applied_to_surface')),
         'b': utils.reverse_force_list(value.get('dimensions')),
@@ -231,19 +302,55 @@ def reverse_physical_medium(self, key, value):
 def reverse_geospatial_reference_data(self, key, value):
     """Reverse - Geospatial Reference Data."""
     indicator_map1 = {
-        "Horizontal coordinate system": "0",
-        "Vertical coordinate system": "1"}
+        'Horizontal coordinate system': '0',
+        'Vertical coordinate system': '1',
+    }
+
     indicator_map2 = {
-        "Altitude": "6",
-        "Depth": "8",
-        "Geodetic model": "5",
-        "Geographic": "0",
-        "Grid coordinate system": "2",
-        "Local": "4",
-        "Local planar": "3",
-        "Map projection": "1",
-        "Method specified in $2": "7"}
+        'Geographic': '0',
+        'Map projection': '1',
+        'Grid coordinate system': '2',
+        'Local planar': '3',
+        'Local': '4',
+        'Geodetic model': '5',
+        'Altitude': '6',
+        'Method specified in $2': '7',
+        'Depth': '8',
+    }
+
+    field_map = {
+        'name': 'a',
+        'coordinate_units_or_distance_units': 'b',
+        'latitude_resolution': 'c',
+        'longitude_resolution': 'd',
+        'standard_parallel_or_oblique_line_latitude': 'e',
+        'oblique_line_longitude': 'f',
+        'longitude_of_central_meridian_or_projection_center': 'g',
+        'latitude_of_projection_center_or_projection_origin': 'h',
+        'false_easting': 'i',
+        'false_northing': 'j',
+        'scale_factor': 'k',
+        'height_of_perspective_point_above_surface': 'l',
+        'azimuthal_angle': 'm',
+        'azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole': 'n',
+        'landsat_number_and_path_number': 'o',
+        'zone_identifier': 'p',
+        'ellipsoid_name': 'q',
+        'semi_major_axis': 'r',
+        'denominator_of_flattening_ratio': 's',
+        'vertical_resolution': 't',
+        'vertical_encoding_method': 'u',
+        'local_planar_local_or_other_projection_or_grid_description': 'v',
+        'local_planar_or_local_georeference_information': 'w',
+        'reference_method_used': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         '2': utils.reverse_force_list(value.get('reference_method_used')),
         '6': utils.reverse_force_list(value.get('linkage')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
@@ -280,7 +387,24 @@ def reverse_geospatial_reference_data(self, key, value):
 @utils.filter_values
 def reverse_planar_coordinate_data(self, key, value):
     """Reverse - Planar Coordinate Data."""
+    field_map = {
+        'planar_coordinate_encoding_method': 'a',
+        'planar_distance_units': 'b',
+        'abscissa_resolution': 'c',
+        'ordinate_resolution': 'd',
+        'distance_resolution': 'e',
+        'bearing_resolution': 'f',
+        'bearing_units': 'g',
+        'bearing_reference_direction': 'h',
+        'bearing_reference_meridian': 'i',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('planar_coordinate_encoding_method')),
         'c': utils.reverse_force_list(value.get('abscissa_resolution')),
         'b': utils.reverse_force_list(value.get('planar_distance_units')),
@@ -345,7 +469,20 @@ def reverse_sound_characteristics(self, key, value):
 @utils.filter_values
 def reverse_projection_characteristics_of_moving_image(self, key, value):
     """Reverse - Projection Characteristics of Moving Image."""
+    field_map = {
+        'presentation_format': 'a',
+        'projection_speed': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('presentation_format')),
         'b': utils.reverse_force_list(value.get('projection_speed')),
         '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
@@ -363,7 +500,20 @@ def reverse_projection_characteristics_of_moving_image(self, key, value):
 @utils.filter_values
 def reverse_video_characteristics(self, key, value):
     """Reverse - Video Characteristics."""
+    field_map = {
+        'video_format': 'a',
+        'broadcast_standard': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('video_format')),
         'b': utils.reverse_force_list(value.get('broadcast_standard')),
         '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
@@ -381,17 +531,65 @@ def reverse_video_characteristics(self, key, value):
 @utils.filter_values
 def reverse_digital_file_characteristics(self, key, value):
     """Reverse - Digital File Characteristics."""
+    field_map = {
+        'file_type': 'a',
+        'encoding_format': 'b',
+        'file_size': 'c',
+        'resolution': 'd',
+        'regional_encoding': 'e',
+        'encoded_bitrate': 'f',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('file_type')),
         'c': utils.reverse_force_list(value.get('file_size')),
         'b': utils.reverse_force_list(value.get('encoding_format')),
         'e': utils.reverse_force_list(value.get('regional_encoding')),
         'd': utils.reverse_force_list(value.get('resolution')),
-        'f': utils.reverse_force_list(value.get('transmission_speed')),
+        'f': utils.reverse_force_list(value.get('encoded_bitrate')),
         '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
         '3': utils.reverse_force_list(value.get('materials_specified')),
         '2': utils.reverse_force_list(value.get('source')),
         '6': utils.reverse_force_list(value.get('linkage')),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
+        '$ind1': '_',
+        '$ind2': '_',
+    }
+
+
+@to_marc21.over('348', '^format_of_notated_music$')
+@utils.reverse_for_each_value
+@utils.filter_values
+def reverse_digital_file_characteristics(self, key, value):
+    """Reverse - Digital File Characteristics."""
+    field_map = {
+        'format_of_notated_music_term': 'a',
+        'format_of_notated_music_code': 'b',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'a': utils.reverse_force_list(value.get('format_of_notated_music_term')),
+        'b': utils.reverse_force_list(value.get('format_of_notated_music_code')),
+        '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
+        '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': '_',
         '$ind2': '_',
@@ -432,7 +630,24 @@ def reverse_organization_and_arrangement_of_materials(self, key, value):
 @utils.filter_values
 def reverse_digital_graphic_representation(self, key, value):
     """Reverse - Digital Graphic Representation."""
+    field_map = {
+        'direct_reference_method': 'a',
+        'object_type': 'b',
+        'object_count': 'c',
+        'row_count': 'd',
+        'column_count': 'e',
+        'vertical_count': 'f',
+        'vpf_topology_level': 'g',
+        'indirect_reference_description': 'i',
+        'format_of_the_digital_image': 'q',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('direct_reference_method')),
         'c': utils.reverse_force_list(value.get('object_count')),
         'b': utils.reverse_force_list(value.get('object_type')),
@@ -455,14 +670,33 @@ def reverse_digital_graphic_representation(self, key, value):
 def reverse_security_classification_control(self, key, value):
     """Reverse - Security Classification Control."""
     indicator_map1 = {
-        "Abstract": "2",
-        "Author": "4",
-        "Contents note": "3",
-        "Document": "0",
-        "None of the above": "8",
-        "Record": "5",
-        "Title": "1"}
+        'Document': '0',
+        'Title': '1',
+        'Abstract': '2',
+        'Contents note': '3',
+        'Author': '4',
+        'Record': '5',
+        'None of the above': '8',
+    }
+
+    field_map = {
+        'security_classification': 'a',
+        'handling_instructions': 'b',
+        'external_dissemination_information': 'c',
+        'downgrading_or_declassification_event': 'd',
+        'classification_system': 'e',
+        'country_of_origin_code': 'f',
+        'downgrading_date': 'g',
+        'declassification_date': 'h',
+        'authorization': 'j',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('security_classification')),
         'c': utils.reverse_force_list(value.get('external_dissemination_information')),
         'b': utils.reverse_force_list(value.get('handling_instructions')),
@@ -483,7 +717,19 @@ def reverse_security_classification_control(self, key, value):
 @utils.filter_values
 def reverse_originator_dissemination_control(self, key, value):
     """Reverse - Originator Dissemination Control."""
+    field_map = {
+        'originator_control_term': 'a',
+        'originating_agency': 'b',
+        'authorized_recipients_of_material': 'c',
+        'other_restrictions': 'g',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('originator_control_term')),
         'c': utils.reverse_force_list(value.get('authorized_recipients_of_material')),
         'b': utils.reverse_force_list(value.get('originating_agency')),
@@ -503,8 +749,22 @@ def reverse_dates_of_publication_and_or_sequential_designation(
         key,
         value):
     """Reverse - Dates of Publication and/or Sequential Designation."""
-    indicator_map1 = {"Formatted style": "0", "Unformatted note": "1"}
+    indicator_map1 = {
+        'Formatted style': '0',
+        'Unformatted note': '1',
+    }
+
+    field_map = {
+        'dates_of_publication_and_or_sequential_designation': 'a',
+        'source_of_information': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('dates_of_publication_and_or_sequential_designation')),
         '8': utils.reverse_force_list(
@@ -526,11 +786,42 @@ def reverse_dates_of_publication_and_or_sequential_designation(
 def reverse_normalized_date_and_sequential_designation(self, key, value):
     """Reverse - Normalized Date and Sequential Designation."""
     indicator_map1 = {
-        "Ending information": "1",
-        "No information provided": "_",
-        "Starting information": "0"}
-    indicator_map2 = {"Closed": "0", "Not specified": "_", "Open": "1"}
+        'No information provided': '_',
+        'Starting information': '0',
+        'Ending information': '1',
+    }
+    indicator_map2 = {
+        'Not specified': '_',
+        'Closed': '0',
+        'Open': '1',
+    }
+
+    field_map = {
+        'first_level_of_enumeration': 'a',
+        'second_level_of_enumeration': 'b',
+        'third_level_of_enumeration': 'c',
+        'fourth_level_of_enumeration': 'd',
+        'fifth_level_of_enumeration': 'e',
+        'sixth_level_of_enumeration': 'f',
+        'alternative_numbering_scheme_first_level_of': 'g',
+        'alternative_numbering_scheme_second_level_of': 'h',
+        'first_level_of_chronology': 'i',
+        'second_level_of_chronology': 'j',
+        'third_level_of_chronology': 'k',
+        'fourth_level_of_chronology': 'l',
+        'alternative_numbering_scheme_chronology': 'm',
+        'first_level_textual_designation': 'u',
+        'first_level_of_chronology_issuance': 'v',
+        'nonpublic_note': 'x',
+        'public_note': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('first_level_of_enumeration')),
         'x': utils.reverse_force_list(value.get('nonpublic_note')),
         'c': utils.reverse_force_list(value.get('third_level_of_enumeration')),
@@ -560,7 +851,28 @@ def reverse_normalized_date_and_sequential_designation(self, key, value):
 @utils.filter_values
 def reverse_trade_price(self, key, value):
     """Reverse - Trade Price."""
+    field_map = {
+        'price_type_code': 'a',
+        'price_amount': 'b',
+        'currency_code': 'c',
+        'unit_of_pricing': 'd',
+        'price_note': 'e',
+        'price_effective_from': 'f',
+        'price_effective_until': 'g',
+        'tax_rate_1': 'h',
+        'tax_rate_2': 'i',
+        'iso_country_code': 'j',
+        'marc_country_code': 'k',
+        'identification_of_pricing_entity': 'm',
+        'source_of_price_type_code': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('price_type_code')),
         'c': utils.reverse_force_list(value.get('currency_code')),
         'b': utils.reverse_force_list(value.get('price_amount')),
@@ -586,7 +898,26 @@ def reverse_trade_price(self, key, value):
 @utils.filter_values
 def reverse_trade_availability_information(self, key, value):
     """Reverse - Trade Availability Information."""
+    field_map = {
+        'publishers_compressed_title_identification': 'a',
+        'detailed_date_of_publication': 'b',
+        'availability_status_code': 'c',
+        'expected_next_availability_date': 'd',
+        'note': 'e',
+        'publishers_discount_category': 'f',
+        'date_made_out_of_print': 'g',
+        'iso_country_code': 'j',
+        'marc_country_code': 'k',
+        'identification_of_agency': 'm',
+        'source_of_availability_status_code': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('publishers_compressed_title_identification')),
         'c': utils.reverse_force_list(value.get('availability_status_code')),
         'b': utils.reverse_force_list(value.get('detailed_date_of_publication')),
@@ -605,19 +936,79 @@ def reverse_trade_availability_information(self, key, value):
     }
 
 
+@to_marc21.over('370', '^associated_place$')
+@utils.for_each_value
+@utils.filter_values
+def associated_place(self, key, value):
+    field_map = {
+        'associated_country': 'c',
+        'other_associated_place': 'f',
+        'place_of_origin_of_work': 'g',
+        'start_period': 's',
+        'end_period': 't',
+        'uniform_resource_identifier': 'u',
+        'source_of_information': 'v',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'c': utils.reverse_force_list(value.get('associated_country')),
+        'f': utils.reverse_force_list(value.get('other_associated_place')),
+        'g': utils.reverse_force_list(value.get('place_of_origin_of_work')),
+        's': value.get('start_period'),
+        't': value.get('end_period'),
+        'u': utils.reverse_force_list(value.get('uniform_resource_identifier')),
+        'v': utils.reverse_force_list(value.get('source_of_information')),
+        '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
+        '2': value.get('source_of_term'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
+        '$ind1': '_',
+        '$ind2': '_',
+    }
+
+
 @to_marc21.over('377', '^associated_language$')
 @utils.reverse_for_each_value
 @utils.filter_values
 def reverse_associated_language(self, key, value):
     """Reverse - Associated Language."""
+    indicator_map2 = {
+        'MARC language code': '_',
+        'Source specified in subfield $2': '7',
+    }
+
+    field_map = {
+        'language_code': 'a',
+        'language_term': 'l',
+        'source': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if indicator_map2.get(value.get('source_of_code'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('language_code')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '2': utils.reverse_force_list(value.get('source')),
         'l': utils.reverse_force_list(value.get('language_term')),
         '6': utils.reverse_force_list(value.get('linkage')),
         '$ind1': '_',
-        '$ind2': '_',
+        '$ind2': indicator_map2.get(value.get('source_of_code'), '_'),
     }
 
 
@@ -658,7 +1049,20 @@ def reverse_other_distinguishing_characteristics_of_work_or_expression(
         key,
         value):
     """Reverse - Other Distinguishing Characteristics of Work or Expression."""
+    field_map = {
+        'other_distinguishing_characteristic': 'a',
+        'uniform_resource_identifier': 'u',
+        'source_of_information': 'v',
+        'record_control_number': '0',
+        'source_of_term': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('other_distinguishing_characteristic')),
         'v': utils.reverse_force_list(value.get('source_of_information')),
         '0': utils.reverse_force_list(value.get('record_control_number')),
@@ -677,19 +1081,42 @@ def reverse_other_distinguishing_characteristics_of_work_or_expression(
 def reverse_medium_of_performance(self, key, value):
     """Reverse - Medium of Performance."""
     indicator_map1 = {
-        "Medium of performance": "0",
-        "No information provided": "_",
-        "Partial medium of performance": "1"}
+        'No information provided': '_',
+        'Medium of performance': '0',
+        'Partial medium of performance': '1',
+    }
+
     indicator_map2 = {
-        "Intended for access": "1",
-        "No information provided": "_",
-        "Not intended for access": "0"}
+        'No information provided': '_',
+        'Not intended for access': '0',
+        'Intended for access': '1',
+    }
+
+    field_map = {
+        'medium_of_performance': 'a',
+        'soloist': 'b',
+        'doubling_instrument': 'd',
+        'number_of_ensembles': 'e',
+        'number_of_performers_of_the_same_medium': 'n',
+        'alternative_medium_of_performance': 'p',
+        'total_number_of_performers': 's',
+        'note': 'v',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('medium_of_performance')),
         'b': utils.reverse_force_list(value.get('soloist')),
         'd': utils.reverse_force_list(value.get('doubling_instrument')),
         'p': utils.reverse_force_list(value.get('alternative_medium_of_performance')),
         'v': utils.reverse_force_list(value.get('note')),
+        'e': utils.reverse_force_list(value.get('number_of_ensembles')),
         'n': utils.reverse_force_list(value.get('number_of_performers_of_the_same_medium')),
         '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
         's': utils.reverse_force_list(value.get('total_number_of_performers')),
@@ -739,10 +1166,21 @@ def reverse_numeric_designation_of_musical_work(self, key, value):
 def reverse_key(self, key, value):
     """Reverse - Key."""
     indicator_map1 = {
-        "Original key ": "0",
-        "Relationship to original unknown ": "_",
-        "Transposed key ": "1"}
+        'Relationship to original unknown': '_',
+        'Original key': '0',
+        'Transposed key': '1',
+    }
+
+    field_map = {
+        'key': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('key')),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '6': utils.reverse_force_list(value.get('linkage')),
@@ -756,7 +1194,22 @@ def reverse_key(self, key, value):
 @utils.filter_values
 def reverse_audience_characteristics(self, key, value):
     """Reverse - Audience Characteristics."""
+    field_map = {
+        'audience_term': 'a',
+        'audience_code': 'b',
+        'demographic_group_term': 'm',
+        'demographic_group_code': 'n',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(value.get('audience_term')),
         'b': utils.reverse_force_list(value.get('audience_code')),
         'm': utils.reverse_force_list(value.get('demographic_group_term')),
@@ -774,18 +1227,76 @@ def reverse_audience_characteristics(self, key, value):
 @to_marc21.over('386', '^creator_contributor_characteristics$')
 @utils.reverse_for_each_value
 @utils.filter_values
+def creator_contributor_characteristics(self, key, value):
+    """Creator/Contributor Characteristics."""
+    field_map = {
+        'creator_contributor_term': 'a',
+        'creator_contributor_code': 'b',
+        'demographic_group_term': 'm',
+        'demographic_group_code': 'n',
+        'authority_record_control_number_or_standard_number': '0',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    return {
+        '__order__': tuple(order) if len(order) else None,
+        'a': utils.reverse_force_list(
+            value.get('creator_contributor_term')
+        ),
+        'b': utils.reverse_force_list(
+            value.get('creator_contributor_code')
+        ),
+        'm': value.get('demographic_group_term'),
+        'n': value.get('demographic_group_code'),
+        '0': utils.reverse_force_list(
+            value.get('authority_record_control_number_or_standard_number')
+        ),
+        '3': value.get('materials_specified'),
+        '2': value.get('source'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
+        '$ind1': '_',
+        '$ind2': '_',
+    }
+
+
+@to_marc21.over('388', '^time_period_of_creation$')
+@utils.reverse_for_each_value
+@utils.filter_values
 def reverse_creator_contributor_characteristics(self, key, value):
     """Reverse - Creator/Contributor Characteristics."""
+    indicator_map1 = {
+        'No information provided': '_',
+        'Creation of work': '1',
+        'Creation of aggregate work': '2',
+    }
+
+    field_map = {
+        'time_period_of_creation_term': 'a',
+        'authority_record_control_number_or_standard_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
-        'a': utils.reverse_force_list(value.get('creator_contributor_term')),
-        'b': utils.reverse_force_list(value.get('creator_contributor_code')),
-        'm': utils.reverse_force_list(value.get('demographic_group_term')),
-        'n': utils.reverse_force_list(value.get('demographic_group_code')),
+        '__order__': tuple(order) if len(order) else None,
+        'a': utils.reverse_force_list(value.get('time_period_of_creation_term')),
         '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
-        '3': utils.reverse_force_list(value.get('materials_specified')),
-        '2': utils.reverse_force_list(value.get('source')),
-        '6': utils.reverse_force_list(value.get('linkage')),
+        '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
-        '$ind1': '_',
+        '$ind1': indicator_map1.get(value.get('type_of_time_period'), '_'),
         '$ind2': '_',
     }

--- a/tests/data/handcrafted/bd3xx.xml
+++ b/tests/data/handcrafted/bd3xx.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="384" ind1="1" ind2=" ">
+      <subfield code="a">Master key 42</subfield>
+      <subfield code="6">880-01$a</subfield>
+      <subfield code="8">12421.45552\52144</subfield>
+      <subfield code="8">22421.45552\52145</subfield>
+      <subfield code="8">32421.45552\52146</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="377" ind1=" " ind2=" ">
+      <subfield code="a">en</subfield>
+      <subfield code="a">de</subfield>
+      <subfield code="a">fi</subfield>
+      <subfield code="a">it</subfield>
+      <subfield code="l">en</subfield>
+      <subfield code="l">de</subfield>
+      <subfield code="l">fi</subfield>
+      <subfield code="l">it</subfield>
+      <subfield code="6">880-01$a</subfield>
+      <subfield code="6">880-01$a</subfield>
+      <subfield code="8">5161254241.2421414124\5251</subfield>
+    </datafield>
+  </record>
+  <record>
+    <datafield tag="377" ind1=" " ind2="7">
+      <subfield code="a">en</subfield>
+      <subfield code="a">de</subfield>
+      <subfield code="a">fi</subfield>
+      <subfield code="a">it</subfield>
+      <subfield code="l">en</subfield>
+      <subfield code="l">de</subfield>
+      <subfield code="l">fi</subfield>
+      <subfield code="l">it</subfield>
+      <subfield code="2">library of lala</subfield>
+      <subfield code="6">880-01$a</subfield>
+      <subfield code="6">880-01$a</subfield>
+      <subfield code="8">5161254241.2421414124\5251</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/library_of_congress/bd20x24x.xml
+++ b/tests/data/library_of_congress/bd20x24x.xml
@@ -262,14 +262,7 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="240" ind1="1" ind2="0">
-      <subfield code="b">Kaffee-Kantate</subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="240" ind1="1" ind2="0">
-      <subfield code="t">Our town</subfield>
-    </datafield>
+    <datafield tag="240" ind1="1" ind2="0"/>
   </record>
   <record>
     <datafield tag="240" ind1="1" ind2="4">

--- a/tests/data/library_of_congress/bd3xx.xml
+++ b/tests/data/library_of_congress/bd3xx.xml
@@ -1665,7 +1665,7 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="357" ind1=" " ind2="0">
+    <datafield tag="357" ind1=" " ind2=" ">
       <subfield code="a">ORCON</subfield>
       <subfield code="b">CIA</subfield>
       <subfield code="c">DIA</subfield>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'handcrafted/bd01x09x.xml',
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
+    'library_of_congress/bd20x24x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,6 +42,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
     'library_of_congress/bd20x24x.xml',
+    'library_of_congress/bd25x28x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,10 +39,12 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'test_16.xml',
     'test_cds_marc21.xml',
     'handcrafted/bd01x09x.xml',
+    'handcrafted/bd3xx.xml',
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
     'library_of_congress/bd20x24x.xml',
     'library_of_congress/bd25x28x.xml',
+    'library_of_congress/bd3xx.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd3xx fields. (closes #94)
- Reaches 100% test coverage for bd3xx fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
