### PR TITLE
dojson: bd4xx field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd4xx.py
+++ b/dojson/contrib/marc21/fields/bd4xx.py
@@ -14,15 +14,20 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('series_statement_added_entry_personal_name', '^400[103_][10_]')
+@marc21.over('series_statement_added_entry_personal_name', '^400[_013][_01]')
 @utils.for_each_value
 @utils.filter_values
 def series_statement_added_entry_personal_name(self, key, value):
     """Series Statement/Added Entry-Personal Name."""
-    indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
+    indicator_map1 = {
+        '0': 'Forename',
+        '1': 'Surname',
+        '3': 'Family name',
+    }
     indicator_map2 = {
-        "0": "Main entry not represented by pronoun",
-        "1": "Main entry represented by pronoun"}
+        '0': 'Main entry not represented by pronoun',
+        '1': 'Main entry represented by pronoun',
+    }
 
     field_map = {
         'a': 'personal_name',
@@ -56,21 +61,19 @@ def series_statement_added_entry_personal_name(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'personal_name': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
+        'numeration': value.get('b'),
         'titles_and_other_words_associated_with_a_name': utils.force_list(
             value.get('c')
         ),
-        'numeration': value.get('b'),
+        'dates_associated_with_a_name': value.get('d'),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'dates_associated_with_a_name': value.get('d'),
-        'miscellaneous_information': value.get('g'),
         'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
         'form_subheading': utils.force_list(
             value.get('k')
         ),
-        'volume_sequential_designation': value.get('v'),
         'language_of_a_work': value.get('l'),
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
@@ -78,7 +81,10 @@ def series_statement_added_entry_personal_name(self, key, value):
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
         ),
+        'title_of_a_work': value.get('t'),
         'affiliation': value.get('u'),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -86,43 +92,73 @@ def series_statement_added_entry_personal_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'title_of_a_work': value.get('t'),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('series_statement_added_entry_corporate_name', '^410[10_2][10_]')
+@marc21.over('series_statement_added_entry_corporate_name', '^410[_012][_01]')
 @utils.for_each_value
 @utils.filter_values
 def series_statement_added_entry_corporate_name(self, key, value):
     """Series Statement/Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
     indicator_map2 = {
-        "0": "Main entry not represented by pronoun",
-        "1": "Main entry represented by pronoun"}
+        '0': 'Main entry not represented by pronoun',
+        '1': 'Main entry represented by pronoun',
+    }
+
+    field_map = {
+        'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
+        'b': 'subordinate_unit',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting_or_treaty_signing',
+        'e': 'relator_term',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'volume_sequential_designation',
+        'x': 'international_standard_serial_number',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_corporate_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('pronoun_represents_main_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'location_of_meeting': value.get('c'),
         'subordinate_unit': utils.force_list(
             value.get('b')
+        ),
+        'location_of_meeting': value.get('c'),
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
         ),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'date_of_meeting_or_treaty_signing': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
         'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
         'form_subheading': utils.force_list(
             value.get('k')
         ),
-        'volume_sequential_designation': value.get('v'),
         'language_of_a_work': value.get('l'),
         'number_of_part_section_meeting': utils.force_list(
             value.get('n')
@@ -130,7 +166,10 @@ def series_statement_added_entry_corporate_name(self, key, value):
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
         ),
+        'title_of_a_work': value.get('t'),
         'affiliation': value.get('u'),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -138,47 +177,80 @@ def series_statement_added_entry_corporate_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'title_of_a_work': value.get('t'),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('series_statement_added_entry_meeting_name', '^411[10_2][10_]')
+@marc21.over('series_statement_added_entry_meeting_name', '^411[_012][_01]')
 @utils.for_each_value
 @utils.filter_values
 def series_statement_added_entry_meeting_name(self, key, value):
     """Series Statement/Added Entry Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
     indicator_map2 = {
-        "0": "Main entry not represented by pronoun",
-        "1": "Main entry represented by pronoun"}
+        '0': 'Main entry not represented by pronoun',
+        '1': 'Main entry represented by pronoun',
+    }
+
+    field_map = {
+        'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
+        'c': 'location_of_meeting',
+        'd': 'date_of_meeting',
+        'e': 'subordinate_unit',
+        'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
+        'k': 'form_subheading',
+        'l': 'language_of_a_work',
+        'n': 'number_of_part_section_meeting',
+        'p': 'name_of_part_section_of_a_work',
+        'q': 'name_of_meeting_following_jurisdiction_name_entry_element',
+        't': 'title_of_a_work',
+        'u': 'affiliation',
+        'v': 'volume_sequential_designation',
+        'x': 'international_standard_serial_number',
+        '4': 'relator_code',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_meeting_name_entry_element')
+    if key[4] in indicator_map2:
+        order.append('pronoun_represents_main_entry')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
         'location_of_meeting': value.get('c'),
+        'date_of_meeting': value.get('d'),
         'subordinate_unit': utils.force_list(
             value.get('e')
         ),
-        'date_of_meeting': value.get('d'),
-        'miscellaneous_information': value.get('g'),
         'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
         'form_subheading': utils.force_list(
             value.get('k')
         ),
-        'volume_sequential_designation': value.get('v'),
         'language_of_a_work': value.get('l'),
         'number_of_part_section_meeting': utils.force_list(
             value.get('n')
         ),
-        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
         ),
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'title_of_a_work': value.get('t'),
         'affiliation': value.get('u'),
