### PR TITLE
dojson: bd5xx field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd5xx.py
+++ b/dojson/contrib/marc21/fields/bd5xx.py
@@ -14,38 +14,59 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('general_note', '^500..')
+@marc21.over('general_note', '^500__')
 @utils.for_each_value
 @utils.filter_values
 def general_note(self, key, value):
     """General Note."""
+    field_map = {
+        'a': 'general_note',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'general_note': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('with_note', '^501..')
+@marc21.over('with_note', '^501__')
 @utils.for_each_value
 @utils.filter_values
 def with_note(self, key, value):
     """With Note."""
+    field_map = {
+        'a': 'with_note',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'with_note': value.get('a'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('dissertation_note', '^502..')
+@marc21.over('dissertation_note', '^502__')
 @utils.for_each_value
 @utils.filter_values
 def dissertation_note(self, key, value):
@@ -66,8 +87,8 @@ def dissertation_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'dissertation_note': value.get('a'),
-        'name_of_granting_institution': value.get('c'),
         'degree_type': value.get('b'),
+        'name_of_granting_institution': value.get('c'),
         'year_degree_granted': value.get('d'),
         'miscellaneous_information': utils.force_list(
             value.get('g')
@@ -82,33 +103,67 @@ def dissertation_note(self, key, value):
     }
 
 
-@marc21.over('bibliography_note', '^504..')
+@marc21.over('bibliography_note', '^504__')
 @utils.for_each_value
 @utils.filter_values
 def bibliography_note(self, key, value):
     """Bibliography, Etc. Note."""
+    field_map = {
+        'a': 'bibliography_note',
+        'b': 'number_of_references',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'bibliography_note': value.get('a'),
+        'number_of_references': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'number_of_references': value.get('b'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('formatted_contents_note', '^505[10_28][0_]')
+@marc21.over('formatted_contents_note', '^505[_0128][_0]')
 @utils.for_each_value
 @utils.filter_values
 def formatted_contents_note(self, key, value):
     """Formatted Contents Note."""
     indicator_map1 = {
-        "0": "Contents",
-        "1": "Incomplete contents",
-        "2": "Partial contents",
-        "8": "No display constant generated"}
-    indicator_map2 = {"#": "Basic", "0": "Enhanced"}
+        '0': 'Contents',
+        '1': 'Incomplete contents',
+        '2': 'Partial contents',
+        '8': 'No display constant generated',
+    }
+
+    indicator_map2 = {
+        '_': 'Basic',
+        '0': 'Enhanced',
+    }
+
+    field_map = {
+        'a': 'formatted_contents_note',
+        'g': 'miscellaneous_information',
+        'r': 'statement_of_responsibility',
+        't': 'title',
+        'u': 'uniform_resource_identifier',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+    if key[4] in indicator_map2:
+        order.append('level_of_content_designation')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'formatted_contents_note': value.get('a'),
         'miscellaneous_information': utils.force_list(
             value.get('g')
@@ -116,11 +171,11 @@ def formatted_contents_note(self, key, value):
         'statement_of_responsibility': utils.force_list(
             value.get('r')
         ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
         'title': utils.force_list(
             value.get('t')
+        ),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
         ),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
@@ -131,15 +186,16 @@ def formatted_contents_note(self, key, value):
     }
 
 
-@marc21.over('restrictions_on_access_note', '^506[10_].')
+@marc21.over('restrictions_on_access_note', '^506[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def restrictions_on_access_note(self, key, value):
     """Restrictions on Access Note."""
     indicator_map1 = {
-        "_": "No information provided",
-        "0": "No restrictions",
-        "1": "Restrictions apply"}
+        '_': 'No information provided',
+        '0': 'No restrictions',
+        '1': 'Restrictions apply',
+    }
 
     field_map = {
         'a': 'terms_governing_access',
@@ -164,83 +220,121 @@ def restrictions_on_access_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'terms_governing_access': value.get('a'),
-        'physical_access_provisions': utils.force_list(
-            value.get('c')
-        ),
         'jurisdiction': utils.force_list(
             value.get('b')
         ),
-        'authorization': utils.force_list(
-            value.get('e')
+        'physical_access_provisions': utils.force_list(
+            value.get('c')
         ),
         'authorized_users': utils.force_list(
             value.get('d')
         ),
+        'authorization': utils.force_list(
+            value.get('e')
+        ),
         'standardized_terminology_for_access_restriction': utils.force_list(
             value.get('f')
         ),
-        'materials_specified': value.get('3'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
         'restriction': indicator_map1.get(key[3], '_'),
     }
 
 
-@marc21.over('scale_note_for_graphic_material', '^507..')
+@marc21.over('scale_note_for_graphic_material', '^507__')
 @utils.filter_values
 def scale_note_for_graphic_material(self, key, value):
     """Scale Note for Graphic Material."""
+    field_map = {
+        'a': 'representative_fraction_of_scale_note',
+        'b': 'remainder_of_scale_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'representative_fraction_of_scale_note': value.get('a'),
+        'remainder_of_scale_note': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'remainder_of_scale_note': value.get('b'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('creation_production_credits_note', '^508..')
+@marc21.over('creation_production_credits_note', '^508__')
 @utils.for_each_value
 @utils.filter_values
 def creation_production_credits_note(self, key, value):
     """Creation/Production Credits Note."""
+    field_map = {
+        'a': 'creation_production_credits_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'creation_production_credits_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('citation_references_note', '^510[10324_].')
+@marc21.over('citation_references_note', '^510[_01234]_')
 @utils.for_each_value
 @utils.filter_values
 def citation_references_note(self, key, value):
     """Citation/References Note."""
     indicator_map1 = {
-        "0": "Coverage unknown",
-        "1": "Coverage complete",
-        "2": "Coverage is selective",
-        "3": "Location in source not given",
-        "4": "Location in source given"}
+        '0': 'Coverage unknown',
+        '1': 'Coverage complete',
+        '2': 'Coverage is selective',
+        '3': 'Location in source not given',
+        '4': 'Location in source given',
+    }
+
+    field_map = {
+        'a': 'name_of_source',
+        'b': 'coverage_of_source',
+        'c': 'location_within_source',
+        'u': 'uniform_resource_identifier',
+        'x': 'international_standard_serial_number',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('coverage_location_in_source')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'name_of_source': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'location_within_source': value.get('c'),
         'coverage_of_source': value.get('b'),
-        'materials_specified': value.get('3'),
+        'location_within_source': value.get('c'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'international_standard_serial_number': value.get('x'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -249,85 +343,142 @@ def citation_references_note(self, key, value):
     }
 
 
-@marc21.over('participant_or_performer_note', '^511[10_].')
+@marc21.over('participant_or_performer_note', '^511[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def participant_or_performer_note(self, key, value):
     """Participant or Performer Note."""
-    indicator_map1 = {"0": "No display constant generated", "1": "Cast"}
+    indicator_map1 = {
+        '0': 'No display constant generated',
+        '1': 'Cast',
+    }
+
+    field_map = {
+        'a': 'participant_or_performer_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'participant_or_performer_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('type_of_report_and_period_covered_note', '^513..')
+@marc21.over('type_of_report_and_period_covered_note', '^513__')
 @utils.for_each_value
 @utils.filter_values
 def type_of_report_and_period_covered_note(self, key, value):
     """Type of Report and Period Covered Note."""
+    field_map = {
+        'a': 'type_of_report',
+        'b': 'period_covered',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'type_of_report': value.get('a'),
+        'period_covered': value.get('b'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'period_covered': value.get('b'),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('data_quality_note', '^514..')
+@marc21.over('data_quality_note', '^514__')
 @utils.filter_values
 def data_quality_note(self, key, value):
     """Data Quality Note."""
+    field_map = {
+        'a': 'attribute_accuracy_report',
+        'b': 'attribute_accuracy_value',
+        'c': 'attribute_accuracy_explanation',
+        'd': 'logical_consistency_report',
+        'e': 'completeness_report',
+        'f': 'horizontal_position_accuracy_report',
+        'g': 'horizontal_position_accuracy_value',
+        'h': 'horizontal_position_accuracy_explanation',
+        'i': 'vertical_positional_accuracy_report',
+        'j': 'vertical_positional_accuracy_value',
+        'k': 'vertical_positional_accuracy_explanation',
+        'm': 'cloud_cover',
+        'u': 'uniform_resource_identifier',
+        'z': 'display_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'attribute_accuracy_report': value.get('a'),
-        'attribute_accuracy_explanation': utils.force_list(
-            value.get('c')
-        ),
         'attribute_accuracy_value': utils.force_list(
             value.get('b')
         ),
-        'completeness_report': value.get('e'),
+        'attribute_accuracy_explanation': utils.force_list(
+            value.get('c')
+        ),
         'logical_consistency_report': value.get('d'),
+        'completeness_report': value.get('e'),
+        'horizontal_position_accuracy_report': value.get('f'),
         'horizontal_position_accuracy_value': utils.force_list(
             value.get('g')
         ),
-        'horizontal_position_accuracy_report': value.get('f'),
-        'vertical_positional_accuracy_report': value.get('i'),
         'horizontal_position_accuracy_explanation': utils.force_list(
             value.get('h')
         ),
-        'vertical_positional_accuracy_explanation': utils.force_list(
-            value.get('k')
-        ),
+        'vertical_positional_accuracy_report': value.get('i'),
         'vertical_positional_accuracy_value': utils.force_list(
             value.get('j')
+        ),
+        'vertical_positional_accuracy_explanation': utils.force_list(
+            value.get('k')
         ),
         'cloud_cover': value.get('m'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'display_note': utils.force_list(
+            value.get('z')
+        ),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'display_note': utils.force_list(
-            value.get('z')
-        ),
     }
 
 
-@marc21.over('numbering_peculiarities_note', '^515..')
+@marc21.over('numbering_peculiarities_note', '^515__')
 @utils.for_each_value
 @utils.filter_values
 def numbering_peculiarities_note(self, key, value):
     """Numbering Peculiarities Note."""
+    field_map = {
+        'a': 'numbering_peculiarities_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'numbering_peculiarities_note': value.get('a'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -336,47 +487,76 @@ def numbering_peculiarities_note(self, key, value):
     }
 
 
-@marc21.over('type_of_computer_file_or_data_note', '^516[8_].')
+@marc21.over('type_of_computer_file_or_data_note', '^516[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def type_of_computer_file_or_data_note(self, key, value):
     """Type of Computer File or Data Note."""
     indicator_map1 = {
-        "#": "Type of file",
-        "8": "No display constant generated"}
+        '_': 'Type of file',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'type_of_computer_file_or_data_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'type_of_computer_file_or_data_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('date_time_and_place_of_an_event_note', '^518..')
+@marc21.over('date_time_and_place_of_an_event_note', '^518__')
 @utils.for_each_value
 @utils.filter_values
 def date_time_and_place_of_an_event_note(self, key, value):
     """Date/Time and Place of an Event Note."""
+    field_map = {
+        'a': 'date_time_and_place_of_an_event_note',
+        'd': 'date_of_event',
+        'o': 'other_event_information',
+        'p': 'place_of_event',
+        '0': 'record_control_number',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'date_time_and_place_of_an_event_note': value.get('a'),
         'date_of_event': utils.force_list(
             value.get('d')
         ),
-        'place_of_event': utils.force_list(
-            value.get('p')
-        ),
         'other_event_information': utils.force_list(
             value.get('o')
+        ),
+        'place_of_event': utils.force_list(
+            value.get('p')
         ),
         'record_control_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_term': utils.force_list(
             value.get('2')
         ),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -384,28 +564,47 @@ def date_time_and_place_of_an_event_note(self, key, value):
     }
 
 
-@marc21.over('summary', '^520[10_2483].')
+@marc21.over('summary', '^520[_012348]_')
 @utils.for_each_value
 @utils.filter_values
 def summary(self, key, value):
     """Summary, Etc.."""
     indicator_map1 = {
-        "#": "Summary",
-        "0": "Subject",
-        "1": "Review",
-        "2": "Scope and content",
-        "3": "Abstract",
-        "4": "Content advice",
-        "8": "No display constant generated"}
+        '_': 'Summary',
+        '0': 'Subject',
+        '1': 'Review',
+        '2': 'Scope and content',
+        '3': 'Abstract',
+        '4': 'Content advice',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'summary',
+        'b': 'expansion_of_summary_note',
+        'c': 'assigning_source',
+        'u': 'uniform_resource_identifier',
+        '2': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'summary': value.get('a'),
-        'assigning_source': value.get('c'),
         'expansion_of_summary_note': value.get('b'),
-        'materials_specified': value.get('3'),
-        'source': value.get('2'),
+        'assigning_source': value.get('c'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'source': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -414,91 +613,148 @@ def summary(self, key, value):
     }
 
 
-@marc21.over('target_audience_note', '^521[10_2483].')
+@marc21.over('target_audience_note', '^521[_012348]_')
 @utils.for_each_value
 @utils.filter_values
 def target_audience_note(self, key, value):
     """Target Audience Note."""
     indicator_map1 = {
-        "#": "Audience",
-        "0": "Reading grade level",
-        "1": "Interest age level",
-        "2": "Interest grade level",
-        "3": "Special audience characteristics",
-        "4": "Motivation/interest level",
-        "8": "No display constant generated"}
+        '_': 'Audience',
+        '0': 'Reading grade level',
+        '1': 'Interest age level',
+        '2': 'Interest grade level',
+        '3': 'Special audience characteristics',
+        '4': 'Motivation/interest level',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'target_audience_note',
+        'b': 'source',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'target_audience_note': utils.force_list(
             value.get('a')
         ),
+        'source': value.get('b'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'materials_specified': value.get('3'),
-        'source': value.get('b'),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('geographic_coverage_note', '^522[8_].')
+@marc21.over('geographic_coverage_note', '^522[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def geographic_coverage_note(self, key, value):
     """Geographic Coverage Note."""
     indicator_map1 = {
-        "#": "Geographic coverage",
-        "8": "No display constant generated"}
+        '_': 'Geographic coverage',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'geographic_coverage_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'geographic_coverage_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('preferred_citation_of_described_materials_note', '^524[8_].')
+@marc21.over('preferred_citation_of_described_materials_note', '^524[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def preferred_citation_of_described_materials_note(self, key, value):
     """Preferred Citation of Described Materials Note."""
-    indicator_map1 = {"#": "Cite as", "8": "No display constant generated"}
+    indicator_map1 = {
+        '_': 'Cite as',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'preferred_citation_of_described_materials_note',
+        '2': 'source_of_schema_used',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'preferred_citation_of_described_materials_note': value.get('a'),
+        'source_of_schema_used': value.get('2'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'materials_specified': value.get('3'),
-        'source_of_schema_used': value.get('2'),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('supplement_note', '^525..')
+@marc21.over('supplement_note', '^525__')
 @utils.for_each_value
 @utils.filter_values
 def supplement_note(self, key, value):
     """Supplement Note."""
+    field_map = {
+        'a': 'supplement_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'supplement_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('study_program_information_note', '^526[0_8].')
+@marc21.over('study_program_information_note', '^526[_08]_')
 @utils.for_each_value
 @utils.filter_values
 def study_program_information_note(self, key, value):
     """Study Program Information Note."""
     indicator_map1 = {
-        "0": "Reading program",
-        "8": "No display constant generated",
+        '0': 'Reading program',
+        '8': 'No display constant generated',
     }
 
     field_map = {
@@ -522,26 +778,26 @@ def study_program_information_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'program_name': value.get('a'),
+        'interest_level': value.get('b'),
+        'reading_level': value.get('c'),
+        'title_point_value': value.get('d'),
+        'display_text': value.get('i'),
         'nonpublic_note': utils.force_list(
             value.get('x')
         ),
-        'reading_level': value.get('c'),
-        'interest_level': value.get('b'),
-        'title_point_value': value.get('d'),
-        'display_text': value.get('i'),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'public_note': utils.force_list(
-            value.get('z')
-        ),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('additional_physical_form_available_note', '^530..')
+@marc21.over('additional_physical_form_available_note', '^530__')
 @utils.for_each_value
 @utils.filter_values
 def additional_physical_form_available_note(self, key, value):
@@ -562,13 +818,13 @@ def additional_physical_form_available_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'additional_physical_form_available_note': value.get('a'),
-        'availability_conditions': value.get('c'),
         'availability_source': value.get('b'),
+        'availability_conditions': value.get('c'),
         'order_number': value.get('d'),
-        'materials_specified': value.get('3'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -576,7 +832,7 @@ def additional_physical_form_available_note(self, key, value):
     }
 
 
-@marc21.over('reproduction_note', '^533..')
+@marc21.over('reproduction_note', '^533__')
 @utils.for_each_value
 @utils.filter_values
 def reproduction_note(self, key, value):
@@ -602,14 +858,14 @@ def reproduction_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'type_of_reproduction': value.get('a'),
-        'agency_responsible_for_reproduction': utils.force_list(
-            value.get('c')
-        ),
         'place_of_reproduction': utils.force_list(
             value.get('b')
         ),
-        'physical_description_of_reproduction': value.get('e'),
+        'agency_responsible_for_reproduction': utils.force_list(
+            value.get('c')
+        ),
         'date_of_reproduction': value.get('d'),
+        'physical_description_of_reproduction': value.get('e'),
         'series_statement_of_reproduction': utils.force_list(
             value.get('f')
         ),
@@ -621,15 +877,15 @@ def reproduction_note(self, key, value):
         ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
-        'fixed_length_data_elements_of_reproduction': value.get('7'),
         'linkage': value.get('6'),
+        'fixed_length_data_elements_of_reproduction': value.get('7'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
     }
 
 
-@marc21.over('original_version_note', '^534..')
+@marc21.over('original_version_note', '^534__')
 @utils.for_each_value
 @utils.filter_values
 def original_version_note(self, key, value):
@@ -659,11 +915,8 @@ def original_version_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'main_entry_of_original': value.get('a'),
-        'international_standard_serial_number': utils.force_list(
-            value.get('x')
-        ),
-        'publication_distribution_of_original': value.get('c'),
         'edition_statement_of_original': value.get('b'),
+        'publication_distribution_of_original': value.get('c'),
         'physical_description_of_original': value.get('e'),
         'series_statement_of_original': utils.force_list(
             value.get('f')
@@ -671,40 +924,64 @@ def original_version_note(self, key, value):
         'key_title_of_original': utils.force_list(
             value.get('k')
         ),
-        'material_specific_details': value.get('m'),
         'location_of_original': value.get('l'),
-        'other_resource_identifier': utils.force_list(
-            value.get('o')
-        ),
+        'material_specific_details': value.get('m'),
         'note_about_original': utils.force_list(
             value.get('n')
+        ),
+        'other_resource_identifier': utils.force_list(
+            value.get('o')
         ),
         'introductory_phrase': value.get('p'),
         'materials_specified': value.get('3'),
         'title_statement_of_original': value.get('t'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
+        'international_standard_serial_number': utils.force_list(
+            value.get('x')
         ),
         'international_standard_book_number': utils.force_list(
             value.get('z')
         ),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('location_of_originals_duplicates_note', '^535[1_2].')
+@marc21.over('location_of_originals_duplicates_note', '^535[_12]_')
 @utils.for_each_value
 @utils.filter_values
 def location_of_originals_duplicates_note(self, key, value):
     """Location of Originals/Duplicates Note."""
-    indicator_map1 = {"1": "Holder of originals", "2": "Holder of duplicates"}
+    indicator_map1 = {
+        '1': 'Holder of originals',
+        '2': 'Holder of duplicates',
+    }
+
+    field_map = {
+        'a': 'custodian',
+        'b': 'postal_address',
+        'c': 'country',
+        'd': 'telecommunications_address',
+        'g': 'repository_location_code',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('custodial_role')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'custodian': value.get('a'),
-        'country': utils.force_list(
-            value.get('c')
-        ),
         'postal_address': utils.force_list(
             value.get('b')
+        ),
+        'country': utils.force_list(
+            value.get('c')
         ),
         'telecommunications_address': utils.force_list(
             value.get('d')
@@ -719,7 +996,7 @@ def location_of_originals_duplicates_note(self, key, value):
     }
 
 
-@marc21.over('funding_information_note', '^536..')
+@marc21.over('funding_information_note', '^536__')
 @utils.for_each_value
 @utils.filter_values
 def funding_information_note(self, key, value):
@@ -742,23 +1019,23 @@ def funding_information_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'text_of_note': value.get('a'),
-        'grant_number': utils.force_list(
-            value.get('c')
-        ),
         'contract_number': utils.force_list(
             value.get('b')
         ),
-        'program_element_number': utils.force_list(
-            value.get('e')
+        'grant_number': utils.force_list(
+            value.get('c')
         ),
         'undifferentiated_number': utils.force_list(
             value.get('d')
         ),
-        'task_number': utils.force_list(
-            value.get('g')
+        'program_element_number': utils.force_list(
+            value.get('e')
         ),
         'project_number': utils.force_list(
             value.get('f')
+        ),
+        'task_number': utils.force_list(
+            value.get('g')
         ),
         'work_unit_number': utils.force_list(
             value.get('h')
@@ -770,14 +1047,30 @@ def funding_information_note(self, key, value):
     }
 
 
-@marc21.over('system_details_note', '^538..')
+@marc21.over('system_details_note', '^538__')
 @utils.for_each_value
 @utils.filter_values
 def system_details_note(self, key, value):
     """System Details Note."""
+    field_map = {
+        'a': 'system_details_note',
+        'i': 'display_text',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'system_details_note': value.get('a'),
         'display_text': value.get('i'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': utils.force_list(
             value.get('5')
@@ -786,71 +1079,92 @@ def system_details_note(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
     }
 
 
-@marc21.over('terms_governing_use_and_reproduction_note', '^540..')
+@marc21.over('terms_governing_use_and_reproduction_note', '^540__')
 @utils.for_each_value
 @utils.filter_values
 def terms_governing_use_and_reproduction_note(self, key, value):
     """Terms Governing Use and Reproduction Note."""
     field_map = {
         'a': 'terms_governing_use_and_reproduction',
-        'c': 'authorization',
         'b': 'jurisdiction',
+        'c': 'authorization',
         'd': 'authorized_users',
+        'u': 'uniform_resource_identifier',
         '3': 'materials_specified',
         '5': 'institution_to_which_field_applies',
         '6': 'linkage',
         '8': 'field_link_and_sequence_number',
-        'u': 'uniform_resource_identifier',
     }
 
     order = utils.map_order(field_map, value)
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'terms_governing_use_and_reproduction': value.get('a'),
-        'authorization': value.get('c'),
         'jurisdiction': value.get('b'),
+        'authorization': value.get('c'),
         'authorized_users': value.get('d'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
-        '__order__': tuple(order) if len(order) else None
     }
 
 
-@marc21.over('immediate_source_of_acquisition_note', '^541[10_].')
+@marc21.over('immediate_source_of_acquisition_note', '^541[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def immediate_source_of_acquisition_note(self, key, value):
     """Immediate Source of Acquisition Note."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Private",
-        "1": "Not private"}
+        '_': 'No information provided',
+        '0': 'Private',
+        '1': 'Not private',
+    }
+
+    field_map = {
+        'a': 'source_of_acquisition',
+        'b': 'address',
+        'c': 'method_of_acquisition',
+        'd': 'date_of_acquisition',
+        'e': 'accession_number',
+        'f': 'owner',
+        'h': 'purchase_price',
+        'n': 'extent',
+        'o': 'type_of_unit',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('privacy')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'source_of_acquisition': value.get('a'),
-        'method_of_acquisition': value.get('c'),
         'address': value.get('b'),
-        'accession_number': value.get('e'),
+        'method_of_acquisition': value.get('c'),
         'date_of_acquisition': value.get('d'),
+        'accession_number': value.get('e'),
         'owner': value.get('f'),
         'purchase_price': value.get('h'),
-        'type_of_unit': utils.force_list(
-            value.get('o')
-        ),
         'extent': utils.force_list(
             value.get('n')
+        ),
+        'type_of_unit': utils.force_list(
+            value.get('o')
         ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
@@ -862,85 +1176,139 @@ def immediate_source_of_acquisition_note(self, key, value):
     }
 
 
-@marc21.over('information_relating_to_copyright_status', '^542[10_].')
+@marc21.over('information_relating_to_copyright_status', '^542[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def information_relating_to_copyright_status(self, key, value):
     """Information Relating to Copyright Status."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Private",
-        "1": "Not private"}
+        '_': 'No information provided',
+        '0': 'Private',
+        '1': 'Not private',
+    }
+
+    field_map = {
+        'a': 'personal_creator',
+        'b': 'personal_creator_death_date',
+        'c': 'corporate_creator',
+        'd': 'copyright_holder',
+        'e': 'copyright_holder_contact_information',
+        'f': 'copyright_statement',
+        'g': 'copyright_date',
+        'h': 'copyright_renewal_date',
+        'i': 'publication_date',
+        'j': 'creation_date',
+        'k': 'publisher',
+        'l': 'copyright_status',
+        'm': 'publication_status',
+        'n': 'note',
+        'o': 'research_date',
+        'p': 'country_of_publication_or_creation',
+        'q': 'supplying_agency',
+        'r': 'jurisdiction_of_copyright_assessment',
+        's': 'source_of_information',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('privacy')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
+        'personal_creator': value.get('a'),
+        'personal_creator_death_date': value.get('b'),
+        'corporate_creator': value.get('c'),
+        'copyright_holder': utils.force_list(
+            value.get('d')
+        ),
+        'copyright_holder_contact_information': utils.force_list(
+            value.get('e')
+        ),
+        'copyright_statement': utils.force_list(
+            value.get('f')
+        ),
+        'copyright_date': value.get('g'),
+        'copyright_renewal_date': utils.force_list(
+            value.get('h')
+        ),
+        'publication_date': value.get('i'),
+        'creation_date': value.get('j'),
+        'publisher': utils.force_list(
+            value.get('k')
+        ),
+        'copyright_status': value.get('l'),
+        'publication_status': value.get('m'),
+        'note': utils.force_list(
+            value.get('n')
+        ),
+        'research_date': value.get('o'),
+        'country_of_publication_or_creation': utils.force_list(
+            value.get('p')
+        ),
+        'supplying_agency': value.get('q'),
+        'jurisdiction_of_copyright_assessment': value.get('r'),
+        'source_of_information': value.get('s'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'personal_creator': value.get('a'),
-        'corporate_creator': value.get('c'),
-        'personal_creator_death_date': value.get('b'),
-        'copyright_holder_contact_information': utils.force_list(
-            value.get('e')
-        ),
-        'copyright_holder': utils.force_list(
-            value.get('d')
-        ),
-        'copyright_date': value.get('g'),
-        'copyright_statement': utils.force_list(
-            value.get('f')
-        ),
-        'publication_date': value.get('i'),
-        'copyright_renewal_date': utils.force_list(
-            value.get('h')
-        ),
-        'publisher': utils.force_list(
-            value.get('k')
-        ),
-        'creation_date': value.get('j'),
-        'publication_status': value.get('m'),
-        'copyright_status': value.get('l'),
-        'research_date': value.get('o'),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'supplying_agency': value.get('q'),
-        'country_of_publication_or_creation': utils.force_list(
-            value.get('p')
-        ),
-        'source_of_information': value.get('s'),
-        'jurisdiction_of_copyright_assessment': value.get('r'),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
         'privacy': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('location_of_other_archival_materials_note', '^544[10_].')
+@marc21.over('location_of_other_archival_materials_note', '^544[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def location_of_other_archival_materials_note(self, key, value):
     """Location of Other Archival Materials Note."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Associated materials",
-        "1": "Related materials"}
+        '_': 'No information provided',
+        '0': 'Associated materials',
+        '1': 'Related materials',
+    }
+
+    field_map = {
+        'a': 'custodian',
+        'b': 'address',
+        'c': 'country',
+        'd': 'title',
+        'e': 'provenance',
+        'n': 'note',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('relationship')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'custodian': utils.force_list(
             value.get('a')
-        ),
-        'country': utils.force_list(
-            value.get('c')
         ),
         'address': utils.force_list(
             value.get('b')
         ),
-        'provenance': utils.force_list(
-            value.get('e')
+        'country': utils.force_list(
+            value.get('c')
         ),
         'title': utils.force_list(
             value.get('d')
+        ),
+        'provenance': utils.force_list(
+            value.get('e')
         ),
         'note': utils.force_list(
             value.get('n')
@@ -954,62 +1322,98 @@ def location_of_other_archival_materials_note(self, key, value):
     }
 
 
-@marc21.over('biographical_or_historical_data', '^545[10_].')
+@marc21.over('biographical_or_historical_data', '^545[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def biographical_or_historical_data(self, key, value):
     """Biographical or Historical Data."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Biographical sketch",
-        "1": "Administrative history"}
+        '_': 'No information provided',
+        '0': 'Biographical sketch',
+        '1': 'Administrative history',
+    }
+
+    field_map = {
+        'a': 'biographical_or_historical_data',
+        'b': 'expansion',
+        'u': 'uniform_resource_identifier',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('type_of_data')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'biographical_or_historical_data': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'expansion': value.get('b'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'type_of_data': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('language_note', '^546..')
+@marc21.over('language_note', '^546__')
 @utils.for_each_value
 @utils.filter_values
 def language_note(self, key, value):
     """Language Note."""
+    field_map = {
+        'a': 'language_note',
+        'b': 'information_code_or_alphabet',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'language_note': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'materials_specified': value.get('3'),
         'information_code_or_alphabet': utils.force_list(
             value.get('b')
         ),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('former_title_complexity_note', '^547..')
+@marc21.over('former_title_complexity_note', '^547__')
 @utils.for_each_value
 @utils.filter_values
 def former_title_complexity_note(self, key, value):
     """Former Title Complexity Note."""
+    field_map = {
+        'a': 'former_title_complexity_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'former_title_complexity_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('issuing_body_note', '^550..')
+@marc21.over('issuing_body_note', '^550__')
 @utils.for_each_value
 @utils.filter_values
 def issuing_body_note(self, key, value):
@@ -1025,76 +1429,121 @@ def issuing_body_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'issuing_body_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('entity_and_attribute_information_note', '^552..')
+@marc21.over('entity_and_attribute_information_note', '^552__')
 @utils.for_each_value
 @utils.filter_values
 def entity_and_attribute_information_note(self, key, value):
     """Entity and Attribute Information Note."""
+    field_map = {
+        'a': 'entity_type_label',
+        'b': 'entity_type_definition_and_source',
+        'c': 'attribute_label',
+        'd': 'attribute_definition_and_source',
+        'e': 'enumerated_domain_value',
+        'f': 'enumerated_domain_value_definition_and_source',
+        'g': 'range_domain_minimum_and_maximum',
+        'h': 'codeset_name_and_source',
+        'i': 'unrepresentable_domain',
+        'j': 'attribute_units_of_measurement_and_resolution',
+        'k': 'beginning_and_ending_date_of_attribute_values',
+        'l': 'attribute_value_accuracy',
+        'm': 'attribute_value_accuracy_explanation',
+        'n': 'attribute_measurement_frequency',
+        'o': 'entity_and_attribute_overview',
+        'p': 'entity_and_attribute_detail_citation',
+        'u': 'uniform_resource_identifier',
+        'z': 'display_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'entity_type_label': value.get('a'),
-        'attribute_label': value.get('c'),
         'entity_type_definition_and_source': value.get('b'),
+        'attribute_label': value.get('c'),
+        'attribute_definition_and_source': value.get('d'),
         'enumerated_domain_value': utils.force_list(
             value.get('e')
         ),
-        'attribute_definition_and_source': value.get('d'),
-        'range_domain_minimum_and_maximum': value.get('g'),
         'enumerated_domain_value_definition_and_source': utils.force_list(
             value.get('f')
         ),
-        'unrepresentable_domain': value.get('i'),
+        'range_domain_minimum_and_maximum': value.get('g'),
         'codeset_name_and_source': value.get('h'),
-        'beginning_and_ending_date_of_attribute_values': value.get('k'),
+        'unrepresentable_domain': value.get('i'),
         'attribute_units_of_measurement_and_resolution': value.get('j'),
-        'attribute_value_accuracy_explanation': value.get('m'),
+        'beginning_and_ending_date_of_attribute_values': value.get('k'),
         'attribute_value_accuracy': value.get('l'),
+        'attribute_value_accuracy_explanation': value.get('m'),
+        'attribute_measurement_frequency': value.get('n'),
         'entity_and_attribute_overview': utils.force_list(
             value.get('o')
         ),
-        'attribute_measurement_frequency': value.get('n'),
         'entity_and_attribute_detail_citation': utils.force_list(
             value.get('p')
         ),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'display_note': utils.force_list(
+            value.get('z')
+        ),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'display_note': utils.force_list(
-            value.get('z')
-        ),
     }
 
 
-@marc21.over('cumulative_index_finding_aids_note', '^555[0_8].')
+@marc21.over('cumulative_index_finding_aids_note', '^555[_08]_')
 @utils.for_each_value
 @utils.filter_values
 def cumulative_index_finding_aids_note(self, key, value):
     """Cumulative Index/Finding Aids Note."""
     indicator_map1 = {
-        "#": "Indexes",
-        "0": "Finding aids",
-        "8": "No display constant generated"}
+        '_': 'Indexes',
+        '0': 'Finding aids',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'cumulative_index_finding_aids_note',
+        'b': 'availability_source',
+        'c': 'degree_of_control',
+        'd': 'bibliographic_reference',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'cumulative_index_finding_aids_note': value.get('a'),
-        'degree_of_control': value.get('c'),
         'availability_source': utils.force_list(
             value.get('b')
         ),
+        'degree_of_control': value.get('c'),
         'bibliographic_reference': value.get('d'),
-        'materials_specified': value.get('3'),
         'uniform_resource_identifier': utils.force_list(
             value.get('u')
         ),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -1103,72 +1552,119 @@ def cumulative_index_finding_aids_note(self, key, value):
     }
 
 
-@marc21.over('information_about_documentation_note', '^556[8_].')
+@marc21.over('information_about_documentation_note', '^556[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def information_about_documentation_note(self, key, value):
     """Information About Documentation Note."""
     indicator_map1 = {
-        "#": "Documentation",
-        "8": "No display constant generated"}
+        '_': 'Documentation',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'information_about_documentation_note',
+        'z': 'international_standard_book_number',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'information_about_documentation_note': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'international_standard_book_number': utils.force_list(
             value.get('z')
         ),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('ownership_and_custodial_history', '^561[10_].')
+@marc21.over('ownership_and_custodial_history', '^561[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def ownership_and_custodial_history(self, key, value):
     """Ownership and Custodial History."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Private",
-        "1": "Not private"}
+        '_': 'No information provided',
+        '0': 'Private',
+        '1': 'Not private',
+    }
+
+    field_map = {
+        'a': 'history',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('privacy')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'history': value.get('a'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
         ),
         'privacy': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('copy_and_version_identification_note', '^562..')
+@marc21.over('copy_and_version_identification_note', '^562__')
 @utils.for_each_value
 @utils.filter_values
 def copy_and_version_identification_note(self, key, value):
     """Copy and Version Identification Note."""
+    field_map = {
+        'a': 'identifying_markings',
+        'b': 'copy_identification',
+        'c': 'version_identification',
+        'd': 'presentation_format',
+        'e': 'number_of_copies',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'identifying_markings': utils.force_list(
             value.get('a')
-        ),
-        'version_identification': utils.force_list(
-            value.get('c')
         ),
         'copy_identification': utils.force_list(
             value.get('b')
         ),
-        'number_of_copies': utils.force_list(
-            value.get('e')
+        'version_identification': utils.force_list(
+            value.get('c')
         ),
         'presentation_format': utils.force_list(
             value.get('d')
         ),
+        'number_of_copies': utils.force_list(
+            value.get('e')
+        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
@@ -1178,47 +1674,78 @@ def copy_and_version_identification_note(self, key, value):
     }
 
 
-@marc21.over('binding_information', '^563..')
+@marc21.over('binding_information', '^563__')
 @utils.for_each_value
 @utils.filter_values
 def binding_information(self, key, value):
     """Binding Information."""
+    field_map = {
+        'a': 'binding_note',
+        'u': 'uniform_resource_identifier',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'binding_note': value.get('a'),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
     }
 
 
-@marc21.over('case_file_characteristics_note', '^565[0_8].')
+@marc21.over('case_file_characteristics_note', '^565[_08]_')
 @utils.for_each_value
 @utils.filter_values
 def case_file_characteristics_note(self, key, value):
     """Case File Characteristics Note."""
     indicator_map1 = {
-        "#": "File size",
-        "0": "Case file characteristics",
-        "8": "No display constant generated"}
+        '_': 'File size',
+        '0': 'Case file characteristics',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'number_of_cases_variables',
+        'b': 'name_of_variable',
+        'c': 'unit_of_analysis',
+        'd': 'universe_of_data',
+        'e': 'filing_scheme_or_code',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'number_of_cases_variables': value.get('a'),
-        'unit_of_analysis': utils.force_list(
-            value.get('c')
-        ),
         'name_of_variable': utils.force_list(
             value.get('b')
         ),
-        'filing_scheme_or_code': utils.force_list(
-            value.get('e')
+        'unit_of_analysis': utils.force_list(
+            value.get('c')
         ),
         'universe_of_data': utils.force_list(
             value.get('d')
+        ),
+        'filing_scheme_or_code': utils.force_list(
+            value.get('e')
         ),
         'materials_specified': value.get('3'),
         'linkage': value.get('6'),
@@ -1229,131 +1756,216 @@ def case_file_characteristics_note(self, key, value):
     }
 
 
-@marc21.over('methodology_note', '^567[8_].')
+@marc21.over('methodology_note', '^567[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def methodology_note(self, key, value):
     """Methodology Note."""
-    indicator_map1 = {"#": "Methodology", "8": "No display constant generated"}
+    indicator_map1 = {
+        '_': 'Methodology',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'methodology_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'methodology_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('linking_entry_complexity_note', '^580..')
+@marc21.over('linking_entry_complexity_note', '^580__')
 @utils.for_each_value
 @utils.filter_values
 def linking_entry_complexity_note(self, key, value):
     """Linking Entry Complexity Note."""
+    field_map = {
+        'a': 'linking_entry_complexity_note',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'linking_entry_complexity_note': value.get('a'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
     }
 
 
-@marc21.over('publications_about_described_materials_note', '^581[8_].')
+@marc21.over('publications_about_described_materials_note', '^581[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def publications_about_described_materials_note(self, key, value):
     """Publications About Described Materials Note."""
     indicator_map1 = {
-        "#": "Publications",
-        "8": "No display constant generated"}
+        '_': 'Publications',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'publications_about_described_materials_note',
+        'z': 'international_standard_book_number',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'publications_about_described_materials_note': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'materials_specified': value.get('3'),
         'international_standard_book_number': utils.force_list(
             value.get('z')
         ),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('action_note', '^583[10_].')
+@marc21.over('action_note', '^583[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def action_note(self, key, value):
     """Action Note."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Private",
-        "1": "Not private"}
+        '_': 'No information provided',
+        '0': 'Private',
+        '1': 'Not private',
+    }
+
+    field_map = {
+        'a': 'action',
+        'b': 'action_identification',
+        'c': 'time_date_of_action',
+        'd': 'action_interval',
+        'e': 'contingency_for_action',
+        'f': 'authorization',
+        'h': 'jurisdiction',
+        'i': 'method_of_action',
+        'j': 'site_of_action',
+        'k': 'action_agent',
+        'l': 'status',
+        'n': 'extent',
+        'o': 'type_of_unit',
+        'u': 'uniform_resource_identifier',
+        'x': 'nonpublic_note',
+        'z': 'public_note',
+        '2': 'source_of_term',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('privacy')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'action': value.get('a'),
-        'nonpublic_note': utils.force_list(
-            value.get('x')
+        'action_identification': utils.force_list(
+            value.get('b')
         ),
         'time_date_of_action': utils.force_list(
             value.get('c')
         ),
-        'action_identification': utils.force_list(
-            value.get('b')
+        'action_interval': utils.force_list(
+            value.get('d')
         ),
         'contingency_for_action': utils.force_list(
             value.get('e')
         ),
-        'action_interval': utils.force_list(
-            value.get('d')
-        ),
         'authorization': utils.force_list(
             value.get('f')
-        ),
-        'method_of_action': utils.force_list(
-            value.get('i')
         ),
         'jurisdiction': utils.force_list(
             value.get('h')
         ),
-        'action_agent': utils.force_list(
-            value.get('k')
+        'method_of_action': utils.force_list(
+            value.get('i')
         ),
         'site_of_action': utils.force_list(
             value.get('j')
         ),
+        'action_agent': utils.force_list(
+            value.get('k')
+        ),
         'status': utils.force_list(
             value.get('l')
-        ),
-        'type_of_unit': utils.force_list(
-            value.get('o')
         ),
         'extent': utils.force_list(
             value.get('n')
         ),
-        'materials_specified': value.get('3'),
+        'type_of_unit': utils.force_list(
+            value.get('o')
+        ),
+        'uniform_resource_identifier': utils.force_list(
+            value.get('u')
+        ),
+        'nonpublic_note': utils.force_list(
+            value.get('x')
+        ),
+        'public_note': utils.force_list(
+            value.get('z')
+        ),
         'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'public_note': utils.force_list(
-            value.get('z')
-        ),
-        'uniform_resource_identifier': utils.force_list(
-            value.get('u')
-        ),
         'privacy': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('accumulation_and_frequency_of_use_note', '^584..')
+@marc21.over('accumulation_and_frequency_of_use_note', '^584__')
 @utils.for_each_value
 @utils.filter_values
 def accumulation_and_frequency_of_use_note(self, key, value):
     """Accumulation and Frequency of Use Note."""
+    field_map = {
+        'a': 'accumulation',
+        'b': 'frequency_of_use',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'accumulation': utils.force_list(
             value.get('a')
         ),
@@ -1369,46 +1981,74 @@ def accumulation_and_frequency_of_use_note(self, key, value):
     }
 
 
-@marc21.over('exhibitions_note', '^585..')
+@marc21.over('exhibitions_note', '^585__')
 @utils.for_each_value
 @utils.filter_values
 def exhibitions_note(self, key, value):
     """Exhibitions Note."""
+    field_map = {
+        'a': 'exhibitions_note',
+        '3': 'materials_specified',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'exhibitions_note': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('awards_note', '^586[8_].')
+@marc21.over('awards_note', '^586[_8]_')
 @utils.for_each_value
 @utils.filter_values
 def awards_note(self, key, value):
     """Awards Note."""
-    indicator_map1 = {"#": "Awards", "8": "No display constant generated"}
+    indicator_map1 = {
+        '_': 'Awards',
+        '8': 'No display constant generated',
+    }
+
+    field_map = {
+        'a': 'awards_note',
+        '3': 'materials_specified',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
+    }
+
+    order = utils.map_order(field_map, value)
+
+    if key[3] in indicator_map1:
+        order.append('display_constant_controller')
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'awards_note': value.get('a'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'materials_specified': value.get('3'),
-        'linkage': value.get('6'),
         'display_constant_controller': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('source_of_description_note', '^588..')
+@marc21.over('source_of_description_note', '^588[_01]_')
 @utils.for_each_value
 @utils.filter_values
 def source_of_description_note(self, key, value):
     """Source of Description Note."""
     indicator_map1 = {
-        '#': 'No information provided',
+        '_': 'No information provided',
         '0': 'Source of description',
         '1': 'Latest issue consulted',
     }
@@ -1428,10 +2068,10 @@ def source_of_description_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'source_of_description_note': value.get('a'),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'institution_to_which_field_applies': value.get('5'),
-        'linkage': value.get('6'),
-        'display_constant_controller': indicator_map1.get(key[3], '_')
+        'display_constant_controller': indicator_map1.get(key[3])
     }

--- a/dojson/contrib/to_marc21/fields/bd5xx.py
+++ b/dojson/contrib/to_marc21/fields/bd5xx.py
@@ -19,14 +19,25 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_general_note(self, key, value):
     """Reverse - General Note."""
+    field_map = {
+        'general_note': 'a',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('general_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -37,13 +48,23 @@ def reverse_general_note(self, key, value):
 @utils.filter_values
 def reverse_with_note(self, key, value):
     """Reverse - With Note."""
+    field_map = {
+        'with_note': 'a',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('with_note'),
+        '5': value.get('institution_to_which_field_applies'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '5': value.get('institution_to_which_field_applies'),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -70,8 +91,8 @@ def reverse_dissertation_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('dissertation_note'),
-        'c': value.get('name_of_granting_institution'),
         'b': value.get('degree_type'),
+        'c': value.get('name_of_granting_institution'),
         'd': value.get('year_degree_granted'),
         'g': utils.reverse_force_list(
             value.get('miscellaneous_information')
@@ -93,13 +114,23 @@ def reverse_dissertation_note(self, key, value):
 @utils.filter_values
 def reverse_bibliography_note(self, key, value):
     """Reverse - Bibliography, Etc. Note."""
+    field_map = {
+        'bibliography_note': 'a',
+        'number_of_references': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('bibliography_note'),
+        'b': value.get('number_of_references'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        'b': value.get('number_of_references'),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -111,12 +142,31 @@ def reverse_bibliography_note(self, key, value):
 def reverse_formatted_contents_note(self, key, value):
     """Reverse - Formatted Contents Note."""
     indicator_map1 = {
-        "Contents": "0",
-        "Incomplete contents": "1",
-        "No display constant generated": "8",
-        "Partial contents": "2"}
-    indicator_map2 = {"Basic": "_", "Enhanced": "0"}
+        'Contents': '0',
+        'Incomplete contents': '1',
+        'Partial contents': '2',
+        'No display constant generated': '8',
+    }
+
+    indicator_map2 = {
+        'Basic': '_',
+        'Enhanced': '0',
+    }
+
+    field_map = {
+        'formatted_contents_note': 'a',
+        'miscellaneous_information': 'g',
+        'statement_of_responsibility': 'r',
+        'title': 't',
+        'uniform_resource_identifier': 'u',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('formatted_contents_note'),
         'g': utils.reverse_force_list(
             value.get('miscellaneous_information')
@@ -124,11 +174,11 @@ def reverse_formatted_contents_note(self, key, value):
         'r': utils.reverse_force_list(
             value.get('statement_of_responsibility')
         ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
-        ),
         't': utils.reverse_force_list(
             value.get('title')
+        ),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
         ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
@@ -145,9 +195,10 @@ def reverse_formatted_contents_note(self, key, value):
 def reverse_restrictions_on_access_note(self, key, value):
     """Reverse - Restrictions on Access Note."""
     indicator_map1 = {
-        "No information provided": "_",
-        "No restrictions": "0",
-        "Restrictions apply": "1"}
+        'No information provided': '_',
+        'No restrictions': '0',
+        'Restrictions apply': '1',
+    }
 
     field_map = {
         'terms_governing_access': 'a',
@@ -166,36 +217,33 @@ def reverse_restrictions_on_access_note(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('restriction')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('terms_governing_access'),
-        'c': utils.reverse_force_list(
-            value.get('physical_access_provisions')
-        ),
         'b': utils.reverse_force_list(
             value.get('jurisdiction')
         ),
-        'e': utils.reverse_force_list(
-            value.get('authorization')
+        'c': utils.reverse_force_list(
+            value.get('physical_access_provisions')
         ),
         'd': utils.reverse_force_list(
             value.get('authorized_users')
         ),
+        'e': utils.reverse_force_list(
+            value.get('authorization')
+        ),
         'f': utils.reverse_force_list(
             value.get('standardized_terminology_for_access_restriction')
         ),
-        '3': value.get('materials_specified'),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
         '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
         ),
         '$ind1': indicator_map1.get(value.get('restriction'), '_'),
     }
@@ -205,13 +253,23 @@ def reverse_restrictions_on_access_note(self, key, value):
 @utils.filter_values
 def reverse_scale_note_for_graphic_material(self, key, value):
     """Reverse - Scale Note for Graphic Material."""
+    field_map = {
+        'representative_fraction_of_scale_note': 'a',
+        'remainder_of_scale_note': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('representative_fraction_of_scale_note'),
+        'b': value.get('remainder_of_scale_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        'b': value.get('remainder_of_scale_note'),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -222,12 +280,21 @@ def reverse_scale_note_for_graphic_material(self, key, value):
 @utils.filter_values
 def reverse_creation_production_credits_note(self, key, value):
     """Reverse - Creation/Production Credits Note."""
+    field_map = {
+        'creation_production_credits_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('creation_production_credits_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -239,19 +306,35 @@ def reverse_creation_production_credits_note(self, key, value):
 def reverse_citation_references_note(self, key, value):
     """Reverse - Citation/References Note."""
     indicator_map1 = {
-        "Coverage complete": "1",
-        "Coverage is selective": "2",
-        "Coverage unknown": "0",
-        "Location in source given": "4",
-        "Location in source not given": "3"}
+        'Coverage unknown': '0',
+        'Coverage complete': '1',
+        'Coverage is selective': '2',
+        'Location in source not given': '3',
+        'Location in source given': '4',
+    }
+
+    field_map = {
+        'name_of_source': 'a',
+        'coverage_of_source': 'b',
+        'location_within_source': 'c',
+        'uniform_resource_identifier': 'u',
+        'international_standard_serial_number': 'x',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('name_of_source'),
-        'x': value.get('international_standard_serial_number'),
-        'c': value.get('location_within_source'),
         'b': value.get('coverage_of_source'),
-        '3': value.get('materials_specified'),
+        'c': value.get('location_within_source'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')),
+        'x': value.get('international_standard_serial_number'),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -267,8 +350,21 @@ def reverse_citation_references_note(self, key, value):
 @utils.filter_values
 def reverse_participant_or_performer_note(self, key, value):
     """Reverse - Participant or Performer Note."""
-    indicator_map1 = {"Cast": "1", "No display constant generated": "0"}
+    indicator_map1 = {
+        'Cast': '1',
+        'No display constant generated': '0',
+    }
+
+    field_map = {
+        'participant_or_performer_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('participant_or_performer_note'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -285,13 +381,23 @@ def reverse_participant_or_performer_note(self, key, value):
 @utils.filter_values
 def reverse_type_of_report_and_period_covered_note(self, key, value):
     """Reverse - Type of Report and Period Covered Note."""
+    field_map = {
+        'type_of_report': 'a',
+        'period_covered': 'b',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('type_of_report'),
+        'b': value.get('period_covered'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        'b': value.get('period_covered'),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -301,40 +407,62 @@ def reverse_type_of_report_and_period_covered_note(self, key, value):
 @utils.filter_values
 def reverse_data_quality_note(self, key, value):
     """Reverse - Data Quality Note."""
+    field_map = {
+        'attribute_accuracy_report': 'a',
+        'attribute_accuracy_value': 'b',
+        'attribute_accuracy_explanation': 'c',
+        'logical_consistency_report': 'd',
+        'completeness_report': 'e',
+        'horizontal_position_accuracy_report': 'f',
+        'horizontal_position_accuracy_value': 'g',
+        'horizontal_position_accuracy_explanation': 'h',
+        'vertical_positional_accuracy_report': 'i',
+        'vertical_positional_accuracy_value': 'j',
+        'vertical_positional_accuracy_explanation': 'k',
+        'cloud_cover': 'm',
+        'uniform_resource_identifier': 'u',
+        'display_note': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('attribute_accuracy_report'),
-        'c': utils.reverse_force_list(
-            value.get('attribute_accuracy_explanation')
-        ),
         'b': utils.reverse_force_list(
             value.get('attribute_accuracy_value')
         ),
-        'e': value.get('completeness_report'),
+        'c': utils.reverse_force_list(
+            value.get('attribute_accuracy_explanation')
+        ),
         'd': value.get('logical_consistency_report'),
+        'e': value.get('completeness_report'),
+        'f': value.get('horizontal_position_accuracy_report'),
         'g': utils.reverse_force_list(
             value.get('horizontal_position_accuracy_value')
         ),
-        'f': value.get('horizontal_position_accuracy_report'),
-        'i': value.get('vertical_positional_accuracy_report'),
         'h': utils.reverse_force_list(
             value.get('horizontal_position_accuracy_explanation')
         ),
-        'k': utils.reverse_force_list(
-            value.get('vertical_positional_accuracy_explanation')
-        ),
+        'i': value.get('vertical_positional_accuracy_report'),
         'j': utils.reverse_force_list(
             value.get('vertical_positional_accuracy_value')
+        ),
+        'k': utils.reverse_force_list(
+            value.get('vertical_positional_accuracy_explanation')
         ),
         'm': value.get('cloud_cover'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')
         ),
+        'z': utils.reverse_force_list(
+            value.get('display_note')
+        ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('display_note')
         ),
         '$ind1': '_',
         '$ind2': '_',
@@ -346,7 +474,16 @@ def reverse_data_quality_note(self, key, value):
 @utils.filter_values
 def reverse_numbering_peculiarities_note(self, key, value):
     """Reverse - Numbering Peculiarities Note."""
+    field_map = {
+        'numbering_peculiarities_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('numbering_peculiarities_note'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -363,13 +500,24 @@ def reverse_numbering_peculiarities_note(self, key, value):
 def reverse_type_of_computer_file_or_data_note(self, key, value):
     """Reverse - Type of Computer File or Data Note."""
     indicator_map1 = {
-        "No display constant generated": "8",
-        "Type of file": "_"}
+        'Type of file': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'type_of_computer_file_or_data_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('type_of_computer_file_or_data_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -382,24 +530,39 @@ def reverse_type_of_computer_file_or_data_note(self, key, value):
 @utils.filter_values
 def reverse_date_time_and_place_of_an_event_note(self, key, value):
     """Reverse - Date/Time and Place of an Event Note."""
+    field_map = {
+        'date_time_and_place_of_an_event_note': 'a',
+        'date_of_event': 'd',
+        'other_event_information': 'o',
+        'place_of_event': 'p',
+        'record_control_number': '0',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('date_time_and_place_of_an_event_note'),
         'd': utils.reverse_force_list(
             value.get('date_of_event')
         ),
-        'p': utils.reverse_force_list(
-            value.get('place_of_event')
-        ),
         'o': utils.reverse_force_list(
             value.get('other_event_information')
+        ),
+        'p': utils.reverse_force_list(
+            value.get('place_of_event')
         ),
         '0': utils.reverse_force_list(
             value.get('record_control_number')
         ),
-        '3': value.get('materials_specified'),
         '2': utils.reverse_force_list(
             value.get('source_of_term')
         ),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -415,21 +578,37 @@ def reverse_date_time_and_place_of_an_event_note(self, key, value):
 def reverse_summary(self, key, value):
     """Reverse - Summary, Etc.."""
     indicator_map1 = {
-        "Abstract": "3",
-        "Content advice": "4",
-        "No display constant generated": "8",
-        "Review": "1",
-        "Scope and content": "2",
-        "Subject": "0",
-        "Summary": "_"}
+        'Summary': '_',
+        'Subject': '0',
+        'Review': '1',
+        'Scope and content': '2',
+        'Abstract': '3',
+        'Content advice': '4',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'summary': 'a',
+        'expansion_of_summary_note': 'b',
+        'assigning_source': 'c',
+        'uniform_resource_identifier': 'u',
+        'source': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('summary'),
-        'c': value.get('assigning_source'),
         'b': value.get('expansion_of_summary_note'),
-        '3': value.get('materials_specified'),
-        '2': value.get('source'),
+        'c': value.get('assigning_source'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')),
+        '2': value.get('source'),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -446,21 +625,34 @@ def reverse_summary(self, key, value):
 def reverse_target_audience_note(self, key, value):
     """Reverse - Target Audience Note."""
     indicator_map1 = {
-        "Audience": "_",
-        "Interest age level": "1",
-        "Interest grade level": "2",
-        "Motivation/interest level": "4",
-        "No display constant generated": "8",
-        "Reading grade level": "0",
-        "Special audience characteristics": "3"}
+        'Audience': '_',
+        'Interest age level': '1',
+        'Interest grade level': '2',
+        'Motivation/interest level': '4',
+        'No display constant generated': '8',
+        'Reading grade level': '0',
+        'Special audience characteristics': '3',
+    }
+
+    field_map = {
+        'target_audience_note': 'a',
+        'source': 'b',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('target_audience_note')),
+        'b': value.get('source'),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        '3': value.get('materials_specified'),
-        'b': value.get('source'),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -474,13 +666,24 @@ def reverse_target_audience_note(self, key, value):
 def reverse_geographic_coverage_note(self, key, value):
     """Reverse - Geographic Coverage Note."""
     indicator_map1 = {
-        "Geographic coverage": "_",
-        "No display constant generated": "8"}
+        'Geographic coverage': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'geographic_coverage_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_coverage_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -493,14 +696,29 @@ def reverse_geographic_coverage_note(self, key, value):
 @utils.filter_values
 def reverse_preferred_citation_of_described_materials_note(self, key, value):
     """Reverse - Preferred Citation of Described Materials Note."""
-    indicator_map1 = {"Cite as": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Cite as': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'preferred_citation_of_described_materials_note': 'a',
+        'source_of_schema_used': '2',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('preferred_citation_of_described_materials_note'),
+        '2': value.get('source_of_schema_used'),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        '3': value.get('materials_specified'),
-        '2': value.get('source_of_schema_used'),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -513,12 +731,21 @@ def reverse_preferred_citation_of_described_materials_note(self, key, value):
 @utils.filter_values
 def reverse_supplement_note(self, key, value):
     """Reverse - Supplement Note."""
+    field_map = {
+        'supplement_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('supplement_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -530,8 +757,8 @@ def reverse_supplement_note(self, key, value):
 def reverse_study_program_information_note(self, key, value):
     """Reverse - Study Program Information Note."""
     indicator_map1 = {
-        "No display constant generated": "8",
-        "Reading program": "0",
+        'Reading program': '0',
+        'No display constant generated': '8',
     }
 
     field_map = {
@@ -549,24 +776,21 @@ def reverse_study_program_information_note(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('program_name'),
-        'x': utils.reverse_force_list(
-            value.get('nonpublic_note')),
-        'c': value.get('reading_level'),
         'b': value.get('interest_level'),
+        'c': value.get('reading_level'),
         'd': value.get('title_point_value'),
         'i': value.get('display_text'),
+        'x': utils.reverse_force_list(
+            value.get('nonpublic_note')),
+        'z': utils.reverse_force_list(
+            value.get('public_note')),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        'z': utils.reverse_force_list(
-            value.get('public_note')),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -595,13 +819,13 @@ def reverse_additional_physical_form_available_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('additional_physical_form_available_note'),
-        'c': value.get('availability_conditions'),
         'b': value.get('availability_source'),
+        'c': value.get('availability_conditions'),
         'd': value.get('order_number'),
-        '3': value.get('materials_specified'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')
         ),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -637,14 +861,14 @@ def reverse_reproduction_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('type_of_reproduction'),
-        'c': utils.reverse_force_list(
-            value.get('agency_responsible_for_reproduction')
-        ),
         'b': utils.reverse_force_list(
             value.get('place_of_reproduction')
         ),
-        'e': value.get('physical_description_of_reproduction'),
+        'c': utils.reverse_force_list(
+            value.get('agency_responsible_for_reproduction')
+        ),
         'd': value.get('date_of_reproduction'),
+        'e': value.get('physical_description_of_reproduction'),
         'f': utils.reverse_force_list(
             value.get('series_statement_of_reproduction')
         ),
@@ -697,11 +921,8 @@ def reverse_original_version_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_of_original'),
-        'x': utils.reverse_force_list(
-            value.get('international_standard_serial_number')
-        ),
-        'c': value.get('publication_distribution_of_original'),
         'b': value.get('edition_statement_of_original'),
+        'c': value.get('publication_distribution_of_original'),
         'e': value.get('physical_description_of_original'),
         'f': utils.reverse_force_list(
             value.get('series_statement_of_original')
@@ -709,17 +930,20 @@ def reverse_original_version_note(self, key, value):
         'k': utils.reverse_force_list(
             value.get('key_title_of_original')
         ),
-        'm': value.get('material_specific_details'),
         'l': value.get('location_of_original'),
-        'o': utils.reverse_force_list(
-            value.get('other_resource_identifier')
-        ),
+        'm': value.get('material_specific_details'),
         'n': utils.reverse_force_list(
             value.get('note_about_original')
         ),
+        'o': utils.reverse_force_list(
+            value.get('other_resource_identifier')
+        ),
         'p': value.get('introductory_phrase'),
-        '3': value.get('materials_specified'),
         't': value.get('title_statement_of_original'),
+        'x': utils.reverse_force_list(
+            value.get('international_standard_serial_number')
+        ),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
@@ -737,14 +961,32 @@ def reverse_original_version_note(self, key, value):
 @utils.filter_values
 def reverse_location_of_originals_duplicates_note(self, key, value):
     """Reverse - Location of Originals/Duplicates Note."""
-    indicator_map1 = {"Holder of duplicates": "2", "Holder of originals": "1"}
+    indicator_map1 = {
+        'Holder of originals': '1',
+        'Holder of duplicates': '2',
+    }
+
+    field_map = {
+        'custodian': 'a',
+        'postal_address': 'b',
+        'country': 'c',
+        'telecommunications_address': 'd',
+        'repository_location_code': 'g',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('custodian'),
-        'c': utils.reverse_force_list(
-            value.get('country')
-        ),
         'b': utils.reverse_force_list(
             value.get('postal_address')
+        ),
+        'c': utils.reverse_force_list(
+            value.get('country')
         ),
         'd': utils.reverse_force_list(
             value.get('telecommunications_address')
@@ -783,23 +1025,23 @@ def reverse_funding_information_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('text_of_note'),
-        'c': utils.reverse_force_list(
-            value.get('grant_number')
-        ),
         'b': utils.reverse_force_list(
             value.get('contract_number')
         ),
-        'e': utils.reverse_force_list(
-            value.get('program_element_number')
+        'c': utils.reverse_force_list(
+            value.get('grant_number')
         ),
         'd': utils.reverse_force_list(
             value.get('undifferentiated_number')
         ),
-        'g': utils.reverse_force_list(
-            value.get('task_number')
+        'e': utils.reverse_force_list(
+            value.get('program_element_number')
         ),
         'f': utils.reverse_force_list(
             value.get('project_number')
+        ),
+        'g': utils.reverse_force_list(
+            value.get('task_number')
         ),
         'h': utils.reverse_force_list(
             value.get('work_unit_number')
@@ -818,9 +1060,25 @@ def reverse_funding_information_note(self, key, value):
 @utils.filter_values
 def reverse_system_details_note(self, key, value):
     """Reverse - System Details Note."""
+    field_map = {
+        'system_details_note': 'a',
+        'display_text': 'i',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('system_details_note'),
         'i': value.get('display_text'),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
         '3': value.get('materials_specified'),
         '5': utils.reverse_force_list(
             value.get('institution_to_which_field_applies')
@@ -828,9 +1086,6 @@ def reverse_system_details_note(self, key, value):
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
         ),
         '$ind1': '_',
         '$ind2': '_',
@@ -844,35 +1099,35 @@ def reverse_terms_governing_use_and_reproduction_note(self, key, value):
     """Reverse - Terms Governing Use and Reproduction Note."""
     field_map = {
         'terms_governing_use_and_reproduction': 'a',
-        'authorization': 'c',
         'jurisdiction': 'b',
+        'authorization': 'c',
         'authorized_users': 'd',
+        'uniform_resource_identifier': 'u',
         'materials_specified': '3',
         'institution_to_which_field_applies': '5',
         'linkage': '6',
         'field_link_and_sequence_number': '8',
-        'uniform_resource_identifier': 'u',
     }
 
     order = utils.map_order(field_map, value)
 
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('terms_governing_use_and_reproduction'),
-        'c': value.get('authorization'),
         'b': value.get('jurisdiction'),
+        'c': value.get('authorization'),
         'd': value.get('authorized_users'),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
-        ),
         '$ind1': '_',
         '$ind2': '_',
-        '__order__': tuple(order) if len(order) else None
     }
 
 
@@ -882,22 +1137,43 @@ def reverse_terms_governing_use_and_reproduction_note(self, key, value):
 def reverse_immediate_source_of_acquisition_note(self, key, value):
     """Reverse - Immediate Source of Acquisition Note."""
     indicator_map1 = {
-        "No information provided": "_",
-        "Not private": "1",
-        "Private": "0"}
+        'No information provided': '_',
+        'Private': '0',
+        'Not private': '1',
+    }
+
+    field_map = {
+        'source_of_acquisition': 'a',
+        'address': 'b',
+        'method_of_acquisition': 'c',
+        'date_of_acquisition': 'd',
+        'accession_number': 'e',
+        'owner': 'f',
+        'purchase_price': 'h',
+        'extent': 'n',
+        'type_of_unit': 'o',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('source_of_acquisition'),
-        'c': value.get('method_of_acquisition'),
         'b': value.get('address'),
-        'e': value.get('accession_number'),
+        'c': value.get('method_of_acquisition'),
         'd': value.get('date_of_acquisition'),
+        'e': value.get('accession_number'),
         'f': value.get('owner'),
         'h': value.get('purchase_price'),
-        'o': utils.reverse_force_list(
-            value.get('type_of_unit')
-        ),
         'n': utils.reverse_force_list(
             value.get('extent')
+        ),
+        'o': utils.reverse_force_list(
+            value.get('type_of_unit')
         ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
@@ -916,50 +1192,81 @@ def reverse_immediate_source_of_acquisition_note(self, key, value):
 def reverse_information_relating_to_copyright_status(self, key, value):
     """Reverse - Information Relating to Copyright Status."""
     indicator_map1 = {
-        "No information provided": "_",
-        "Not private": "1",
-        "Private": "0"}
+        'No information provided': '_',
+        'Private': '0',
+        'Not private': '1',
+    }
+
+    field_map = {
+        'personal_creator': 'a',
+        'personal_creator_death_date': 'b',
+        'corporate_creator': 'c',
+        'copyright_holder': 'd',
+        'copyright_holder_contact_information': 'e',
+        'copyright_statement': 'f',
+        'copyright_date': 'g',
+        'copyright_renewal_date': 'h',
+        'publication_date': 'i',
+        'creation_date': 'j',
+        'publisher': 'k',
+        'copyright_status': 'l',
+        'publication_status': 'm',
+        'note': 'n',
+        'research_date': 'o',
+        'country_of_publication_or_creation': 'p',
+        'supplying_agency': 'q',
+        'jurisdiction_of_copyright_assessment': 'r',
+        'source_of_information': 's',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
-        '3': value.get('materials_specified'),
-        '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('personal_creator'),
-        'c': value.get('corporate_creator'),
         'b': value.get('personal_creator_death_date'),
-        'e': utils.reverse_force_list(
-            value.get('copyright_holder_contact_information')
-        ),
+        'c': value.get('corporate_creator'),
         'd': utils.reverse_force_list(
             value.get('copyright_holder')
         ),
-        'g': value.get('copyright_date'),
+        'e': utils.reverse_force_list(
+            value.get('copyright_holder_contact_information')
+        ),
         'f': utils.reverse_force_list(
             value.get('copyright_statement')
         ),
+        'g': value.get('copyright_date'),
         'i': value.get('publication_date'),
         'h': utils.reverse_force_list(
             value.get('copyright_renewal_date')
         ),
+        'j': value.get('creation_date'),
         'k': utils.reverse_force_list(
             value.get('publisher')
         ),
-        'j': value.get('creation_date'),
-        'm': value.get('publication_status'),
         'l': value.get('copyright_status'),
-        'o': value.get('research_date'),
+        'm': value.get('publication_status'),
         'n': utils.reverse_force_list(
             value.get('note')
         ),
-        'q': value.get('supplying_agency'),
+        'o': value.get('research_date'),
         'p': utils.reverse_force_list(
             value.get('country_of_publication_or_creation')
         ),
-        's': value.get('source_of_information'),
+        'q': value.get('supplying_agency'),
         'r': value.get('jurisdiction_of_copyright_assessment'),
+        's': value.get('source_of_information'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')
+        ),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
         ),
         '$ind1': indicator_map1.get(value.get('privacy'), '_'),
         '$ind2': '_',
@@ -972,24 +1279,41 @@ def reverse_information_relating_to_copyright_status(self, key, value):
 def reverse_location_of_other_archival_materials_note(self, key, value):
     """Reverse - Location of Other Archival Materials Note."""
     indicator_map1 = {
-        "Associated materials": "0",
-        "No information provided": "_",
-        "Related materials": "1"}
+        'No information provided': '_',
+        'Associated materials': '0',
+        'Related materials': '1',
+    }
+
+    field_map = {
+        'custodian': 'a',
+        'address': 'b',
+        'country': 'c',
+        'title': 'd',
+        'provenance': 'e',
+        'note': 'n',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('custodian')
-        ),
-        'c': utils.reverse_force_list(
-            value.get('country')
         ),
         'b': utils.reverse_force_list(
             value.get('address')
         ),
-        'e': utils.reverse_force_list(
-            value.get('provenance')
+        'c': utils.reverse_force_list(
+            value.get('country')
         ),
         'd': utils.reverse_force_list(
             value.get('title')
+        ),
+        'e': utils.reverse_force_list(
+            value.get('provenance')
         ),
         'n': utils.reverse_force_list(
             value.get('note')
@@ -1010,19 +1334,32 @@ def reverse_location_of_other_archival_materials_note(self, key, value):
 def reverse_biographical_or_historical_data(self, key, value):
     """Reverse - Biographical or Historical Data."""
     indicator_map1 = {
-        "Administrative history": "1",
-        "Biographical sketch": "0",
-        "No information provided": "_"}
+        'No information provided': '_',
+        'Biographical sketch': '0',
+        'Administrative history': '1',
+    }
+
+    field_map = {
+        'biographical_or_historical_data': 'a',
+        'expansion': 'b',
+        'uniform_resource_identifier': 'u',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('biographical_or_historical_data'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         'b': value.get('expansion'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')
         ),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
         '$ind1': indicator_map1.get(value.get('type_of_data'), '_'),
         '$ind2': '_',
     }
@@ -1033,16 +1370,27 @@ def reverse_biographical_or_historical_data(self, key, value):
 @utils.filter_values
 def reverse_language_note(self, key, value):
     """Reverse - Language Note."""
+    field_map = {
+        'language_note': 'a',
+        'information_code_or_alphabet': 'b',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('language_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        '3': value.get('materials_specified'),
         'b': utils.reverse_force_list(
             value.get('information_code_or_alphabet')
         ),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -1053,12 +1401,21 @@ def reverse_language_note(self, key, value):
 @utils.filter_values
 def reverse_former_title_complexity_note(self, key, value):
     """Reverse - Former Title Complexity Note."""
+    field_map = {
+        'former_title_complexity_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('former_title_complexity_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -1080,10 +1437,10 @@ def reverse_issuing_body_note(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('issuing_body_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -1094,40 +1451,66 @@ def reverse_issuing_body_note(self, key, value):
 @utils.filter_values
 def reverse_entity_and_attribute_information_note(self, key, value):
     """Reverse - Entity and Attribute Information Note."""
+    field_map = {
+        'entity_type_label': 'a',
+        'entity_type_definition_and_source': 'b',
+        'attribute_label': 'c',
+        'attribute_definition_and_source': 'd',
+        'enumerated_domain_value': 'e',
+        'enumerated_domain_value_definition_and_source': 'f',
+        'range_domain_minimum_and_maximum': 'g',
+        'codeset_name_and_source': 'h',
+        'unrepresentable_domain': 'i',
+        'attribute_units_of_measurement_and_resolution': 'j',
+        'beginning_and_ending_date_of_attribute_values': 'k',
+        'attribute_value_accuracy': 'l',
+        'attribute_value_accuracy_explanation': 'm',
+        'attribute_measurement_frequency': 'n',
+        'entity_and_attribute_overview': 'o',
+        'entity_and_attribute_detail_citation': 'p',
+        'uniform_resource_identifier': 'u',
+        'display_note': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('entity_type_label'),
-        'c': value.get('attribute_label'),
         'b': value.get('entity_type_definition_and_source'),
+        'c': value.get('attribute_label'),
+        'd': value.get('attribute_definition_and_source'),
         'e': utils.reverse_force_list(
             value.get('enumerated_domain_value')
         ),
-        'd': value.get('attribute_definition_and_source'),
-        'g': value.get('range_domain_minimum_and_maximum'),
         'f': utils.reverse_force_list(
             value.get('enumerated_domain_value_definition_and_source')
         ),
-        'i': value.get('unrepresentable_domain'),
+        'g': value.get('range_domain_minimum_and_maximum'),
         'h': value.get('codeset_name_and_source'),
-        'k': value.get('beginning_and_ending_date_of_attribute_values'),
+        'i': value.get('unrepresentable_domain'),
         'j': value.get('attribute_units_of_measurement_and_resolution'),
-        'm': value.get('attribute_value_accuracy_explanation'),
+        'k': value.get('beginning_and_ending_date_of_attribute_values'),
         'l': value.get('attribute_value_accuracy'),
+        'm': value.get('attribute_value_accuracy_explanation'),
+        'n': value.get('attribute_measurement_frequency'),
         'o': utils.reverse_force_list(
             value.get('entity_and_attribute_overview')
         ),
-        'n': value.get('attribute_measurement_frequency'),
         'p': utils.reverse_force_list(
             value.get('entity_and_attribute_detail_citation')
         ),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')
         ),
+        'z': utils.reverse_force_list(
+            value.get('display_note')
+        ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('display_note')
         ),
         '$ind1': '_',
         '$ind2': '_',
@@ -1140,18 +1523,34 @@ def reverse_entity_and_attribute_information_note(self, key, value):
 def reverse_cumulative_index_finding_aids_note(self, key, value):
     """Reverse - Cumulative Index/Finding Aids Note."""
     indicator_map1 = {
-        "Finding aids": "0",
-        "Indexes": "_",
-        "No display constant generated": "8"}
+        'Indexes': '_',
+        'Finding aids': '0',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'cumulative_index_finding_aids_note': 'a',
+        'availability_source': 'b',
+        'degree_of_control': 'c',
+        'bibliographic_reference': 'd',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('cumulative_index_finding_aids_note'),
-        'c': value.get('degree_of_control'),
         'b': utils.reverse_force_list(
             value.get('availability_source')),
+        'c': value.get('degree_of_control'),
         'd': value.get('bibliographic_reference'),
-        '3': value.get('materials_specified'),
         'u': utils.reverse_force_list(
             value.get('uniform_resource_identifier')),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
@@ -1168,15 +1567,27 @@ def reverse_cumulative_index_finding_aids_note(self, key, value):
 def reverse_information_about_documentation_note(self, key, value):
     """Reverse - Information About Documentation Note."""
     indicator_map1 = {
-        "Documentation": "_",
-        "No display constant generated": "8"}
+        'Documentation': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'information_about_documentation_note': 'a',
+        'international_standard_book_number': 'z',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('information_about_documentation_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')),
         'z': utils.reverse_force_list(
             value.get('international_standard_book_number')),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -1190,19 +1601,33 @@ def reverse_information_about_documentation_note(self, key, value):
 def reverse_ownership_and_custodial_history(self, key, value):
     """Reverse - Ownership and Custodial History."""
     indicator_map1 = {
-        "No information provided": "_",
-        "Not private": "1",
-        "Private": "0"}
+        'No information provided': '_',
+        'Private': '0',
+        'Not private': '1',
+    }
+
+    field_map = {
+        'history': 'a',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('history'),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
         ),
         '$ind1': indicator_map1.get(value.get('privacy'), '_'),
         '$ind2': '_',
@@ -1214,21 +1639,36 @@ def reverse_ownership_and_custodial_history(self, key, value):
 @utils.filter_values
 def reverse_copy_and_version_identification_note(self, key, value):
     """Reverse - Copy and Version Identification Note."""
+    field_map = {
+        'identifying_markings': 'a',
+        'copy_identification': 'b',
+        'version_identification': 'c',
+        'presentation_format': 'd',
+        'number_of_copies': 'e',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('identifying_markings')
-        ),
-        'c': utils.reverse_force_list(
-            value.get('version_identification')
         ),
         'b': utils.reverse_force_list(
             value.get('copy_identification')
         ),
-        'e': utils.reverse_force_list(
-            value.get('number_of_copies')
+        'c': utils.reverse_force_list(
+            value.get('version_identification')
         ),
         'd': utils.reverse_force_list(
             value.get('presentation_format')
+        ),
+        'e': utils.reverse_force_list(
+            value.get('number_of_copies')
         ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
@@ -1246,16 +1686,28 @@ def reverse_copy_and_version_identification_note(self, key, value):
 @utils.filter_values
 def reverse_binding_information(self, key, value):
     """Reverse - Binding Information."""
+    field_map = {
+        'binding_note': 'a',
+        'uniform_resource_identifier': 'u',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('binding_note'),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
         ),
         '$ind1': '_',
         '$ind2': '_',
@@ -1268,19 +1720,35 @@ def reverse_binding_information(self, key, value):
 def reverse_case_file_characteristics_note(self, key, value):
     """Reverse - Case File Characteristics Note."""
     indicator_map1 = {
-        "Case file characteristics": "0",
-        "File size": "_",
-        "No display constant generated": "8"}
+        'File size': '_',
+        'Case file characteristics': '0',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'number_of_cases_variables': 'a',
+        'name_of_variable': 'b',
+        'unit_of_analysis': 'c',
+        'universe_of_data': 'd',
+        'filing_scheme_or_code': 'e',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('number_of_cases_variables'),
-        'c': utils.reverse_force_list(
-            value.get('unit_of_analysis')),
         'b': utils.reverse_force_list(
             value.get('name_of_variable')),
-        'e': utils.reverse_force_list(
-            value.get('filing_scheme_or_code')),
+        'c': utils.reverse_force_list(
+            value.get('unit_of_analysis')),
         'd': utils.reverse_force_list(
             value.get('universe_of_data')),
+        'e': utils.reverse_force_list(
+            value.get('filing_scheme_or_code')),
         '3': value.get('materials_specified'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
@@ -1297,12 +1765,25 @@ def reverse_case_file_characteristics_note(self, key, value):
 @utils.filter_values
 def reverse_methodology_note(self, key, value):
     """Reverse - Methodology Note."""
-    indicator_map1 = {"Methodology": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Methodology': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'methodology_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('methodology_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -1315,12 +1796,21 @@ def reverse_methodology_note(self, key, value):
 @utils.filter_values
 def reverse_linking_entry_complexity_note(self, key, value):
     """Reverse - Linking Entry Complexity Note."""
+    field_map = {
+        'linking_entry_complexity_note': 'a',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('linking_entry_complexity_note'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -1332,16 +1822,29 @@ def reverse_linking_entry_complexity_note(self, key, value):
 def reverse_publications_about_described_materials_note(self, key, value):
     """Reverse - Publications About Described Materials Note."""
     indicator_map1 = {
-        "No display constant generated": "8",
-        "Publications": "_"}
+        'Publications': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'publications_about_described_materials_note': 'a',
+        'international_standard_book_number': 'z',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('publications_about_described_materials_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')),
-        '3': value.get('materials_specified'),
         'z': utils.reverse_force_list(
             value.get('international_standard_book_number')),
+        '3': value.get('materials_specified'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -1355,62 +1858,91 @@ def reverse_publications_about_described_materials_note(self, key, value):
 def reverse_action_note(self, key, value):
     """Reverse - Action Note."""
     indicator_map1 = {
-        "No information provided": "_",
-        "Not private": "1",
-        "Private": "0"}
+        'No information provided': '_',
+        'Private': '0',
+        'Not private': '1',
+    }
+
+    field_map = {
+        'action': 'a',
+        'action_identification': 'b',
+        'time_date_of_action': 'c',
+        'action_interval': 'd',
+        'contingency_for_action': 'e',
+        'authorization': 'f',
+        'jurisdiction': 'h',
+        'method_of_action': 'i',
+        'site_of_action': 'j',
+        'action_agent': 'k',
+        'status': 'l',
+        'extent': 'n',
+        'type_of_unit': 'o',
+        'uniform_resource_identifier': 'u',
+        'nonpublic_note': 'x',
+        'public_note': 'z',
+        'source_of_term': '2',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('action'),
-        'x': utils.reverse_force_list(
-            value.get('nonpublic_note')
+        'b': utils.reverse_force_list(
+            value.get('action_identification')
         ),
         'c': utils.reverse_force_list(
             value.get('time_date_of_action')
         ),
-        'b': utils.reverse_force_list(
-            value.get('action_identification')
+        'd': utils.reverse_force_list(
+            value.get('action_interval')
         ),
         'e': utils.reverse_force_list(
             value.get('contingency_for_action')
         ),
-        'd': utils.reverse_force_list(
-            value.get('action_interval')
-        ),
         'f': utils.reverse_force_list(
             value.get('authorization')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('method_of_action')
         ),
         'h': utils.reverse_force_list(
             value.get('jurisdiction')
         ),
-        'k': utils.reverse_force_list(
-            value.get('action_agent')
+        'i': utils.reverse_force_list(
+            value.get('method_of_action')
         ),
         'j': utils.reverse_force_list(
             value.get('site_of_action')
         ),
+        'k': utils.reverse_force_list(
+            value.get('action_agent')
+        ),
         'l': utils.reverse_force_list(
             value.get('status')
-        ),
-        'o': utils.reverse_force_list(
-            value.get('type_of_unit')
         ),
         'n': utils.reverse_force_list(
             value.get('extent')
         ),
-        '3': value.get('materials_specified'),
-        '2': value.get('source_of_term'),
-        '5': value.get('institution_to_which_field_applies'),
-        '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
+        'o': utils.reverse_force_list(
+            value.get('type_of_unit')
+        ),
+        'u': utils.reverse_force_list(
+            value.get('uniform_resource_identifier')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('nonpublic_note')
         ),
         'z': utils.reverse_force_list(
             value.get('public_note')
         ),
-        'u': utils.reverse_force_list(
-            value.get('uniform_resource_identifier')
+        '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
+        '5': value.get('institution_to_which_field_applies'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
         ),
         '$ind1': indicator_map1.get(value.get('privacy'), '_'),
         '$ind2': '_',
@@ -1422,7 +1954,19 @@ def reverse_action_note(self, key, value):
 @utils.filter_values
 def reverse_accumulation_and_frequency_of_use_note(self, key, value):
     """Reverse - Accumulation and Frequency of Use Note."""
+    field_map = {
+        'accumulation': 'a',
+        'frequency_of_use': 'b',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('accumulation')
         ),
@@ -1445,14 +1989,25 @@ def reverse_accumulation_and_frequency_of_use_note(self, key, value):
 @utils.filter_values
 def reverse_exhibitions_note(self, key, value):
     """Reverse - Exhibitions Note."""
+    field_map = {
+        'exhibitions_note': 'a',
+        'materials_specified': '3',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('exhibitions_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         '3': value.get('materials_specified'),
         '5': value.get('institution_to_which_field_applies'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -1463,13 +2018,27 @@ def reverse_exhibitions_note(self, key, value):
 @utils.filter_values
 def reverse_awards_note(self, key, value):
     """Reverse - Awards Note."""
-    indicator_map1 = {"Awards": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Awards': '_',
+        'No display constant generated': '8',
+    }
+
+    field_map = {
+        'awards_note': 'a',
+        'materials_specified': '3',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
+    }
+
+    order = utils.map_order(field_map, value)
+
     return {
+        '__order__': tuple(order) if len(order) else None,
         'a': value.get('awards_note'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')),
         '3': value.get('materials_specified'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(
             value.get('display_constant_controller'),
             '_'),
@@ -1483,7 +2052,7 @@ def reverse_awards_note(self, key, value):
 def reverse_source_of_description_note(self, key, value):
     """Reverse - Source of Description Note."""
     indicator_map1 = {
-        'No information provided': '#',
+        'No information provided': '_',
         'Source of description': '0',
         'Latest issue consulted': '1',
     }
@@ -1497,17 +2066,14 @@ def reverse_source_of_description_note(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('source_of_description_note'),
+        '5': value.get('institution_to_which_field_applies'),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '5': value.get('institution_to_which_field_applies'),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(value.get('display_constant_controller'), '_'),
         '$ind2': '_',
     }

--- a/tests/data/library_of_congress/bd5xx.xml
+++ b/tests/data/library_of_congress/bd5xx.xml
@@ -2308,8 +2308,7 @@
       <subfield code="3">Photoprints</subfield>
       <subfield code="c">Purchased;</subfield>
       <subfield code="d">1974</subfield>
-      <subfield code="h"></subfield>
-      <subfield code="4">,000.</subfield>
+      <subfield code="h">$4,000.</subfield>
     </datafield>
   </record>
   <record>
@@ -2317,8 +2316,7 @@
       <subfield code="3">Photoprints</subfield>
       <subfield code="c">Purchased;</subfield>
       <subfield code="d">1974;</subfield>
-      <subfield code="h"></subfield>
-      <subfield code="4">,000.</subfield>
+      <subfield code="h">$4,000.</subfield>
     </datafield>
   </record>
   <record>
@@ -2397,8 +2395,7 @@
       <subfield code="d">1981/09/24;</subfield>
       <subfield code="e">81-325;</subfield>
       <subfield code="f">Jonathan P. Merriwether Estate;</subfield>
-      <subfield code="h"></subfield>
-      <subfield code="7">,850.</subfield>
+      <subfield code="h">$7,850.</subfield>
     </datafield>
   </record>
   <record>
@@ -2413,7 +2410,7 @@
       <subfield code="e">81-325;</subfield>
       <subfield code="f">Jonathan P. Merriwether Estate;</subfield>
       <subfield code="h"></subfield>
-      <subfield code="7">,850.</subfield>
+      <subfield code="h">$7,850.</subfield>
     </datafield>
   </record>
   <record>
@@ -2428,7 +2425,7 @@
       <subfield code="e">81-325;</subfield>
       <subfield code="f">Jonathan P. Merriwether Estate;</subfield>
       <subfield code="h"></subfield>
-      <subfield code="7">,850.</subfield>
+      <subfield code="h">$7,850.</subfield>
     </datafield>
   </record>
   <record>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,6 +46,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd25x28x.xml',
     'library_of_congress/bd3xx.xml',
     'library_of_congress/bd4xx.xml',
+    'library_of_congress/bd5xx.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd5xx fields. (closes #96)
- Reaches 100% test coverage for bd5xx fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
