### PR TITLE
dojson: bd76x78x field maps

### DIFF
--- a/dojson/contrib/marc21/fields/bd6xx.py
+++ b/dojson/contrib/marc21/fields/bd6xx.py
@@ -14,21 +14,26 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('subject_added_entry_personal_name', '^600[103_][_10325476]')
+@marc21.over('subject_added_entry_personal_name', '^600[_013][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_personal_name(self, key, value):
     """Subject Added Entry-Personal Name."""
-    indicator_map1 = {"0": "Forename", "1": "Surname", "3": "Family name"}
+    indicator_map1 = {
+        '0': 'Forename',
+        '1': 'Surname',
+        '3': 'Family name',
+    }
+
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2",
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -71,13 +76,65 @@ def subject_added_entry_personal_name(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
+        'personal_name': value.get('a'),
+        'numeration': value.get('b'),
+        'titles_and_other_words_associated_with_a_name': utils.force_list(
+            value.get('c')
+        ),
+        'dates_associated_with_a_name': value.get('d'),
+        'relator_term': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'attribution_qualifier': utils.force_list(
+            value.get('j')
+        ),
+        'form_subheading': utils.force_list(
+            value.get('k')
+        ),
+        'language_of_a_work': value.get('l'),
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
+        ),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
+        ),
+        'arranged_statement_for_music': value.get('o'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
+        ),
+        'fuller_form_of_name': value.get('q'),
+        'key_for_music': value.get('r'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -85,75 +142,31 @@ def subject_added_entry_personal_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'personal_name': value.get('a'),
-        'titles_and_other_words_associated_with_a_name': utils.force_list(
-            value.get('c')
-        ),
-        'numeration': value.get('b'),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
-        'dates_associated_with_a_name': value.get('d'),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'attribution_qualifier': utils.force_list(
-            value.get('j')
-        ),
-        'medium_of_performance_for_music': utils.force_list(
-            value.get('m')
-        ),
-        'language_of_a_work': value.get('l'),
-        'arranged_statement_for_music': value.get('o'),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
-        'fuller_form_of_name': value.get('q'),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'key_for_music': value.get('r'),
-        'affiliation': value.get('u'),
-        'title_of_a_work': value.get('t'),
-        'form_subdivision': utils.force_list(
-            value.get('v')
-        ),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
-        ),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_corporate_name', '^610[10_2][_10325476]')
+@marc21.over('subject_added_entry_corporate_name', '^610[_0-2][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_corporate_name(self, key, value):
     """Subject Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -194,13 +207,63 @@ def subject_added_entry_corporate_name(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'subordinate_unit': utils.force_list(
+            value.get('b')
+        ),
+        'location_of_meeting': value.get('c'),
+        'date_of_meeting_or_treaty_signing': utils.force_list(
+            value.get('d')
+        ),
+        'relator_term': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
+        ),
+        'language_of_a_work': value.get('l'),
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
+        ),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
+        ),
+        'arranged_statement_for_music': value.get('o'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
+        ),
+        'key_for_music': value.get('r'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -208,73 +271,31 @@ def subject_added_entry_corporate_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'location_of_meeting': value.get('c'),
-        'subordinate_unit': utils.force_list(
-            value.get('b')
-        ),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_meeting_or_treaty_signing': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'medium_of_performance_for_music': utils.force_list(
-            value.get('m')
-        ),
-        'language_of_a_work': value.get('l'),
-        'arranged_statement_for_music': value.get('o'),
-        'number_of_part_section_meeting': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'key_for_music': value.get('r'),
-        'affiliation': value.get('u'),
-        'title_of_a_work': value.get('t'),
-        'form_subdivision': utils.force_list(
-            value.get('v')
-        ),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
-        ),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_meeting_name', '^611[10_2][_10325476]')
+@marc21.over('subject_added_entry_meeting_name', '^611[_0-2][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_meeting_name(self, key, value):
     """Subject Added Entry-Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2",
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -313,13 +334,57 @@ def subject_added_entry_meeting_name(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'date_of_meeting': value.get('d'),
+        'subordinate_unit': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'relator_term': utils.force_list(
+            value.get('j')
+        ),
+        'form_subheading': utils.force_list(
+            value.get('k')
+        ),
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(
+            value.get('n')
+        ),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
+        ),
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -327,65 +392,27 @@ def subject_added_entry_meeting_name(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'location_of_meeting': value.get('c'),
-        'subordinate_unit': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_meeting': value.get('d'),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'relator_term': utils.force_list(
-            value.get('j')
-        ),
-        'language_of_a_work': value.get('l'),
-        'number_of_part_section_meeting': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'affiliation': value.get('u'),
-        'title_of_a_work': value.get('t'),
-        'form_subdivision': utils.force_list(
-            value.get('v')
-        ),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
-        ),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
 @marc21.over(
-    'subject_added_entry_uniform_title', '^630[_1032547698][_10325476]')
+    'subject_added_entry_uniform_title', '^630[_0-9][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_uniform_title(self, key, value):
     """Subject Added Entry-Uniform Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -423,13 +450,58 @@ def subject_added_entry_uniform_title(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
+        'uniform_title': value.get('a'),
+        'date_of_treaty_signing': utils.force_list(
+            value.get('d')
+        ),
+        'relator_term': utils.force_list(
+            value.get('e')
+        ),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'form_subheading': utils.force_list(
+            value.get('k')
+        ),
+        'language_of_a_work': value.get('l'),
+        'medium_of_performance_for_music': utils.force_list(
+            value.get('m')
+        ),
+        'number_of_part_section_of_a_work': utils.force_list(
+            value.get('n')
+        ),
+        'arranged_statement_for_music': value.get('o'),
+        'name_of_part_section_of_a_work': utils.force_list(
+            value.get('p')
+        ),
+        'key_for_music': value.get('r'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
@@ -437,68 +509,31 @@ def subject_added_entry_uniform_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'uniform_title': value.get('a'),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_treaty_signing': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'medium_of_performance_for_music': utils.force_list(
-            value.get('m')
-        ),
-        'language_of_a_work': value.get('l'),
-        'arranged_statement_for_music': value.get('o'),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'key_for_music': value.get('r'),
-        'title_of_a_work': value.get('t'),
-        'form_subdivision': utils.force_list(
-            value.get('v')
-        ),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
-        ),
         'nonfiling_characters': key[3],
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_chronological_term', '^648[10_][_10325476]')
+@marc21.over('subject_added_entry_chronological_term', '^648[_01][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_chronological_term(self, key, value):
     """Subject Added Entry-Chronological Term."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "Date or time period covered or depicted",