+        'volume_sequential_designation': value.get('v'),
+        'international_standard_serial_number': value.get('x'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -186,13 +258,12 @@ def series_statement_added_entry_meeting_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'title_of_a_work': value.get('t'),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'pronoun_represents_main_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('series_statement_added_entry_title', '^440.[_1032547698]')
+@marc21.over('series_statement_added_entry_title', '^440_[_0-9]')
 @utils.for_each_value
 @utils.filter_values
 def series_statement_added_entry_title(self, key, value):
@@ -219,19 +290,19 @@ def series_statement_added_entry_title(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'title': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
+        ),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
         ),
         'volume_sequential_designation': value.get('v'),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
-        'authority_record_control_number_or_standard_number': utils.force_list(
-            value.get('0')
-        ),
         'bibliographic_record_control_number': utils.force_list(
             value.get('w')
+        ),
+        'international_standard_serial_number': value.get('x'),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
         ),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
@@ -241,25 +312,45 @@ def series_statement_added_entry_title(self, key, value):
     }
 
 
-@marc21.over('series_statement', '^490[10_].')
+@marc21.over('series_statement', '^490[01_]_')
 @utils.for_each_value
 @utils.filter_values
 def series_statement(self, key, value):
     """Series Statement."""
-    indicator_map1 = {"0": "Series not traced", "1": "Series traced"}
+    indicator_map1 = {
+        '0': 'Series not traced',
+        '1': 'Series traced',
+    }
+
+    field_map = {
+        'a': 'series_statement',
+        'l': 'library_of_congress_call_number',
+        'v': 'volume_sequential_designation',
+        'x': 'international_standard_serial_number',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('series_tracing_policy')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'series_statement': utils.force_list(
             value.get('a')
+        ),
+        'library_of_congress_call_number': value.get('l'),
+        'volume_sequential_designation': utils.force_list(
+            value.get('v')
         ),
         'international_standard_serial_number': utils.force_list(
             value.get('x')
         ),
-        'linkage': value.get('6'),
-        'library_of_congress_call_number': value.get('l'),
         'materials_specified': value.get('3'),
-        'volume_sequential_designation': utils.force_list(
-            value.get('v')
-        ),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),

