### PR TITLE
dojson: fix for missing order key

### DIFF
--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -127,8 +127,9 @@ class Overdo(object):
         handlers.update(exception_handlers or {})
 
         def clean_missing(exc, output, key, value):
-            order = output['__order__']
-            del order[order.index(key)]
+            order = output.get('__order__')
+            if order:
+                order.remove(key)
 
         if ignore_missing:
             handlers.setdefault(MissingRule, clean_missing)


### PR DESCRIPTION
- Fixes crash on missing **order** key.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