-        "1": "Date or time period of creation or origin"}
+        '_': 'No information provided',
+        '0': 'Date or time period covered or depicted',
+        '1': 'Date or time period of creation or origin',
+    }
+
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re",
-        "7": "Source specified in subfield $2"
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -515,54 +550,63 @@ def subject_added_entry_chronological_term(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'chronological_term': value.get('a'),
+        'form_subdivision': utils.force_list(
+            value.get('v')
+        ),
         'general_subdivision': utils.force_list(
             value.get('x')
         ),
-        'form_subdivision': utils.force_list(
-            value.get('v')
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'linkage': value.get('6'),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
         ),
         'type_of_date_or_time_period': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_topical_term', '^650[10_2][_10325476]')
+@marc21.over('subject_added_entry_topical_term', '^650[_0-2][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_topical_term(self, key, value):
     """Subject Added Entry-Topical Term."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "No level specified",
-        "1": "Primary",
-        "2": "Secondary"}
+        '_': 'No information provided',
+        '0': 'No level specified',
+        '1': 'Primary',
+        '2': 'Secondary',
+    }
+
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"}
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
+    }
 
     field_map = {
         'a': 'topical_term_or_geographic_name_entry_element',
@@ -590,58 +634,64 @@ def subject_added_entry_topical_term(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'topical_term_or_geographic_name_entry_element': value.get('a'),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
-        'location_of_event': value.get('c'),
         'topical_term_following_geographic_name_entry_element': value.get('b'),
+        'location_of_event': value.get('c'),
+        'active_dates': value.get('d'),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'active_dates': value.get('d'),
         'form_subdivision': utils.force_list(
             value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
         'linkage': value.get('6'),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
         ),
         'level_of_subject': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_geographic_name', '^651.[_10325476]')
+@marc21.over('subject_added_entry_geographic_name', '^651_[_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_geographic_name(self, key, value):
     """Subject Added Entry-Geographic Name."""
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -665,59 +715,67 @@ def subject_added_entry_geographic_name(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_heading_or_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'geographic_name': value.get('a'),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
         'relator_term': utils.force_list(
             value.get('e')
         ),
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
         'linkage': value.get('6'),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
         ),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('index_term_uncontrolled', '^653[10_2][_1032546]')
+@marc21.over('index_term_uncontrolled', '^653[_0-2][_0-6]')
 @utils.for_each_value
 @utils.filter_values
 def index_term_uncontrolled(self, key, value):
     """Index Term-Uncontrolled."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "No level specified",
-        "1": "Primary",
-        "2": "Secondary"}
+        '_': 'No information provided',
+        '0': 'No level specified',
+        '1': 'Primary',
+        '2': 'Secondary',
+    }
+
     indicator_map2 = {
-        "#": "No information provided",
-        "0": "Topical term",
-        "1": "Personal name",
-        "2": "Corporate name",
-        "3": "Meeting name",
-        "4": "Chronological term",
-        "5": "Geographic name",
-        "6": "Genre/form term"
+        '_': 'No information provided',
+        '0': 'Topical term',
+        '1': 'Personal name',
+        '2': 'Corporate name',
+        '3': 'Meeting name',
+        '4': 'Chronological term',
+        '5': 'Geographic name',
+        '6': 'Genre/form term',
     }
 
     field_map = {
@@ -738,25 +796,25 @@ def index_term_uncontrolled(self, key, value):
         'uncontrolled_term': utils.force_list(
             value.get('a')
         ),
+        'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'linkage': value.get('6'),
         'level_of_index_term': indicator_map1.get(key[3]),
         'type_of_term_or_name': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subject_added_entry_faceted_topical_terms', '^654[10_2].')
+@marc21.over('subject_added_entry_faceted_topical_terms', '^654[_0-2]_')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_faceted_topical_terms(self, key, value):
     """Subject Added Entry-Faceted Topical Terms."""
     indicator_map1 = {
-        "#": "No information provided",
-        "0": "No level specified",
-        "1": "Primary",
-        "2": "Secondary"
+        '_': 'No information provided',
+        '0': 'No level specified',
+        '1': 'Primary',
+        '2': 'Secondary',
     }
 
     field_map = {
@@ -785,11 +843,11 @@ def subject_added_entry_faceted_topical_terms(self, key, value):
         'focus_term': utils.force_list(
             value.get('a')
         ),
-        'facet_hierarchy_designation': utils.force_list(
-            value.get('c')
-        ),
         'non_focus_term': utils.force_list(
             value.get('b')
+        ),
+        'facet_hierarchy_designation': utils.force_list(
+            value.get('c')
         ),
         'relator_term': utils.force_list(
             value.get('e')
@@ -797,43 +855,46 @@ def subject_added_entry_faceted_topical_terms(self, key, value):
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
+        ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'relator_code': utils.force_list(
             value.get('4')
         ),
         'linkage': value.get('6'),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
         ),
         'level_of_subject': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('index_term_genre_form', '^655[0_][_10325476]')
+@marc21.over('index_term_genre_form', '^655[_0][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def index_term_genre_form(self, key, value):
     """Index Term-Genre/Form."""
-    indicator_map1 = {"#": "Basic", "0": "Faceted"}
+    indicator_map1 = {
+        '_': 'Basic',
+        '0': 'Faceted',
+    }
     indicator_map2 = {
-        "0": "Library of Congress Subject Headings",
-        "1": "LC subject headings for children\u0027s literature",
-        "2": "Medical Subject Headings",
-        "3": "National Agricultural Library subject authority file",
-        "4": "Source not specified",
-        "5": "Canadian Subject Headings",
-        "6": "R\u00e9pertoire de vedettes-mati\u00e8re",
-        "7": "Source specified in subfield $2"
+        '0': 'Library of Congress Subject Headings',
+        '1': 'LC subject headings for children\u0027s literature',
+        '2': 'Medical Subject Headings',
+        '3': 'National Agricultural Library subject authority file',
+        '4': 'Source not specified',
+        '5': 'Canadian Subject Headings',
+        '6': 'R\u00e9pertoire de vedettes-mati\u00e8re',
+        '7': 'Source specified in subfield $2',
     }
 
     field_map = {
@@ -859,43 +920,49 @@ def index_term_genre_form(self, key, value):
     if key[4] in indicator_map2:
         order.append('thesaurus')
 
+    if key[4] != '7':
+        try:
+            order.remove('source_of_term')
+        except ValueError:
+            pass
+
     return {
         '__order__': tuple(order) if len(order) else None,
         'genre_form_data_or_focus_term': value.get('a'),
-        'general_subdivision': utils.force_list(
-            value.get('x')
+        'non_focus_term': utils.force_list(
+            value.get('b')
         ),
         'facet_hierarchy_designation': utils.force_list(
             value.get('c')
         ),
-        'non_focus_term': utils.force_list(
-            value.get('b')
-        ),
         'form_subdivision': utils.force_list(
             value.get('v')
+        ),
+        'general_subdivision': utils.force_list(
+            value.get('x')
+        ),
+        'chronological_subdivision': utils.force_list(
+            value.get('y')
+        ),
+        'geographic_subdivision': utils.force_list(
+            value.get('z')
         ),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
-        'chronological_subdivision': utils.force_list(
-            value.get('y')
-        ),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
-        ),
-        'geographic_subdivision': utils.force_list(
-            value.get('z')
         ),
         'type_of_heading': indicator_map1.get(key[3]),
         'thesaurus': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('index_term_occupation', '^656..')
+@marc21.over('index_term_occupation', '^656_7')
 @utils.for_each_value
 @utils.filter_values
 def index_term_occupation(self, key, value):
@@ -919,32 +986,32 @@ def index_term_occupation(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'occupation': value.get('a'),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
         'form': value.get('k'),
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number_or_standard_number': utils.force_list(
-            value.get('0')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'materials_specified': value.get('3'),
-        'source_of_term': value.get('2'),
-        'linkage': value.get('6'),
         'chronological_subdivision': utils.force_list(
             value.get('y')
-        ),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
         ),
         'geographic_subdivision': utils.force_list(
             value.get('z')
         ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('index_term_function', '^657..')
+@marc21.over('index_term_function', '^657_7')
 @utils.for_each_value
 @utils.filter_values
 def index_term_function(self, key, value):
@@ -955,7 +1022,7 @@ def index_term_function(self, key, value):
         'x': 'general_subdivision',
         'y': 'chronological_subdivision',
         'z': 'geographic_subdivision',
-        '0': 'authority_record_control_number_or_standard_number',
+        '0': 'authority_record_control_number',
         '2': 'source_of_term',
         '3': 'materials_specified',
         '6': 'linkage',
@@ -967,31 +1034,31 @@ def index_term_function(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'function': value.get('a'),
-        'general_subdivision': utils.force_list(
-            value.get('x')
-        ),
         'form_subdivision': utils.force_list(
             value.get('v')
         ),
-        'authority_record_control_number_or_standard_number': utils.force_list(
-            value.get('0')
+        'general_subdivision': utils.force_list(
+            value.get('x')
         ),
-        'materials_specified': value.get('3'),
-        'source_of_term': value.get('2'),
-        'linkage': value.get('6'),
         'chronological_subdivision': utils.force_list(
             value.get('y')
-        ),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
         ),
         'geographic_subdivision': utils.force_list(
             value.get('z')
         ),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'source_of_term': value.get('2'),
+        'materials_specified': value.get('3'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(
+            value.get('8')
+        ),
     }
 
 
-@marc21.over('index_term_curriculum_objective', '^658..')
+@marc21.over('index_term_curriculum_objective', '^658__')
 @utils.for_each_value
 @utils.filter_values
 def index_term_curriculum_objective(self, key, value):
@@ -1011,10 +1078,10 @@ def index_term_curriculum_objective(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'main_curriculum_objective': value.get('a'),
-        'curriculum_code': value.get('c'),
         'subordinate_curriculum_objective': utils.force_list(
             value.get('b')
         ),
+        'curriculum_code': value.get('c'),
         'correlation_factor': value.get('d'),
         'source_of_term_or_code': value.get('2'),
         'linkage': value.get('6'),
@@ -1024,7 +1091,7 @@ def index_term_curriculum_objective(self, key, value):
     }
 
 
-@marc21.over('subject_added_entry_hierarchical_place_name', '^662..')
+@marc21.over('subject_added_entry_hierarchical_place_name', '^662__')
 @utils.for_each_value
 @utils.filter_values
 def subject_added_entry_hierarchical_place_name(self, key, value):
@@ -1052,19 +1119,19 @@ def subject_added_entry_hierarchical_place_name(self, key, value):
         'country_or_larger_entity': utils.force_list(
             value.get('a')
         ),
+        'first_order_political_jurisdiction': value.get('b'),
         'intermediate_political_jurisdiction': utils.force_list(
             value.get('c')
         ),
-        'first_order_political_jurisdiction': value.get('b'),
+        'city': value.get('d'),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'city': value.get('d'),
-        'other_nonjurisdictional_geographic_region_and_feature': utils.force_list(
-            value.get('g')
-        ),
         'city_subsection': utils.force_list(
             value.get('f')
+        ),
+        'other_nonjurisdictional_geographic_region_and_feature': utils.force_list(
+            value.get('g')
         ),
         'extraterrestrial_area': utils.force_list(
             value.get('h')

--- a/dojson/contrib/marc21/fields/bd70x75x.py
+++ b/dojson/contrib/marc21/fields/bd70x75x.py
@@ -14,7 +14,7 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('added_entry_personal_name', '^700[103_][_2]')
+@marc21.over('added_entry_personal_name', '^700[_013][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_personal_name(self, key, value):
@@ -24,23 +24,20 @@ def added_entry_personal_name(self, key, value):
         '1': 'Surname',
         '3': 'Family name',
     }
+
     indicator_map2 = {
         '_': 'No information provided',
         '2': 'Analytical entry',
     }
+
     field_map = {
-        '0': 'authority_record_control_number_or_standard_number',
-        '3': 'materials_specified',
-        '4': 'relator_code',
-        '5': 'institution_to_which_field_applies',
-        '6': 'linkage',
-        '8': 'field_link_and_sequence_number',
         'a': 'personal_name',
         'b': 'numeration',
         'c': 'titles_and_other_words_associated_with_a_name',
         'd': 'dates_associated_with_a_name',
         'e': 'relator_term',
         'f': 'date_of_a_work',
+        'g': 'miscellaneous_information',
         'h': 'medium',
         'i': 'relationship_information',
         'j': 'attribution_qualifier',
@@ -50,86 +47,95 @@ def added_entry_personal_name(self, key, value):
         'n': 'number_of_part_section_of_a_work',
         'o': 'arranged_statement_for_music',
         'p': 'name_of_part_section_of_a_work',
-        's': 'version',
+        'q': 'fuller_form_of_name',
         'r': 'key_for_music',
-        'u': 'affiliation',
+        's': 'version',
         't': 'title_of_a_work',
+        'u': 'affiliation',
         'x': 'international_standard_serial_number',
+        '0': 'authority_record_control_number_or_standard_number',
+        '3': 'materials_specified',
+        '4': 'relator_code',
+        '5': 'institution_to_which_field_applies',
+        '6': 'linkage',
+        '8': 'field_link_and_sequence_number',
     }
 
     order = utils.map_order(field_map, value)
+
     if key[3] in indicator_map1:
         order.append('type_of_personal_name_entry_element')
     if key[4] in indicator_map2:
         order.append('type_of_added_entry')
 
     return {
-        'authority_record_control_number_or_standard_number': utils.force_list(
-            value.get('0')
-        ),
-        'materials_specified': value.get('3'),
-        'institution_to_which_field_applies': value.get('5'),
-        'relator_code': utils.force_list(
-            value.get('4')
-        ),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
+        '__order__': tuple(order) if len(order) else None,
         'personal_name': value.get('a'),
+        'numeration': value.get('b'),
         'titles_and_other_words_associated_with_a_name': utils.force_list(
             value.get('c')
         ),
-        'numeration': value.get('b'),
+        'dates_associated_with_a_name': value.get('d'),
         'relator_term': utils.force_list(
             value.get('e')
         ),
-        'dates_associated_with_a_name': value.get('d'),
-        'miscellaneous_information': value.get('g'),
         'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
         'relationship_information': utils.force_list(
             value.get('i')
-        ),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
         ),
         'attribution_qualifier': utils.force_list(
             value.get('j')
         ),
+        'form_subheading': utils.force_list(
+            value.get('k')
+        ),
+        'language_of_a_work': value.get('l'),
         'medium_of_performance_for_music': utils.force_list(
             value.get('m')
         ),
-        'language_of_a_work': value.get('l'),
-        'arranged_statement_for_music': value.get('o'),
         'number_of_part_section_of_a_work': utils.force_list(
             value.get('n')
         ),
-        'fuller_form_of_name': value.get('q'),
         'name_of_part_section_of_a_work': utils.force_list(
             value.get('p')
         ),
-        'version': value.get('s'),
+        'fuller_form_of_name': value.get('q'),
+        'arranged_statement_for_music': value.get('o'),
         'key_for_music': value.get('r'),
-        'affiliation': value.get('u'),
+        'version': value.get('s'),
         'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
         'international_standard_serial_number': value.get('x'),
+        'authority_record_control_number_or_standard_number': utils.force_list(
+            value.get('0')
+        ),
+        'materials_specified': value.get('3'),
+        'relator_code': utils.force_list(value.get('4')),
+        'institution_to_which_field_applies': value.get('5'),
+        'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'type_of_personal_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
-        '__order__': tuple(order) if len(order) else None
     }
 
 
-@marc21.over('added_entry_corporate_name', '^710[10_2][_2]')
+@marc21.over('added_entry_corporate_name', '^710[_0-2][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_corporate_name(self, key, value):
     """Added Entry-Corporate Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
-    indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
+    indicator_map2 = {
+        '_': 'No information provided',
+        '2': 'Analytical entry',
+    }
 
     field_map = {
         'a': 'corporate_name_or_jurisdiction_name_as_entry_element',
@@ -169,69 +175,54 @@ def added_entry_corporate_name(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'subordinate_unit': utils.force_list(value.get('b')),
+        'location_of_meeting': value.get('c'),
+        'date_of_meeting_or_treaty_signing': utils.force_list(value.get('d')),
+        'relator_term': utils.force_list(value.get('e')),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'form_subheading': utils.force_list(value.get('k')),
+        'language_of_a_work': value.get('l'),
+        'medium_of_performance_for_music': utils.force_list(value.get('m')),
+        'number_of_part_section_meeting': utils.force_list(value.get('n')),
+        'arranged_statement_for_music': value.get('o'),
+        'name_of_part_section_of_a_work': utils.force_list(value.get('p')),
+        'key_for_music': value.get('r'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
+        'international_standard_serial_number': value.get('x'),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
+        'relator_code': utils.force_list(value.get('4')),
         'institution_to_which_field_applies': value.get('5'),
-        'relator_code': utils.force_list(
-            value.get('4')
-        ),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'corporate_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'location_of_meeting': value.get('c'),
-        'subordinate_unit': utils.force_list(
-            value.get('b')
-        ),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_meeting_or_treaty_signing': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'medium_of_performance_for_music': utils.force_list(
-            value.get('m')
-        ),
-        'language_of_a_work': value.get('l'),
-        'arranged_statement_for_music': value.get('o'),
-        'number_of_part_section_meeting': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'key_for_music': value.get('r'),
-        'affiliation': value.get('u'),
-        'title_of_a_work': value.get('t'),
-        'international_standard_serial_number': value.get('x'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'type_of_corporate_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('added_entry_meeting_name', '^711[10_2][_2]')
+@marc21.over('added_entry_meeting_name', '^711[_0-2][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_meeting_name(self, key, value):
     """Added Entry-Meeting Name."""
     indicator_map1 = {
-        "0": "Inverted name",
-        "1": "Jurisdiction name",
-        "2": "Name in direct order"}
-    indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+        '0': 'Inverted name',
+        '1': 'Jurisdiction name',
+        '2': 'Name in direct order',
+    }
+
+    indicator_map2 = {
+        '_': 'No information provided',
+        '2': 'Analytical entry',
+    }
 
     field_map = {
         'a': 'meeting_name_or_jurisdiction_name_as_entry_element',
@@ -269,59 +260,47 @@ def added_entry_meeting_name(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
+        'location_of_meeting': value.get('c'),
+        'date_of_meeting': value.get('d'),
+        'subordinate_unit': utils.force_list(value.get('e')),
+        'date_of_a_work': value.get('f'),
+        'miscellaneous_information': value.get('g'),
+        'medium': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'relator_term': utils.force_list(value.get('j')),
+        'form_subheading': utils.force_list(value.get('k')),
+        'language_of_a_work': value.get('l'),
+        'number_of_part_section_meeting': utils.force_list(value.get('n')),
+        'name_of_part_section_of_a_work': utils.force_list(value.get('p')),
+        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'affiliation': value.get('u'),
+        'international_standard_serial_number': value.get('x'),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
+        'relator_code': utils.force_list(value.get('4')),
         'institution_to_which_field_applies': value.get('5'),
-        'relator_code': utils.force_list(
-            value.get('4')
-        ),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'meeting_name_or_jurisdiction_name_as_entry_element': value.get('a'),
-        'location_of_meeting': value.get('c'),
-        'subordinate_unit': utils.force_list(
-            value.get('e')
-        ),
-        'date_of_meeting': value.get('d'),
-        'miscellaneous_information': value.get('g'),
-        'date_of_a_work': value.get('f'),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'relator_term': utils.force_list(
-            value.get('j')
-        ),
-        'language_of_a_work': value.get('l'),
-        'number_of_part_section_meeting': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_meeting_following_jurisdiction_name_entry_element': value.get('q'),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'version': value.get('s'),
-        'affiliation': value.get('u'),
-        'title_of_a_work': value.get('t'),
-        'international_standard_serial_number': value.get('x'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'type_of_meeting_name_entry_element': indicator_map1.get(key[3]),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('added_entry_uncontrolled_name', '^720[1_2].')
+@marc21.over('added_entry_uncontrolled_name', '^720[_12]_')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uncontrolled_name(self, key, value):
     """Added Entry-Uncontrolled Name."""
-    indicator_map1 = {"#": "Not specified", "1": "Personal", "2": "Other"}
+    indicator_map1 = {
+        '_': 'Not specified',
+        '1': 'Personal',
+        '2': 'Other',
+    }
 
     field_map = {
         'a': 'name',
@@ -339,28 +318,23 @@ def added_entry_uncontrolled_name(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'name': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
-        'relator_code': utils.force_list(
-            value.get('4')
-        ),
+        'relator_term': utils.force_list(value.get('e')),
+        'relator_code': utils.force_list(value.get('4')),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'type_of_name': indicator_map1.get(key[3]),
     }
 
 
-@marc21.over('added_entry_uniform_title', '^730[_1032547698][_2]')
+@marc21.over('added_entry_uniform_title', '^730[_0-9][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uniform_title(self, key, value):
     """Added Entry-Uniform Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map2 = {
-        '#': 'No information provided',
+        '_': 'No information provided',
         '2': 'Analytical entry',
     }
 
@@ -398,42 +372,28 @@ def added_entry_uniform_title(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'uniform_title': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
-        'date_of_treaty_signing': utils.force_list(
-            value.get('d')
-        ),
-        'miscellaneous_information': value.get('g'),
+        'date_of_treaty_signing': utils.force_list(value.get('d')),
         'date_of_a_work': value.get('f'),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'miscellaneous_information': value.get('g'),
         'medium': value.get('h'),
-        'form_subheading': utils.force_list(
-            value.get('k')
-        ),
-        'medium_of_performance_for_music': utils.force_list(
-            value.get('m')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'form_subheading': utils.force_list(value.get('k')),
         'language_of_a_work': value.get('l'),
+        'medium_of_performance_for_music': utils.force_list(value.get('m')),
+        'number_of_part_section_of_a_work': utils.force_list(value.get('n')),
         'arranged_statement_for_music': value.get('o'),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
+        'name_of_part_section_of_a_work': utils.force_list(value.get('p')),
+        'key_for_music': value.get('r'),
+        'version': value.get('s'),
+        'title_of_a_work': value.get('t'),
+        'international_standard_serial_number': value.get('x'),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'materials_specified': value.get('3'),
-        'key_for_music': value.get('r'),
         'institution_to_which_field_applies': value.get('5'),
-        'title_of_a_work': value.get('t'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'version': value.get('s'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'nonfiling_characters': key[3],
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
@@ -441,13 +401,17 @@ def added_entry_uniform_title(self, key, value):
 
 @marc21.over(
     'added_entry_uncontrolled_related_analytical_title',
-    '^740[_1032547698][_2]')
+    '^740[_0-9][_2]')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_uncontrolled_related_analytical_title(self, key, value):
     """Added Entry-Uncontrolled Related/Analytical Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
-    indicator_map2 = {"#": "No information provided", "2": "Analytical entry"}
+
+    indicator_map2 = {
+        '_': 'No information provided',
+        '2': 'Analytical entry',
+    }
 
     field_map = {
         'a': 'uncontrolled_related_analytical_title',
@@ -470,12 +434,8 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
         '__order__': tuple(order) if len(order) else None,
         'uncontrolled_related_analytical_title': value.get('a'),
         'medium': value.get('h'),
-        'number_of_part_section_of_a_work': utils.force_list(
-            value.get('n')
-        ),
-        'name_of_part_section_of_a_work': utils.force_list(
-            value.get('p')
-        ),
+        'number_of_part_section_of_a_work': utils.force_list(value.get('n')),
+        'name_of_part_section_of_a_work': utils.force_list(value.get('p')),
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
@@ -486,7 +446,7 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
     }
 
 
-@marc21.over('added_entry_geographic_name', '^751..')
+@marc21.over('added_entry_geographic_name', '^751__')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_geographic_name(self, key, value):
@@ -507,17 +467,13 @@ def added_entry_geographic_name(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'geographic_name': value.get('a'),
-        'relator_term': utils.force_list(
-            value.get('e')
-        ),
+        'relator_term': utils.force_list(value.get('e')),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
-        'materials_specified': value.get('3'),
         'source_of_heading_or_term': value.get('2'),
-        'relator_code': utils.force_list(
-            value.get('4')
-        ),
+        'materials_specified': value.get('3'),
+        'relator_code': utils.force_list(value.get('4')),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
@@ -525,7 +481,7 @@ def added_entry_geographic_name(self, key, value):
     }
 
 
-@marc21.over('added_entry_hierarchical_place_name', '^752..')
+@marc21.over('added_entry_hierarchical_place_name', '^752__')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_hierarchical_place_name(self, key, value):
@@ -548,35 +504,25 @@ def added_entry_hierarchical_place_name(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'country_or_larger_entity': utils.force_list(
-            value.get('a')
-        ),
-        'intermediate_political_jurisdiction': utils.force_list(
-            value.get('c')
-        ),
+        'country_or_larger_entity': utils.force_list(value.get('a')),
         'first_order_political_jurisdiction': value.get('b'),
+        'intermediate_political_jurisdiction': utils.force_list(value.get('c')),
         'city': value.get('d'),
+        'city_subsection': utils.force_list(value.get('f')),
         'other_nonjurisdictional_geographic_region_and_feature': utils.force_list(
             value.get('g')
         ),
-        'city_subsection': utils.force_list(
-            value.get('f')
-        ),
-        'extraterrestrial_area': utils.force_list(
-            value.get('h')
-        ),
+        'extraterrestrial_area': utils.force_list(value.get('h')),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'source_of_heading_or_term': value.get('2'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
     }
 
 
-@marc21.over('system_details_access_to_computer_files', '^753..')
+@marc21.over('system_details_access_to_computer_files', '^753__')
 @utils.for_each_value
 @utils.filter_values
 def system_details_access_to_computer_files(self, key, value):
@@ -594,16 +540,14 @@ def system_details_access_to_computer_files(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'make_and_model_of_machine': value.get('a'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'operating_system': value.get('c'),
         'programming_language': value.get('b'),
+        'operating_system': value.get('c'),
         'linkage': value.get('6'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
     }
 
 
-@marc21.over('added_entry_taxonomic_identification', '^754..')
+@marc21.over('added_entry_taxonomic_identification', '^754__')
 @utils.for_each_value
 @utils.filter_values
 def added_entry_taxonomic_identification(self, key, value):
@@ -624,27 +568,15 @@ def added_entry_taxonomic_identification(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'taxonomic_name': utils.force_list(
-            value.get('a')
-        ),
-        'non_public_note': utils.force_list(
-            value.get('x')
-        ),
-        'taxonomic_category': utils.force_list(
-            value.get('c')
-        ),
-        'common_or_alternative_name': utils.force_list(
-            value.get('d')
-        ),
+        'taxonomic_name': utils.force_list(value.get('a')),
+        'taxonomic_category': utils.force_list(value.get('c')),
+        'common_or_alternative_name': utils.force_list(value.get('d')),
+        'non_public_note': utils.force_list(value.get('x')),
+        'public_note': utils.force_list(value.get('z')),
         'authority_record_control_number_or_standard_number': utils.force_list(
             value.get('0')
         ),
         'source_of_taxonomic_identification': value.get('2'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'public_note': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
     }

--- a/dojson/contrib/marc21/fields/bd76x78x.py
+++ b/dojson/contrib/marc21/fields/bd76x78x.py
@@ -14,13 +14,20 @@ from dojson import utils
 from ..model import marc21
 
 
-@marc21.over('main_series_entry', '^760[10_][8_]')
+@marc21.over('main_series_entry', '^760[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def main_series_entry(self, key, value):
     """Main Series Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
-    indicator_map2 = {"#": "Main series", "8": "No display constant generated"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
+    indicator_map2 = {
+        '_': 'Main series',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -54,52 +61,41 @@ def main_series_entry(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
         'uniform_title': value.get('s'),
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'coden_designation': value.get('y'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'title': value.get('t'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('subseries_entry', '^762[10_][8_]')
+@marc21.over('subseries_entry', '^762[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def subseries_entry(self, key, value):
     """Subseries Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
     indicator_map2 = {
-        "#": "Has subseries",
-        "8": "No display constant generated"
+        '_': 'Has subseries',
+        '8': 'No display constant generated'
     }
 
     field_map = {
@@ -134,52 +130,42 @@ def subseries_entry(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
         'uniform_title': value.get('s'),
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'title': value.get('t'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'coden_designation': value.get('y'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'title': value.get('t'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('original_language_entry', '^765[10_][8_]')
+@marc21.over('original_language_entry', '^765[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def original_language_entry(self, key, value):
     """Original Language Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Translation of",
-        "8": "No display constant generated"
+        '_': 'Translation of',
+        '8': 'No display constant generated'
     }
 
     field_map = {
@@ -217,63 +203,47 @@ def original_language_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('translation_entry', '^767[10_][8_]')
+@marc21.over('translation_entry', '^767[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def translation_entry(self, key, value):
     """Translation Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Translated as",
-        "8": "No display constant generated"
+        '_': 'Translated as',
+        '8': 'No display constant generated',
     }
 
     field_map = {
@@ -311,63 +281,47 @@ def translation_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('supplement_special_issue_entry', '^770[10_][8_]')
+@marc21.over('supplement_special_issue_entry', '^770[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def supplement_special_issue_entry(self, key, value):
     """Supplement/Special Issue Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Has supplement",
-        "8": "No display constant generated"
+        '_': 'Has supplement',
+        '8': 'No display constant generated'
     }
 
     field_map = {
@@ -405,64 +359,48 @@ def supplement_special_issue_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('supplement_parent_entry', '^772[10_][0_8]')
+@marc21.over('supplement_parent_entry', '^772[_01][_08]')
 @utils.for_each_value
 @utils.filter_values
 def supplement_parent_entry(self, key, value):
     """Supplement Parent Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Supplement to",
-        "0": "Parent",
-        "8": "No display constant generated"
+        '_': 'Supplement to',
+        '0': 'Parent',
+        '8': 'No display constant generated',
     }
 
     field_map = {
@@ -500,61 +438,48 @@ def supplement_parent_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('host_item_entry', '^773[10_][8_]')
+@marc21.over('host_item_entry', '^773[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def host_item_entry(self, key, value):
     """Host Item Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
-    indicator_map2 = {"#": "In", "8": "No display constant generated"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
+    indicator_map2 = {
+        '_': 'In',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -593,65 +518,49 @@ def host_item_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'materials_specified': value.get('3'),
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'main_entry_heading': value.get('a'),
         'edition': value.get('b'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'enumeration_and_first_page': value.get('q'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
         'abbreviated_title': value.get('p'),
+        'report_number': utils.force_list(value.get('r')),
+        'enumeration_and_first_page': value.get('q'),
         'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
         'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
         'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'materials_specified': value.get('3'),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('constituent_unit_entry', '^774[10_][8_]')
+@marc21.over('constituent_unit_entry', '^774[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def constituent_unit_entry(self, key, value):
     """Constituent Unit Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Constituent unit",
-        "8": "No display constant generated"
+        '_': 'Constituent unit',
+        '8': 'No display constant generated'
     }
 
     field_map = {
@@ -689,63 +598,48 @@ def constituent_unit_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('other_edition_entry', '^775[10_][8_]')
+@marc21.over('other_edition_entry', '^775[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def other_edition_entry(self, key, value):
     """Other Edition Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Other edition available",
-        "8": "No display constant generated"}
+        '_': 'Other edition available',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -779,71 +673,55 @@ def other_edition_entry(self, key, value):
 
     if key[3] in indicator_map1:
         order.append('note_controller')
-
     if key[4] in indicator_map2:
         order.append('display_constant_controller')
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
-        'language_code': value.get('e'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
+        'language_code': value.get('e'),
         'country_code': value.get('f'),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
         'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
         'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
         'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('additional_physical_form_entry', '^776[10_][8_]')
+@marc21.over('additional_physical_form_entry', '^776[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def additional_physical_form_entry(self, key, value):
     """Additional Physical Form Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "#": "Available in another form",
-        "8": "No display constant generated"}
+        '_': 'Available in another form',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -880,61 +758,48 @@ def additional_physical_form_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('issued_with_entry', '^777[10_][8_]')
+@marc21.over('issued_with_entry', '^777[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def issued_with_entry(self, key, value):
     """Issued With Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
-    indicator_map2 = {"#": "Issued with", "8": "No display constant generated"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
+    indicator_map2 = {
+        '_': 'Issued with',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -969,61 +834,49 @@ def issued_with_entry(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'main_entry_heading': value.get('a'),
-        'international_standard_serial_number': value.get('x'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
         'uniform_title': value.get('s'),
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'coden_designation': value.get('y'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'title': value.get('t'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('preceding_entry', '^780[10_][_10325476]')
+@marc21.over('preceding_entry', '^780[_01][_0-7]')
 @utils.for_each_value
 @utils.filter_values
 def preceding_entry(self, key, value):
     """Preceding Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "0": "Continues",
-        "1": "Continues in part",
-        "2": "Supersedes",
-        "3": "Supersedes in part",
-        "4": "Formed by the union of ... and ...",
-        "5": "Absorbed",
-        "6": "Absorbed in part",
-        "7": "Separated from"
+        '0': 'Continues',
+        '1': 'Continues in part',
+        '2': 'Supersedes',
+        '3': 'Supersedes in part',
+        '4': 'Formed by the union of ... and ...',
+        '5': 'Absorbed',
+        '6': 'Absorbed in part',
+        '7': 'Separated from',
     }
 
     field_map = {
@@ -1061,70 +914,55 @@ def preceding_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
         'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
         'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
         'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'type_of_relationship': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('succeeding_entry', '^785[10_][_103254768]')
+@marc21.over('succeeding_entry', '^785[_01][_0-8]')
 @utils.for_each_value
 @utils.filter_values
 def succeeding_entry(self, key, value):
     """Succeeding Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
     indicator_map2 = {
-        "0": "Continued by",
-        "1": "Continued in part by",
-        "2": "Superseded by",
-        "3": "Superseded in part by",
-        "4": "Absorbed by",
-        "5": "Absorbed in part by",
-        "6": "Split into ... and ...",
-        "7": "Merged with ... to form ...",
-        "8": "Changed back to"}
+        '0': 'Continued by',
+        '1': 'Continued in part by',
+        '2': 'Superseded by',
+        '3': 'Superseded in part by',
+        '4': 'Absorbed by',
+        '5': 'Absorbed in part by',
+        '6': 'Split into ... and ...',
+        '7': 'Merged with ... to form ...',
+        '8': 'Changed back to',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -1161,61 +999,48 @@ def succeeding_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
         'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
         'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
         'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'type_of_relationship': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('data_source_entry', '^786[10_][8_]')
+@marc21.over('data_source_entry', '^786[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def data_source_entry(self, key, value):
     """Data Source Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
-    indicator_map2 = {"#": "Data source", "8": "No display constant generated"}
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
+    }
+
+    indicator_map2 = {
+        '_': 'Data source',
+        '8': 'No display constant generated',
+    }
 
     field_map = {
         'a': 'main_entry_heading',
@@ -1255,67 +1080,52 @@ def data_source_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
+        'main_entry_heading': value.get('a'),
+        'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
+        'place_publisher_and_date_of_publication': value.get('d'),
+        'related_parts': utils.force_list(value.get('g')),
+        'physical_description': value.get('h'),
+        'relationship_information': utils.force_list(value.get('i')),
+        'period_of_content': value.get('j'),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
+        'material_specific_details': value.get('m'),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'abbreviated_title': value.get('p'),
+        'report_number': utils.force_list(value.get('r')),
+        'uniform_title': value.get('s'),
+        'title': value.get('t'),
+        'standard_technical_report_number': value.get('u'),
+        'source_contribution': value.get('v'),
+        'record_control_number': utils.force_list(value.get('w')),
+        'international_standard_serial_number': value.get('x'),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
         'control_subfield': value.get('7'),
         'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
-        'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
-        'edition': value.get('b'),
-        'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
-        'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
-        'period_of_content': value.get('j'),
-        'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
-        'abbreviated_title': value.get('p'),
-        'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
-        'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'source_contribution': value.get('v'),
-        'coden_designation': value.get('y'),
-        'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }
 
 
-@marc21.over('other_relationship_entry', '^787[10_][8_]')
+@marc21.over('other_relationship_entry', '^787[_01][_8]')
 @utils.for_each_value
 @utils.filter_values
 def other_relationship_entry(self, key, value):
     """Other Relationship Entry."""
-    indicator_map1 = {"0": "Display note", "1": "Do not display note"}
-    indicator_map2 = {
-        "#": "Related item",
-        "8": "No display constant generated",
+    indicator_map1 = {
+        '0': 'Display note',
+        '1': 'Do not display note',
     }
+
+    indicator_map2 = {
+        '_': 'Related item',
+        '8': 'No display constant generated',
+    }
+
     field_map = {
         'a': 'main_entry_heading',
         'b': 'edition',
@@ -1351,49 +1161,29 @@ def other_relationship_entry(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'relationship_code': utils.force_list(
-            value.get('4')
-        ),
-        'control_subfield': value.get('7'),
-        'linkage': value.get('6'),
-        'field_link_and_sequence_number': utils.force_list(
-            value.get('8')
-        ),
         'main_entry_heading': value.get('a'),
-        'qualifying_information': value.get('c'),
         'edition': value.get('b'),
+        'qualifying_information': value.get('c'),
         'place_publisher_and_date_of_publication': value.get('d'),
-        'related_parts': utils.force_list(
-            value.get('g')
-        ),
-        'relationship_information': utils.force_list(
-            value.get('i')
-        ),
+        'related_parts': utils.force_list(value.get('g')),
         'physical_description': value.get('h'),
-        'series_data_for_related_item': utils.force_list(
-            value.get('k')
-        ),
+        'relationship_information': utils.force_list(value.get('i')),
+        'series_data_for_related_item': utils.force_list(value.get('k')),
         'material_specific_details': value.get('m'),
-        'other_item_identifier': utils.force_list(
-            value.get('o')
-        ),
-        'note': utils.force_list(
-            value.get('n')
-        ),
+        'note': utils.force_list(value.get('n')),
+        'other_item_identifier': utils.force_list(value.get('o')),
+        'report_number': utils.force_list(value.get('r')),
         'uniform_title': value.get('s'),
-        'report_number': utils.force_list(
-            value.get('r')
-        ),
-        'standard_technical_report_number': value.get('u'),
         'title': value.get('t'),
-        'record_control_number': utils.force_list(
-            value.get('w')
-        ),
-        'coden_designation': value.get('y'),
+        'standard_technical_report_number': value.get('u'),
+        'record_control_number': utils.force_list(value.get('w')),
         'international_standard_serial_number': value.get('x'),
-        'international_standard_book_number': utils.force_list(
-            value.get('z')
-        ),
+        'coden_designation': value.get('y'),
+        'international_standard_book_number': utils.force_list(value.get('z')),
+        'relationship_code': utils.force_list(value.get('4')),
+        'linkage': value.get('6'),
+        'control_subfield': value.get('7'),
+        'field_link_and_sequence_number': utils.force_list(value.get('8')),
         'note_controller': indicator_map1.get(key[3]),
         'display_constant_controller': indicator_map2.get(key[4]),
     }

--- a/dojson/contrib/to_marc21/fields/bd6xx.py
+++ b/dojson/contrib/to_marc21/fields/bd6xx.py
@@ -19,16 +19,21 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_subject_added_entry_personal_name(self, key, value):
     """Reverse - Subject Added Entry-Personal Name."""
-    indicator_map1 = {"Family name": "3", "Forename": "0", "Surname": "1"}
+    indicator_map1 = {
+        'Forename': '0',
+        'Surname': '1',
+        'Family name': '3',
+    }
+
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7',
     }
 
     field_map = {
@@ -66,70 +71,71 @@ def reverse_subject_added_entry_personal_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_personal_name_entry_element')
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('personal_name'),
+        'b': value.get('numeration'),
+        'c': utils.reverse_force_list(
+            value.get('titles_and_other_words_associated_with_a_name')
+        ),
+        'd': value.get('dates_associated_with_a_name'),
+        'e': utils.reverse_force_list(
+            value.get('relator_term')
+        ),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'j': utils.reverse_force_list(
+            value.get('attribution_qualifier')
+        ),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(
+            value.get('medium_of_performance_for_music')
+        ),
+        'n': utils.reverse_force_list(
+            value.get('number_of_part_section_of_a_work')
+        ),
+        'o': value.get('arranged_statement_for_music'),
+        'p': utils.reverse_force_list(
+            value.get('name_of_part_section_of_a_work')
+        ),
+        'q': value.get('fuller_form_of_name'),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'v': utils.reverse_force_list(
+            value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('personal_name'),
-        'c': utils.reverse_force_list(
-            value.get('titles_and_other_words_associated_with_a_name')
-        ),
-        'b': value.get('numeration'),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'd': value.get('dates_associated_with_a_name'),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'j': utils.reverse_force_list(
-            value.get('attribution_qualifier')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
-        'l': value.get('language_of_a_work'),
-        'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_of_a_work')
-        ),
-        'q': value.get('fuller_form_of_name'),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'r': value.get('key_for_music'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'v': utils.reverse_force_list(
-            value.get('form_subdivision')
-        ),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': indicator_map1.get(value.get('type_of_personal_name_entry_element'), '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -142,18 +148,19 @@ def reverse_subject_added_entry_personal_name(self, key, value):
 def reverse_subject_added_entry_corporate_name(self, key, value):
     """Reverse - Subject Added Entry-Corporate Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7',
     }
 
     field_map = {
@@ -189,68 +196,69 @@ def reverse_subject_added_entry_corporate_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_corporate_name_entry_element')
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
+        'b': utils.reverse_force_list(
+            value.get('subordinate_unit')
+        ),
+        'c': value.get('location_of_meeting'),
+        'd': utils.reverse_force_list(
+            value.get('date_of_meeting_or_treaty_signing')
+        ),
+        'e': utils.reverse_force_list(
+            value.get('relator_term')
+        ),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(
+            value.get('medium_of_performance_for_music')
+        ),
+        'n': utils.reverse_force_list(
+            value.get('number_of_part_section_meeting')
+        ),
+        'o': value.get('arranged_statement_for_music'),
+        'p': utils.reverse_force_list(
+            value.get('name_of_part_section_of_a_work')
+        ),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'v': utils.reverse_force_list(
+            value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
-        'c': value.get('location_of_meeting'),
-        'b': utils.reverse_force_list(
-            value.get('subordinate_unit')
-        ),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'd': utils.reverse_force_list(
-            value.get('date_of_meeting_or_treaty_signing')
-        ),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
-        'l': value.get('language_of_a_work'),
-        'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_meeting')
-        ),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'r': value.get('key_for_music'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'v': utils.reverse_force_list(
-            value.get('form_subdivision')
-        ),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': indicator_map1.get(value.get('type_of_corporate_name_entry_element'), '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -263,18 +271,19 @@ def reverse_subject_added_entry_corporate_name(self, key, value):
 def reverse_subject_added_entry_meeting_name(self, key, value):
     """Reverse - Subject Added Entry-Meeting Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7',
     }
 
     field_map = {
@@ -308,62 +317,63 @@ def reverse_subject_added_entry_meeting_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_meeting_name_entry_element')
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
+        'c': value.get('location_of_meeting'),
+        'd': value.get('date_of_meeting'),
+        'e': utils.reverse_force_list(
+            value.get('subordinate_unit')
+        ),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'j': utils.reverse_force_list(
+            value.get('relator_term')
+        ),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'n': utils.reverse_force_list(
+            value.get('number_of_part_section_meeting')
+        ),
+        'p': utils.reverse_force_list(
+            value.get('name_of_part_section_of_a_work')
+        ),
+        'q': value.get('name_of_meeting_following_jurisdiction_name_entry_element'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'v': utils.reverse_force_list(
+            value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
-        'c': value.get('location_of_meeting'),
-        'e': utils.reverse_force_list(
-            value.get('subordinate_unit')
-        ),
-        'd': value.get('date_of_meeting'),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'j': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'l': value.get('language_of_a_work'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_meeting')
-        ),
-        'q': value.get('name_of_meeting_following_jurisdiction_name_entry_element'),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'v': utils.reverse_force_list(
-            value.get('form_subdivision')
-        ),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': indicator_map1.get(value.get('type_of_meeting_name_entry_element'), '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -376,15 +386,16 @@ def reverse_subject_added_entry_meeting_name(self, key, value):
 def reverse_subject_added_entry_uniform_title(self, key, value):
     """Reverse - Subject Added Entry-Uniform Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7'
     }
 
     field_map = {
@@ -417,64 +428,64 @@ def reverse_subject_added_entry_uniform_title(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in valid_nonfiling_characters:
-        order.append('nonfiling_characters')
-
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('uniform_title'),
+        'd': utils.reverse_force_list(
+            value.get('date_of_treaty_signing')
+        ),
+        'e': utils.reverse_force_list(
+            value.get('relator_term')
+        ),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(
+            value.get('medium_of_performance_for_music')
+        ),
+        'n': utils.reverse_force_list(
+            value.get('number_of_part_section_of_a_work')
+        ),
+        'o': value.get('arranged_statement_for_music'),
+        'p': utils.reverse_force_list(
+            value.get('name_of_part_section_of_a_work')
+        ),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'v': utils.reverse_force_list(
+            value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('uniform_title'),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'd': utils.reverse_force_list(
-            value.get('date_of_treaty_signing')
-        ),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
-        'l': value.get('language_of_a_work'),
-        'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_of_a_work')
-        ),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'r': value.get('key_for_music'),
-        't': value.get('title_of_a_work'),
-        'v': utils.reverse_force_list(
-            value.get('form_subdivision')
-        ),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': value.get('nonfiling_characters', '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -487,18 +498,20 @@ def reverse_subject_added_entry_uniform_title(self, key, value):
 def reverse_subject_added_entry_chronological_term(self, key, value):
     """Reverse - Subject Added Entry-Chronological Term."""
     indicator_map1 = {
-        "Date or time period covered or depicted": "0",
-        "Date or time period of creation or origin": "1",
-        "No information provided": "_"}
+        'No information provided': '_',
+        'Date or time period covered or depicted': '0',
+        'Date or time period of creation or origin': '1',
+    }
+
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00c3\u00a9pertoire de vedettes-mati\u00c3\u00a8re': '6',
+        'Source specified in subfield $2': '7'
     }
 
     field_map = {
@@ -512,16 +525,21 @@ def reverse_subject_added_entry_chronological_term(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('chronological_term'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')),
         'v': utils.reverse_force_list(
             value.get('form_subdivision')),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')),
         '3': value.get('materials_specified'),
@@ -531,8 +549,6 @@ def reverse_subject_added_entry_chronological_term(self, key, value):
             value.get('chronological_subdivision')),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')),
         '$ind1': indicator_map1.get(
             value.get('type_of_date_or_time_period'),
             '_'),
@@ -548,19 +564,21 @@ def reverse_subject_added_entry_chronological_term(self, key, value):
 def reverse_subject_added_entry_topical_term(self, key, value):
     """Reverse - Subject Added Entry-Topical Term."""
     indicator_map1 = {
-        "No information provided": "_",
-        "No level specified": "0",
-        "Primary": "1",
-        "Secondary": "2"}
+        'No information provided': '_',
+        'No level specified': '0',
+        'Primary': '1',
+        'Secondary': '2',
+    }
+
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7",
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7',
     }
 
     field_map = {
@@ -584,43 +602,44 @@ def reverse_subject_added_entry_topical_term(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('level_of_subject')
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('topical_term_or_geographic_name_entry_element'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
-        'c': value.get('location_of_event'),
         'b': value.get('topical_term_following_geographic_name_entry_element'),
+        'c': value.get('location_of_event'),
+        'd': value.get('active_dates'),
         'e': utils.reverse_force_list(
             value.get('relator_term')
         ),
-        'd': value.get('active_dates'),
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
         ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': indicator_map1.get(value.get('level_of_subject'), '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -633,14 +652,14 @@ def reverse_subject_added_entry_topical_term(self, key, value):
 def reverse_subject_added_entry_geographic_name(self, key, value):
     """Reverse - Subject Added Entry-Geographic Name."""
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7'
     }
 
     field_map = {
@@ -661,38 +680,41 @@ def reverse_subject_added_entry_geographic_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_name'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
         'e': utils.reverse_force_list(
             value.get('relator_term')
         ),
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
         ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': '_',
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -705,19 +727,21 @@ def reverse_subject_added_entry_geographic_name(self, key, value):
 def reverse_index_term_uncontrolled(self, key, value):
     """Reverse - Index Term-Uncontrolled."""
     indicator_map1 = {
-        "No information provided": "_",
-        "No level specified": "0",
-        "Primary": "1",
-        "Secondary": "2"}
+        'No information provided': '_',
+        'No level specified': '0',
+        'Primary': '1',
+        'Secondary': '2',
+    }
+
     indicator_map2 = {
-        "Chronological term": "4",
-        "Corporate name": "2",
-        "Genre/form term": "6",
-        "Geographic name": "5",
-        "Meeting name": "3",
-        "No information provided": "_",
-        "Personal name": "1",
-        "Topical term": "0"
+        'No information provided': '_',
+        'Topical term': '0',
+        'Personal name': '1',
+        'Corporate name': '2',
+        'Meeting name': '3',
+        'Chronological term': '4',
+        'Geographic name': '5',
+        'Genre/form term': '6',
     }
 
     field_map = {
@@ -728,20 +752,15 @@ def reverse_index_term_uncontrolled(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('level_of_index_term')
-    if key[4] in indicator_map2:
-        order.append('type_of_term_or_name')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('uncontrolled_term')
         ),
+        '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '6': value.get('linkage'),
         '$ind1': indicator_map1.get(value.get('level_of_index_term'), '_'),
         '$ind2': indicator_map2.get(value.get('type_of_term_or_name'), '_'),
     }
@@ -753,10 +772,10 @@ def reverse_index_term_uncontrolled(self, key, value):
 def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
     """Reverse - Subject Added Entry-Faceted Topical Terms."""
     indicator_map1 = {
-        "No information provided": "_",
-        "No level specified": "0",
-        "Primary": "1",
-        "Secondary": "2"
+        'No information provided': '_',
+        'No level specified': '0',
+        'Primary': '1',
+        'Secondary': '2',
     }
 
     field_map = {
@@ -777,19 +796,16 @@ def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('level_of_subject')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': utils.reverse_force_list(
             value.get('focus_term')
         ),
-        'c': utils.reverse_force_list(
-            value.get('facet_hierarchy_designation')
-        ),
         'b': utils.reverse_force_list(
             value.get('non_focus_term')
+        ),
+        'c': utils.reverse_force_list(
+            value.get('facet_hierarchy_designation')
         ),
         'e': utils.reverse_force_list(
             value.get('relator_term')
@@ -797,23 +813,23 @@ def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
         ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
+        ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
+        '3': value.get('materials_specified'),
         '4': utils.reverse_force_list(
             value.get('relator_code')
         ),
         '6': value.get('linkage'),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
         ),
         '$ind1': indicator_map1.get(value.get('level_of_subject'), '_'),
         '$ind2': '_',
@@ -825,16 +841,20 @@ def reverse_subject_added_entry_faceted_topical_terms(self, key, value):
 @utils.filter_values
 def reverse_index_term_genre_form(self, key, value):
     """Reverse - Index Term-Genre/Form."""
-    indicator_map1 = {"Basic": "_", "Faceted": "0"}
+    indicator_map1 = {
+        'Basic': '_',
+        'Faceted': '0',
+    }
+
     indicator_map2 = {
-        "Canadian Subject Headings": "5",
-        "LC subject headings for children\u0027s literature": "1",
-        "Library of Congress Subject Headings": "0",
-        "Medical Subject Headings": "2",
-        "National Agricultural Library subject authority file": "3",
-        "R\u00e9pertoire de vedettes-mati\u00e8re": "6",
-        "Source not specified": "4",
-        "Source specified in subfield $2": "7"
+        'Library of Congress Subject Headings': '0',
+        'LC subject headings for children\u0027s literature': '1',
+        'Medical Subject Headings': '2',
+        'National Agricultural Library subject authority file': '3',
+        'Source not specified': '4',
+        'Canadian Subject Headings': '5',
+        'R\u00e9pertoire de vedettes-mati\u00e8re': '6',
+        'Source specified in subfield $2': '7'
     }
 
     field_map = {
@@ -855,17 +875,15 @@ def reverse_index_term_genre_form(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_heading')
-    if key[4] in indicator_map2:
-        order.append('thesaurus')
+    if indicator_map2.get(value.get('thesaurus'), '7') != '7':
+        try:
+            order.remove('2')
+        except ValueError:
+            pass
 
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('genre_form_data_or_focus_term'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
         'c': utils.reverse_force_list(
             value.get('facet_hierarchy_designation')
         ),
@@ -875,21 +893,24 @@ def reverse_index_term_genre_form(self, key, value):
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
         ),
-        '0': utils.reverse_force_list(
-            value.get('authority_record_control_number_or_standard_number')
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
         ),
-        '3': value.get('materials_specified'),
-        '2': value.get('source_of_term'),
-        '5': value.get('institution_to_which_field_applies'),
-        '6': value.get('linkage'),
         'y': utils.reverse_force_list(
             value.get('chronological_subdivision')
         ),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         'z': utils.reverse_force_list(
             value.get('geographic_subdivision')
+        ),
+        '0': utils.reverse_force_list(
+            value.get('authority_record_control_number_or_standard_number')
+        ),
+        '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
+        '5': value.get('institution_to_which_field_applies'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
         ),
         '$ind1': indicator_map1.get(value.get('type_of_heading'), '_'),
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
@@ -920,12 +941,18 @@ def reverse_index_term_occupation(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('occupation'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
         'k': value.get('form'),
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
+        ),
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
+        ),
+        'y': utils.reverse_force_list(
+            value.get('chronological_subdivision')
+        ),
+        'z': utils.reverse_force_list(
+            value.get('geographic_subdivision')
         ),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
@@ -933,17 +960,11 @@ def reverse_index_term_occupation(self, key, value):
         '3': value.get('materials_specified'),
         '2': value.get('source_of_term'),
         '6': value.get('linkage'),
-        'y': utils.reverse_force_list(
-            value.get('chronological_subdivision')
-        ),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        'z': utils.reverse_force_list(
-            value.get('geographic_subdivision')
-        ),
         '$ind1': '_',
-        '$ind2': '_',
+        '$ind2': '7',
     }
 
 
@@ -970,29 +991,29 @@ def reverse_index_term_function(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('function'),
-        'x': utils.reverse_force_list(
-            value.get('general_subdivision')
-        ),
         'v': utils.reverse_force_list(
             value.get('form_subdivision')
         ),
-        '0': utils.reverse_force_list(
-            value.get('authority_record_control_number_or_standard_number')
+        'x': utils.reverse_force_list(
+            value.get('general_subdivision')
         ),
-        '3': value.get('materials_specified'),
-        '2': value.get('source_of_term'),
-        '6': value.get('linkage'),
         'y': utils.reverse_force_list(
             value.get('chronological_subdivision')
-        ),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
         ),
         'z': utils.reverse_force_list(
             value.get('geographic_subdivision')
         ),
+        '0': utils.reverse_force_list(
+            value.get('authority_record_control_number_or_standard_number')
+        ),
+        '2': value.get('source_of_term'),
+        '3': value.get('materials_specified'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(
+            value.get('field_link_and_sequence_number')
+        ),
         '$ind1': '_',
-        '$ind2': '_',
+        '$ind2': '7',
     }
 
 
@@ -1016,10 +1037,10 @@ def reverse_index_term_curriculum_objective(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_curriculum_objective'),
-        'c': value.get('curriculum_code'),
         'b': utils.reverse_force_list(
             value.get('subordinate_curriculum_objective')
         ),
+        'c': value.get('curriculum_code'),
         'd': value.get('correlation_factor'),
         '2': value.get('source_of_term_or_code'),
         '6': value.get('linkage'),
@@ -1059,19 +1080,19 @@ def reverse_subject_added_entry_hierarchical_place_name(self, key, value):
         'a': utils.reverse_force_list(
             value.get('country_or_larger_entity')
         ),
+        'b': value.get('first_order_political_jurisdiction'),
         'c': utils.reverse_force_list(
             value.get('intermediate_political_jurisdiction')
         ),
-        'b': value.get('first_order_political_jurisdiction'),
+        'd': value.get('city'),
         'e': utils.reverse_force_list(
             value.get('relator_term')
         ),
-        'd': value.get('city'),
-        'g': utils.reverse_force_list(
-            value.get('other_nonjurisdictional_geographic_region_and_feature')
-        ),
         'f': utils.reverse_force_list(
             value.get('city_subsection')
+        ),
+        'g': utils.reverse_force_list(
+            value.get('other_nonjurisdictional_geographic_region_and_feature')
         ),
         'h': utils.reverse_force_list(
             value.get('extraterrestrial_area')

--- a/dojson/contrib/to_marc21/fields/bd70x75x.py
+++ b/dojson/contrib/to_marc21/fields/bd70x75x.py
@@ -24,23 +24,20 @@ def reverse_added_entry_personal_name(self, key, value):
         'Surname': '1',
         'Family name': '3',
     }
+
     indicator_map2 = {
         'No information provided': '_',
         'Analytical entry': '2',
     }
+
     field_map = {
-        'authority_record_control_number_or_standard_number': '0',
-        'materials_specified': '3',
-        'relator_code': '4',
-        'institution_to_which_field_applies': '5',
-        'linkage': '6',
-        'field_link_and_sequence_number': '8',
         'personal_name': 'a',
         'numeration': 'b',
         'titles_and_other_words_associated_with_a_name': 'c',
         'dates_associated_with_a_name': 'd',
         'relator_term': 'e',
         'date_of_a_work': 'f',
+        'miscellaneous_information': 'g',
         'medium': 'h',
         'relationship_information': 'i',
         'attribution_qualifier': 'j',
@@ -50,76 +47,66 @@ def reverse_added_entry_personal_name(self, key, value):
         'number_of_part_section_of_a_work': 'n',
         'arranged_statement_for_music': 'o',
         'name_of_part_section_of_a_work': 'p',
-        'version': 's',
+        'fuller_form_of_name': 'q',
         'key_for_music': 'r',
-        'affiliation': 'u',
+        'version': 's',
         'title_of_a_work': 't',
+        'affiliation': 'u',
         'international_standard_serial_number': 'x',
-        'type_of_personal_name_entry_element': None,
-        'type_of_added_entry': None
+        'authority_record_control_number_or_standard_number': '0',
+        'materials_specified': '3',
+        'relator_code': '4',
+        'institution_to_which_field_applies': '5',
+        'linkage': '6',
+        'field_link_and_sequence_number': '8',
     }
 
-    ind1 = indicator_map1.get(
-        value.get(
-            'type_of_personal_name_entry_element',
-            '_'))
-    ind2 = indicator_map2.get(value.get('type_of_added_entry', '_'))
     order = utils.map_order(field_map, value)
 
     return {
+        '__order__': tuple(order) if len(order) else None,
+        'a': value.get('personal_name'),
+        'b': value.get('numeration'),
+        'c': utils.reverse_force_list(
+            value.get('titles_and_other_words_associated_with_a_name')
+        ),
+        'd': value.get('dates_associated_with_a_name'),
+        'e': utils.reverse_force_list(
+            value.get('relator_term')
+        ),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'i': utils.reverse_force_list(
+            value.get('relationship_information')
+        ),
+        'j': utils.reverse_force_list(value.get('attribution_qualifier')),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(
+            value.get('medium_of_performance_for_music')
+        ),
+        'n': utils.reverse_force_list(value.get('number_of_part_section_of_a_work')),
+        'o': value.get('arranged_statement_for_music'),
+        'p': utils.reverse_force_list(value.get('name_of_part_section_of_a_work')),
+        'q': value.get('fuller_form_of_name'),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'x': value.get('international_standard_serial_number'),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
+        '4': utils.reverse_force_list(value.get('relator_code')),
         '5': value.get('institution_to_which_field_applies'),
-        '4': utils.reverse_force_list(
-            value.get('relator_code')
-        ),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('personal_name'),
-        'c': utils.reverse_force_list(
-            value.get('titles_and_other_words_associated_with_a_name')
-        ),
-        'b': value.get('numeration'),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'd': value.get('dates_associated_with_a_name'),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'j': utils.reverse_force_list(
-            value.get('attribution_qualifier')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
-        'l': value.get('language_of_a_work'),
-        'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_of_a_work')
-        ),
-        'q': value.get('fuller_form_of_name'),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'r': value.get('key_for_music'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'x': value.get('international_standard_serial_number'),
-        '$ind1': ind1,
-        '$ind2': ind2,
-        '__order__': tuple(order) if len(order) else None
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
+        '$ind1': indicator_map1.get(value.get('type_of_personal_name_entry_element', '_')),
+        '$ind2': indicator_map2.get(value.get('type_of_added_entry', '_')),
     }
 
 
@@ -129,10 +116,15 @@ def reverse_added_entry_personal_name(self, key, value):
 def reverse_added_entry_corporate_name(self, key, value):
     """Reverse - Added Entry-Corporate Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
-    indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
+    indicator_map2 = {
+        'No information provided': '_',
+        'Analytical entry': '2',
+    }
 
     field_map = {
         'corporate_name_or_jurisdiction_name_as_entry_element': 'a',
@@ -165,61 +157,40 @@ def reverse_added_entry_corporate_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_corporate_name_entry_element')
-    if key[4] in indicator_map2:
-        order.append('type_of_added_entry')
-
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
+        'b': utils.reverse_force_list(value.get('subordinate_unit')),
+        'c': value.get('location_of_meeting'),
+        'd': utils.reverse_force_list(value.get('date_of_meeting_or_treaty_signing')),
+        'e': utils.reverse_force_list(value.get('relator_term')),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(
+            value.get('form_subheading')
+        ),
+        'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(value.get('medium_of_performance_for_music')),
+        'n': utils.reverse_force_list(value.get('number_of_part_section_meeting')),
+        'o': value.get('arranged_statement_for_music'),
+        'p': utils.reverse_force_list(
+            value.get('name_of_part_section_of_a_work')
+        ),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'x': value.get('international_standard_serial_number'),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
+        '4': utils.reverse_force_list(value.get('relator_code')),
         '5': value.get('institution_to_which_field_applies'),
-        '4': utils.reverse_force_list(
-            value.get('relator_code')
-        ),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('corporate_name_or_jurisdiction_name_as_entry_element'),
-        'c': value.get('location_of_meeting'),
-        'b': utils.reverse_force_list(
-            value.get('subordinate_unit')
-        ),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'd': utils.reverse_force_list(
-            value.get('date_of_meeting_or_treaty_signing')
-        ),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
-        'l': value.get('language_of_a_work'),
-        'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_meeting')
-        ),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'r': value.get('key_for_music'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'x': value.get('international_standard_serial_number'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('type_of_corporate_name_entry_element'), '_'),
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
@@ -231,10 +202,15 @@ def reverse_added_entry_corporate_name(self, key, value):
 def reverse_added_entry_meeting_name(self, key, value):
     """Reverse - Added Entry-Meeting Name."""
     indicator_map1 = {
-        "Inverted name": "0",
-        "Jurisdiction name": "1",
-        "Name in direct order": "2"}
-    indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+        'Inverted name': '0',
+        'Jurisdiction name': '1',
+        'Name in direct order': '2',
+    }
+
+    indicator_map2 = {
+        'No information provided': '_',
+        'Analytical entry': '2',
+    }
 
     field_map = {
         'meeting_name_or_jurisdiction_name_as_entry_element': 'a',
@@ -265,55 +241,34 @@ def reverse_added_entry_meeting_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_meeting_name_entry_element')
-    if key[4] in indicator_map2:
-        order.append('type_of_added_entry')
-
     return {
         '__order__': tuple(order) if len(order) else None,
+        'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
+        'c': value.get('location_of_meeting'),
+        'd': value.get('date_of_meeting'),
+        'e': utils.reverse_force_list(value.get('subordinate_unit')),
+        'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'j': utils.reverse_force_list(value.get('relator_term')),
+        'k': utils.reverse_force_list(value.get('form_subheading')),
+        'l': value.get('language_of_a_work'),
+        'n': utils.reverse_force_list(value.get('number_of_part_section_meeting')),
+        'p': utils.reverse_force_list(value.get('name_of_part_section_of_a_work')),
+        'q': value.get('name_of_meeting_following_jurisdiction_name_entry_element'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'u': value.get('affiliation'),
+        'x': value.get('international_standard_serial_number'),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
+        '4': utils.reverse_force_list(value.get('relator_code')),
         '5': value.get('institution_to_which_field_applies'),
-        '4': utils.reverse_force_list(
-            value.get('relator_code')
-        ),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('meeting_name_or_jurisdiction_name_as_entry_element'),
-        'c': value.get('location_of_meeting'),
-        'e': utils.reverse_force_list(
-            value.get('subordinate_unit')
-        ),
-        'd': value.get('date_of_meeting'),
-        'g': value.get('miscellaneous_information'),
-        'f': value.get('date_of_a_work'),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'j': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        'l': value.get('language_of_a_work'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_meeting')
-        ),
-        'q': value.get('name_of_meeting_following_jurisdiction_name_entry_element'),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        's': value.get('version'),
-        'u': value.get('affiliation'),
-        't': value.get('title_of_a_work'),
-        'x': value.get('international_standard_serial_number'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('type_of_meeting_name_entry_element'), '_'),
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
@@ -324,7 +279,11 @@ def reverse_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_added_entry_uncontrolled_name(self, key, value):
     """Reverse - Added Entry-Uncontrolled Name."""
-    indicator_map1 = {"Not specified": "_", "Other": "2", "Personal": "1"}
+    indicator_map1 = {
+        'Not specified': '_',
+        'Other': '2',
+        'Personal': '1',
+    }
 
     field_map = {
         'name': 'a',
@@ -336,22 +295,13 @@ def reverse_added_entry_uncontrolled_name(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('type_of_name')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('name'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
-        '4': utils.reverse_force_list(
-            value.get('relator_code')
-        ),
+        'e': utils.reverse_force_list(value.get('relator_term')),
+        '4': utils.reverse_force_list(value.get('relator_code')),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('type_of_name'), '_'),
         '$ind2': '_',
     }
@@ -363,7 +313,11 @@ def reverse_added_entry_uncontrolled_name(self, key, value):
 def reverse_added_entry_uniform_title(self, key, value):
     """Reverse - Added Entry-Uniform Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
-    indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    indicator_map2 = {
+        'No information provided': '_',
+        'Analytical entry': '2',
+    }
 
     field_map = {
         'uniform_title': 'a',
@@ -391,50 +345,35 @@ def reverse_added_entry_uniform_title(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in valid_nonfiling_characters:
-        order.append('nonfiling_characters')
-    if key[4] in indicator_map2:
-        order.append('type_of_added_entry')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('uniform_title'),
-        'x': value.get('international_standard_serial_number'),
-        'p': utils.reverse_force_list(
-            value.get('name_of_part_section_of_a_work')
-        ),
-        'd': utils.reverse_force_list(
-            value.get('date_of_treaty_signing')
-        ),
-        'g': value.get('miscellaneous_information'),
+        'd': utils.reverse_force_list(value.get('date_of_treaty_signing')),
         'f': value.get('date_of_a_work'),
+        'g': value.get('miscellaneous_information'),
+        'h': value.get('medium'),
         'i': utils.reverse_force_list(
             value.get('relationship_information')
         ),
-        'h': value.get('medium'),
-        'k': utils.reverse_force_list(
-            value.get('form_subheading')
-        ),
-        'm': utils.reverse_force_list(
-            value.get('medium_of_performance_for_music')
-        ),
+        'k': utils.reverse_force_list(value.get('form_subheading')),
         'l': value.get('language_of_a_work'),
+        'm': utils.reverse_force_list(value.get('medium_of_performance_for_music')),
+        'n': utils.reverse_force_list(value.get('number_of_part_section_of_a_work')),
         'o': value.get('arranged_statement_for_music'),
-        'n': utils.reverse_force_list(
-            value.get('number_of_part_section_of_a_work')
-        ),
+        'p': utils.reverse_force_list(value.get('name_of_part_section_of_a_work')),
+        'r': value.get('key_for_music'),
+        's': value.get('version'),
+        't': value.get('title_of_a_work'),
+        'x': value.get('international_standard_serial_number'),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
         '3': value.get('materials_specified'),
-        'r': value.get('key_for_music'),
         '5': value.get('institution_to_which_field_applies'),
-        't': value.get('title_of_a_work'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        's': value.get('version'),
         '$ind1': value.get('nonfiling_characters', '_'),
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
@@ -449,7 +388,11 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
         value):
     """Reverse - Added Entry-Uncontrolled Related/Analytical Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
-    indicator_map2 = {"Analytical entry": "2", "No information provided": "_"}
+
+    indicator_map2 = {
+        'No information provided': '_',
+        'Analytical entry': '2',
+    }
 
     field_map = {
         'uncontrolled_related_analytical_title': 'a',
@@ -462,11 +405,6 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
     }
 
     order = utils.map_order(field_map, value)
-
-    if key[3] in valid_nonfiling_characters:
-        order.append('nonfiling_characters')
-    if key[4] in indicator_map2:
-        order.append('type_of_added_entry')
 
     return {
         '__order__': tuple(order) if len(order) else None,
@@ -509,21 +447,15 @@ def reverse_added_entry_geographic_name(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('geographic_name'),
-        'e': utils.reverse_force_list(
-            value.get('relator_term')
-        ),
+        'e': utils.reverse_force_list(value.get('relator_term')),
         '0': utils.reverse_force_list(
             value.get('authority_record_control_number_or_standard_number')
         ),
-        '3': value.get('materials_specified'),
         '2': value.get('source_of_heading_or_term'),
-        '4': utils.reverse_force_list(
-            value.get('relator_code')
-        ),
+        '3': value.get('materials_specified'),
+        '4': utils.reverse_force_list(value.get('relator_code')),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -552,26 +484,14 @@ def reverse_added_entry_hierarchical_place_name(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'a': utils.reverse_force_list(
-            value.get('country_or_larger_entity')
-        ),
-        'c': utils.reverse_force_list(
-            value.get('intermediate_political_jurisdiction')
-        ),
+        'a': utils.reverse_force_list(value.get('country_or_larger_entity')),
         'b': value.get('first_order_political_jurisdiction'),
+        'c': utils.reverse_force_list(value.get('intermediate_political_jurisdiction')),
         'd': value.get('city'),
-        'g': utils.reverse_force_list(
-            value.get('other_nonjurisdictional_geographic_region_and_feature')
-        ),
-        'f': utils.reverse_force_list(
-            value.get('city_subsection')
-        ),
-        'h': utils.reverse_force_list(
-            value.get('extraterrestrial_area')
-        ),
-        '0': utils.reverse_force_list(
-            value.get('authority_record_control_number_or_standard_number')
-        ),
+        'f': utils.reverse_force_list(value.get('city_subsection')),
+        'g': utils.reverse_force_list(value.get('other_nonjurisdictional_geographic_region_and_feature')),
+        'h': utils.reverse_force_list(value.get('extraterrestrial_area')),
+        '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
         '2': value.get('source_of_heading_or_term'),
         '6': value.get('linkage'),
         '8': utils.reverse_force_list(
@@ -600,12 +520,10 @@ def reverse_system_details_access_to_computer_files(self, key, value):
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('make_and_model_of_machine'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'c': value.get('operating_system'),
         'b': value.get('programming_language'),
+        'c': value.get('operating_system'),
         '6': value.get('linkage'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': '_',
         '$ind2': '_',
     }
@@ -632,29 +550,15 @@ def reverse_added_entry_taxonomic_identification(self, key, value):
 
     return {
         '__order__': tuple(order) if len(order) else None,
-        'a': utils.reverse_force_list(
-            value.get('taxonomic_name')
-        ),
-        'x': utils.reverse_force_list(
-            value.get('non_public_note')
-        ),
-        'c': utils.reverse_force_list(
-            value.get('taxonomic_category')
-        ),
-        'd': utils.reverse_force_list(
-            value.get('common_or_alternative_name')
-        ),
-        '0': utils.reverse_force_list(
-            value.get('authority_record_control_number_or_standard_number')
-        ),
+        'a': utils.reverse_force_list(value.get('taxonomic_name')),
+        'c': utils.reverse_force_list(value.get('taxonomic_category')),
+        'd': utils.reverse_force_list(value.get('common_or_alternative_name')),
+        'x': utils.reverse_force_list(value.get('non_public_note')),
+        'z': utils.reverse_force_list(value.get('public_note')),
+        '0': utils.reverse_force_list(value.get('authority_record_control_number_or_standard_number')),
         '2': value.get('source_of_taxonomic_identification'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'z': utils.reverse_force_list(
-            value.get('public_note')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': '_',
         '$ind2': '_',
     }

--- a/dojson/contrib/to_marc21/fields/bd76x78x.py
+++ b/dojson/contrib/to_marc21/fields/bd76x78x.py
@@ -19,8 +19,15 @@ from ..model import to_marc21
 @utils.filter_values
 def reverse_main_series_entry(self, key, value):
     """Reverse - Main Series Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
-    indicator_map2 = {"Main series": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
+    indicator_map2 = {
+        'Main series': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -46,45 +53,29 @@ def reverse_main_series_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
-        'x': value.get('international_standard_serial_number'),
         'c': value.get('qualifying_information'),
         'b': value.get('edition'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')),
-        'n': utils.reverse_force_list(
-            value.get('note')),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
         's': value.get('uniform_title'),
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')),
+        't': value.get('title'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        'y': value.get('coden_designation'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')),
-        't': value.get('title'),
-        '$ind1': indicator_map1.get(
-            value.get('note_controller'),
-            '_'),
-        '$ind2': indicator_map2.get(
-            value.get('display_constant_controller'),
-            '_'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
+        '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
+        '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
 
 
@@ -93,10 +84,14 @@ def reverse_main_series_entry(self, key, value):
 @utils.filter_values
 def reverse_subseries_entry(self, key, value):
     """Reverse - Subseries Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Has subseries": "_",
-        "No display constant generated": "8"
+        'Has subseries': '_',
+        'No display constant generated': '8'
     }
 
     field_map = {
@@ -123,45 +118,29 @@ def reverse_subseries_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
-        'x': value.get('international_standard_serial_number'),
-        'c': value.get('qualifying_information'),
         'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')),
-        'n': utils.reverse_force_list(
-            value.get('note')),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
         's': value.get('uniform_title'),
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')),
+        't': value.get('title'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        'y': value.get('coden_designation'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')),
-        't': value.get('title'),
-        '$ind1': indicator_map1.get(
-            value.get('note_controller'),
-            '_'),
-        '$ind2': indicator_map2.get(
-            value.get('display_constant_controller'),
-            '_'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
+        '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
+        '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
 
 
@@ -170,10 +149,14 @@ def reverse_subseries_entry(self, key, value):
 @utils.filter_values
 def reverse_original_language_entry(self, key, value):
     """Reverse - Original Language Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "No display constant generated": "8",
-        "Translation of": "_"
+        'Translation of': '_',
+        'No display constant generated': '8',
     }
 
     field_map = {
@@ -204,56 +187,31 @@ def reverse_original_language_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -264,10 +222,14 @@ def reverse_original_language_entry(self, key, value):
 @utils.filter_values
 def reverse_translation_entry(self, key, value):
     """Reverse - Translation Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "No display constant generated": "8",
-        "Translated as": "_"
+        'Translated as': '_',
+        'No display constant generated': '8',
     }
 
     field_map = {
@@ -298,56 +260,31 @@ def reverse_translation_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -358,10 +295,14 @@ def reverse_translation_entry(self, key, value):
 @utils.filter_values
 def reverse_supplement_special_issue_entry(self, key, value):
     """Reverse - Supplement/Special Issue Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Has supplement": "_",
-        "No display constant generated": "8"
+        'Has supplement': '_',
+        'No display constant generated': '8'
     }
 
     field_map = {
@@ -392,56 +333,31 @@ def reverse_supplement_special_issue_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -452,11 +368,15 @@ def reverse_supplement_special_issue_entry(self, key, value):
 @utils.filter_values
 def reverse_supplement_parent_entry(self, key, value):
     """Reverse - Supplement Parent Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "No display constant generated": "8",
-        "Parent": "0",
-        "Supplement to": "_"
+        'Supplement to': '_',
+        'Parent': '0',
+        'No display constant generated': '8',
     }
 
     field_map = {
@@ -487,56 +407,31 @@ def reverse_supplement_parent_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -547,8 +442,15 @@ def reverse_supplement_parent_entry(self, key, value):
 @utils.filter_values
 def reverse_host_item_entry(self, key, value):
     """Reverse - Host Item Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
-    indicator_map2 = {"In": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
+    indicator_map2 = {
+        'In': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -580,58 +482,33 @@ def reverse_host_item_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '3': value.get('materials_specified'),
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
-        '7': value.get('control_subfield'),
-        '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         'a': value.get('main_entry_heading'),
         'b': value.get('edition'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        'q': value.get('enumeration_and_first_page'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
         'p': value.get('abbreviated_title'),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        'q': value.get('enumeration_and_first_page'),
         's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
         't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
         'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '3': value.get('materials_specified'),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
+        '7': value.get('control_subfield'),
+        '6': value.get('linkage'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -642,10 +519,14 @@ def reverse_host_item_entry(self, key, value):
 @utils.filter_values
 def reverse_constituent_unit_entry(self, key, value):
     """Reverse - Constituent Unit Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Constituent unit": "_",
-        "No display constant generated": "8"
+        'Constituent unit': '_',
+        'No display constant generated': '8',
     }
 
     field_map = {
@@ -676,56 +557,31 @@ def reverse_constituent_unit_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -736,10 +592,15 @@ def reverse_constituent_unit_entry(self, key, value):
 @utils.filter_values
 def reverse_other_edition_entry(self, key, value):
     """Reverse - Other Edition Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "No display constant generated": "8",
-        "Other edition available": "_"}
+        'Other edition available': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -771,58 +632,33 @@ def reverse_other_edition_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
-        '7': value.get('control_subfield'),
-        '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
         'b': value.get('edition'),
-        'e': value.get('language_code'),
+        'c': value.get('qualifying_information'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
+        'e': value.get('language_code'),
         'f': value.get('country_code'),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
         's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
         't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
         'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
+        '6': value.get('linkage'),
+        '7': value.get('control_subfield'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -833,10 +669,15 @@ def reverse_other_edition_entry(self, key, value):
 @utils.filter_values
 def reverse_additional_physical_form_entry(self, key, value):
     """Reverse - Additional Physical Form Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Available in another form": "_",
-        "No display constant generated": "8"}
+        'Available in another form': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -866,56 +707,31 @@ def reverse_additional_physical_form_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -926,8 +742,15 @@ def reverse_additional_physical_form_entry(self, key, value):
 @utils.filter_values
 def reverse_issued_with_entry(self, key, value):
     """Reverse - Issued With Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
-    indicator_map2 = {"Issued with": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
+    indicator_map2 = {
+        'Issued with': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -954,49 +777,28 @@ def reverse_issued_with_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
         'a': value.get('main_entry_heading'),
-        'x': value.get('international_standard_serial_number'),
-        'c': value.get('qualifying_information'),
         'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
         's': value.get('uniform_title'),
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
-        '7': value.get('control_subfield'),
-        '6': value.get('linkage'),
-        'y': value.get('coden_designation'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         't': value.get('title'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
+        '6': value.get('linkage'),
+        '7': value.get('control_subfield'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -1007,16 +809,20 @@ def reverse_issued_with_entry(self, key, value):
 @utils.filter_values
 def reverse_preceding_entry(self, key, value):
     """Reverse - Preceding Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Absorbed": "5",
-        "Absorbed in part": "6",
-        "Continues": "0",
-        "Continues in part": "1",
-        "Formed by the union of ... and ...": "4",
-        "Separated from": "7",
-        "Supersedes": "2",
-        "Supersedes in part": "3"
+        'Continues': '0',
+        'Continues in part': '1',
+        'Supersedes': '2',
+        'Supersedes in part': '3',
+        'Formed by the union of ... and ...': '4',
+        'Absorbed': '5',
+        'Absorbed in part': '6',
+        'Separated from': '7',
     }
 
     field_map = {
@@ -1047,56 +853,31 @@ def reverse_preceding_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('type_of_relationship')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('type_of_relationship'), '_'),
     }
@@ -1107,17 +888,21 @@ def reverse_preceding_entry(self, key, value):
 @utils.filter_values
 def reverse_succeeding_entry(self, key, value):
     """Reverse - Succeeding Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "Absorbed by": "4",
-        "Absorbed in part by": "5",
-        "Changed back to": "8",
-        "Continued by": "0",
-        "Continued in part by": "1",
-        "Merged with ... to form ...": "7",
-        "Split into ... and ...": "6",
-        "Superseded by": "2",
-        "Superseded in part by": "3"
+        'Continued by': '0',
+        'Continued in part by': '1',
+        'Superseded by': '2',
+        'Superseded in part by': '3',
+        'Absorbed by': '4',
+        'Absorbed in part by': '5',
+        'Split into ... and ...': '6',
+        'Merged with ... to form ...': '7',
+        'Changed back to': '8',
     }
 
     field_map = {
@@ -1148,56 +933,31 @@ def reverse_succeeding_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('type_of_relationship')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('type_of_relationship'), '_'),
     }
@@ -1208,8 +968,15 @@ def reverse_succeeding_entry(self, key, value):
 @utils.filter_values
 def reverse_data_source_entry(self, key, value):
     """Reverse - Data Source Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
-    indicator_map2 = {"Data source": "_", "No display constant generated": "8"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
+    indicator_map2 = {
+        'Data source': '_',
+        'No display constant generated': '8',
+    }
 
     field_map = {
         'main_entry_heading': 'a',
@@ -1242,59 +1009,34 @@ def reverse_data_source_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
+        'a': value.get('main_entry_heading'),
+        'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
+        'd': value.get('place_publisher_and_date_of_publication'),
+        'g': utils.reverse_force_list(value.get('related_parts')),
+        'h': value.get('physical_description'),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'j': value.get('period_of_content'),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
+        'm': value.get('material_specific_details'),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'p': value.get('abbreviated_title'),
+        'r': utils.reverse_force_list(value.get('report_number')),
+        's': value.get('uniform_title'),
+        't': value.get('title'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
+        'v': value.get('source_contribution'),
+        'x': value.get('international_standard_serial_number'),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
         '7': value.get('control_subfield'),
         '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
-        'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
-        'b': value.get('edition'),
-        'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
-        'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
-        'j': value.get('period_of_content'),
-        'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
-        'p': value.get('abbreviated_title'),
-        's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
-        't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'v': value.get('source_contribution'),
-        'y': value.get('coden_designation'),
-        'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }
@@ -1305,10 +1047,16 @@ def reverse_data_source_entry(self, key, value):
 @utils.filter_values
 def reverse_other_relationship_entry(self, key, value):
     """Reverse - Other Relationship Entry."""
-    indicator_map1 = {"Display note": "0", "Do not display note": "1"}
+    indicator_map1 = {
+        'Display note': '0',
+        'Do not display note': '1',
+    }
+
     indicator_map2 = {
-        "No display constant generated": "8",
-        "Related item": "_"}
+        'Related item': '_',
+        'No display constant generated': '8',
+    }
+
     field_map = {
         'main_entry_heading': 'a',
         'edition': 'b',
@@ -1337,56 +1085,31 @@ def reverse_other_relationship_entry(self, key, value):
 
     order = utils.map_order(field_map, value)
 
-    if key[3] in indicator_map1:
-        order.append('note_controller')
-    if key[4] in indicator_map2:
-        order.append('display_constant_controller')
-
     return {
         '__order__': tuple(order) if len(order) else None,
-        '4': utils.reverse_force_list(
-            value.get('relationship_code')
-        ),
-        '7': value.get('control_subfield'),
-        '6': value.get('linkage'),
-        '8': utils.reverse_force_list(
-            value.get('field_link_and_sequence_number')
-        ),
         'a': value.get('main_entry_heading'),
-        'c': value.get('qualifying_information'),
         'b': value.get('edition'),
+        'c': value.get('qualifying_information'),
         'd': value.get('place_publisher_and_date_of_publication'),
-        'g': utils.reverse_force_list(
-            value.get('related_parts')
-        ),
-        'i': utils.reverse_force_list(
-            value.get('relationship_information')
-        ),
+        'g': utils.reverse_force_list(value.get('related_parts')),
         'h': value.get('physical_description'),
-        'k': utils.reverse_force_list(
-            value.get('series_data_for_related_item')
-        ),
+        'i': utils.reverse_force_list(value.get('relationship_information')),
+        'k': utils.reverse_force_list(value.get('series_data_for_related_item')),
         'm': value.get('material_specific_details'),
-        'o': utils.reverse_force_list(
-            value.get('other_item_identifier')
-        ),
-        'n': utils.reverse_force_list(
-            value.get('note')
-        ),
+        'n': utils.reverse_force_list(value.get('note')),
+        'o': utils.reverse_force_list(value.get('other_item_identifier')),
+        'r': utils.reverse_force_list(value.get('report_number')),
         's': value.get('uniform_title'),
-        'r': utils.reverse_force_list(
-            value.get('report_number')
-        ),
-        'u': value.get('standard_technical_report_number'),
         't': value.get('title'),
-        'w': utils.reverse_force_list(
-            value.get('record_control_number')
-        ),
-        'y': value.get('coden_designation'),
+        'u': value.get('standard_technical_report_number'),
+        'w': utils.reverse_force_list(value.get('record_control_number')),
         'x': value.get('international_standard_serial_number'),
-        'z': utils.reverse_force_list(
-            value.get('international_standard_book_number')
-        ),
+        'y': value.get('coden_designation'),
+        'z': utils.reverse_force_list(value.get('international_standard_book_number')),
+        '4': utils.reverse_force_list(value.get('relationship_code')),
+        '6': value.get('linkage'),
+        '7': value.get('control_subfield'),
+        '8': utils.reverse_force_list(value.get('field_link_and_sequence_number')),
         '$ind1': indicator_map1.get(value.get('note_controller'), '_'),
         '$ind2': indicator_map2.get(value.get('display_constant_controller'), '_'),
     }

--- a/tests/data/handcrafted/bd6xx.xml
+++ b/tests/data/handcrafted/bd6xx.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<collection xmlns="http://www.loc.gov/MARC21/slim">
+  <record>
+    <datafield tag="648" ind1=" " ind2="0">
+      <subfield code="a">1800-1899</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/tests/data/library_of_congress/bd6xx.xml
+++ b/tests/data/library_of_congress/bd6xx.xml
@@ -920,20 +920,17 @@
   </record>
   <record>
     <datafield tag="653" ind1=" " ind2=" ">
-      <subfield code="a">Imprints&lt;century&gt; &lt;date as found in 260</subfield>
-      <subfield code="c">&gt;</subfield>
+      <subfield code="a">Imprints&lt;century&gt; &lt;date as found in 260$c&gt;</subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="653" ind1=" " ind2=" ">
-      <subfield code="a">Imprints&lt;not after date as found in 260</subfield>
-      <subfield code="c">&gt;</subfield>
+      <subfield code="a">Imprints&lt;not after date as found in 260$c&gt;</subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="653" ind1=" " ind2=" ">
-      <subfield code="a">Imprints&lt;not before date as found in 260</subfield>
-      <subfield code="c">&gt;</subfield>
+      <subfield code="a">Imprints&lt;not before date as found in 260$c&gt;</subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd70x75x.xml
+++ b/tests/data/library_of_congress/bd70x75x.xml
@@ -181,7 +181,7 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="700" ind1="1" ind2="1">
+    <datafield tag="700" ind1="1" ind2=" ">
       <subfield code="a">Franklin, Benjamin,</subfield>
       <subfield code="d">1706-1790,</subfield>
       <subfield code="e">printer.</subfield>

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,6 +49,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd4xx.xml',
     'library_of_congress/bd5xx.xml',
     'library_of_congress/bd6xx.xml',
+    'library_of_congress/bd70x75x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd5xx.xml',
     'library_of_congress/bd6xx.xml',
     'library_of_congress/bd70x75x.xml',
+    'library_of_congress/bd76x78x.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'test_cds_marc21.xml',
     'handcrafted/bd01x09x.xml',
     'handcrafted/bd3xx.xml',
+    'handcrafted/bd6xx.xml',
     'library_of_congress/bd01x09x.xml',
     'library_of_congress/bd1xx.xml',
     'library_of_congress/bd20x24x.xml',
@@ -47,6 +48,7 @@ from test_core import RECORD_999_FIELD, RECORD_SIMPLE
     'library_of_congress/bd3xx.xml',
     'library_of_congress/bd4xx.xml',
     'library_of_congress/bd5xx.xml',
+    'library_of_congress/bd6xx.xml',
 ])
 def test_xml_to_marc21_to_xml(file_name):
     """Test xslt dump."""


### PR DESCRIPTION
- FIX Preserves order of bd76x78x fields. (closes #87)
- Reaches 100% test coverage for bd76x78x fields.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