--- a/dojson/contrib/to_marc21/fields/bd4xx.py
+++ b/dojson/contrib/to_marc21/fields/bd4xx.py
@@ -46,12 +46,6 @@ def reverse_series_statement_added_entry_personal_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_personal_name_entry_element')
-
-    if key[4] in indicator_map2:
-        order.append('pronoun_represents_main_entry')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('personal_name'),
@@ -94,13 +88,41 @@ def reverse_series_statement_added_entry_personal_name(self, key, value):
 def reverse_series_statement_added_entry_corporate_name(self, key, value):
     """Reverse - Series Statement/Added Entry-Corporate Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
     indicator_map2 = {
-        "Main entry not represented by pronoun": "0",
-        "Main entry represented by pronoun": "1"}
+        'Main entry not represented by pronoun': '0',
+        'Main entry represented by pronoun': '1',
+    }
+
+    field_map = {
+        'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
+        'subordinate_unit': 'b',
+        'location_of_meeting': 'c',
+        'date_of_meeting_or_treaty_signing': 'd',
+        'relator_term': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'volume_sequential_designation': 'v',
+        'international_standard_serial_number': 'x',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
         'x': value.get('international_standard_serial_number'),
         'c': value.get('location_of_meeting'),
@@ -142,13 +164,41 @@ def reverse_series_statement_added_entry_corporate_name(self, key, value):
 def reverse_series_statement_added_entry_meeting_name(self, key, value):
     """Reverse - Series Statement/Added Entry Meeting Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
     indicator_map2 = {
-        "Main entry not represented by pronoun": "0",
-        "Main entry represented by pronoun": "1"}
+        'Main entry not represented by pronoun': '0',
+        'Main entry represented by pronoun': '1',
+    }
+
+    field_map = {
+        'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
+        'location_of_meeting': 'c',
+        'date_of_meeting': 'd',
+        'subordinate_unit': 'e',
+        'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
+        'form_subheading': 'k',
+        'language_of_a_work': 'l',
+        'number_of_part_section_meeting': 'n',
+        'name_of_part_section_of_a_work': 'p',
+        'name_of_meeting_following_jurisdiction_name_entry_element': 'q',
+        'title_of_a_work': 't',
+        'affiliation': 'u',
+        'volume_sequential_designation': 'v',
+        'international_standard_serial_number': 'x',
+        'relator_code': '4',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
         'x': value.get('international_standard_serial_number'),
         'c': value.get('location_of_meeting'),
@@ -205,9 +255,6 @@ def reverse_series_statement_added_entry_title(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[4] in valid_nonfiling_characters:
-        order.append('nonfiling_characters')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('title'),
@@ -239,8 +286,25 @@ def reverse_series_statement_added_entry_title(self, key, value):
 @utils.filter_values
 def reverse_series_statement(self, key, value):
     """Reverse - Series Statement."""
-    indicator_map1 = {"Series not traced": "0", "Series traced": "1"}
+    indicator_map1 = {
+        'Series not traced': '0',
+        'Series traced': '1',
+    }
+
+    field_map = {
+        'series_statement': 'a',
+        'library_of_congress_call_number': 'l',
+        'volume_sequential_designation': 'v',
+        'international_standard_serial_number': 'x',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('series_statement')
         ),

--- a/tests/data/library_of_congress/bd4xx.xml
+++ b/tests/data/library_of_congress/bd4xx.xml
@@ -5,7 +5,6 @@
       <subfield code="a">Gyrowetz, Adalbert,</subfield>
       <subfield code="d">1763-1850.</subfield>
       <subfield code="t">Serenades,</subfield>
-      <subfield code="m">clarinets (2), horns (2), bassoon,</subfield>
       <subfield code="n">op. 5 (Hummel)</subfield>
     </datafield>
   </record>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,6 +45,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd20x24x.xml',
     'library_of_congress/bd25x28x.xml',
     'library_of_congress/bd3xx.xml',
+    'library_of_congress/bd4xx.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd4xx fields. (closes #95)
- Reaches 100% test coverage for bd4xx fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
