### PR TITLE
dojson: non-filing characters schema correction

### DIFF
--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -247,7 +247,7 @@ def main_entry_meeting_name(self, key, value):
     }
 
 
-@marc21.over('main_entry_uniform_title', '^130[_1032547698].')
+@marc21.over('main_entry_uniform_title', '^130[_0-9]_')
 @utils.for_each_value
 @utils.filter_values
 def main_entry_uniform_title(self, key, value):
@@ -312,5 +312,5 @@ def main_entry_uniform_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': key[3] if key[3] else '_',
+        'nonfiling_characters': utils.int_with_default(key[3], '_'),
     }

--- a/dojson/contrib/marc21/fields/bd20x24x.py
+++ b/dojson/contrib/marc21/fields/bd20x24x.py
@@ -60,7 +60,7 @@ def abbreviated_title(self, key, value):
     }
 
 
-@marc21.over('key_title', '^222.[_1032547698]')
+@marc21.over('key_title', '^222_[_0-9]')
 @utils.for_each_value
 @utils.filter_values
 def key_title(self, key, value):
@@ -87,11 +87,11 @@ def key_title(self, key, value):
         ),
         'qualifying_information': value.get('b'),
         'linkage': value.get('6'),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 
-@marc21.over('uniform_title', '^240[10_][_1032547698]')
+@marc21.over('uniform_title', '^240[_01][_0-9]')
 @utils.filter_values
 def uniform_title(self, key, value):
     """Uniform Title."""
@@ -161,12 +161,12 @@ def uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 
 @marc21.over(
-    'translation_of_title_by_cataloging_agency', '^242[10_][_0123456789]')
+    'translation_of_title_by_cataloging_agency', '^242[_01][_0-9]')
 @utils.for_each_value
 @utils.filter_values
 def translation_of_title_by_cataloging_agency(self, key, value):
@@ -215,11 +215,11 @@ def translation_of_title_by_cataloging_agency(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 
-@marc21.over('collective_uniform_title', '^243[10_][_1032547698]')
+@marc21.over('collective_uniform_title', '^243[_01][_0-9]')
 @utils.filter_values
 def collective_uniform_title(self, key, value):
     """Collective Uniform Title."""
@@ -285,11 +285,11 @@ def collective_uniform_title(self, key, value):
             value.get('8')
         ),
         'uniform_title_printed_or_displayed': indicator_map1.get(key[3]),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 
-@marc21.over('title_statement', '^245[10_][_1032547698]')
+@marc21.over('title_statement', '^245[_01][_0-9]')
 @utils.filter_values
 def title_statement(self, key, value):
     """Title Statement."""
@@ -344,7 +344,7 @@ def title_statement(self, key, value):
             value.get('8')
         ),
         'title_added_entry': indicator_map1.get(key[3]),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 

--- a/dojson/contrib/marc21/fields/bd4xx.py
+++ b/dojson/contrib/marc21/fields/bd4xx.py
@@ -308,7 +308,7 @@ def series_statement_added_entry_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }
 
 

--- a/dojson/contrib/marc21/fields/bd6xx.py
+++ b/dojson/contrib/marc21/fields/bd6xx.py
@@ -404,6 +404,7 @@ def subject_added_entry_meeting_name(self, key, value):
 def subject_added_entry_uniform_title(self, key, value):
     """Subject Added Entry-Uniform Title."""
     valid_nonfiling_characters = [str(x) for x in range(10)]
+
     indicator_map2 = {
         '0': 'Library of Congress Subject Headings',
         '1': 'LC subject headings for children\u0027s literature',
@@ -509,7 +510,7 @@ def subject_added_entry_uniform_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': key[3],
+        'nonfiling_characters': utils.int_with_default(key[3], '_'),
         'thesaurus': indicator_map2.get(key[4]),
     }
 

--- a/dojson/contrib/marc21/fields/bd70x75x.py
+++ b/dojson/contrib/marc21/fields/bd70x75x.py
@@ -394,7 +394,7 @@ def added_entry_uniform_title(self, key, value):
         'institution_to_which_field_applies': value.get('5'),
         'linkage': value.get('6'),
         'field_link_and_sequence_number': utils.force_list(value.get('8')),
-        'nonfiling_characters': key[3],
+        'nonfiling_characters': utils.int_with_default(key[3], '_'),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 
@@ -441,7 +441,7 @@ def added_entry_uncontrolled_related_analytical_title(self, key, value):
         'field_link_and_sequence_number': utils.force_list(
             value.get('8')
         ),
-        'nonfiling_characters': key[3],
+        'nonfiling_characters': utils.int_with_default(key[3], '_'),
         'type_of_added_entry': indicator_map2.get(key[4]),
     }
 

--- a/dojson/contrib/marc21/fields/bd80x83x.py
+++ b/dojson/contrib/marc21/fields/bd80x83x.py
@@ -320,5 +320,5 @@ def series_added_entry_uniform_title(self, key, value):
         'linkage': value.get('6'),
         'control_subfield': value.get('7'),
         'field_link_and_sequence_number': utils.force_list(value.get('8')),
-        'nonfiling_characters': key[4],
+        'nonfiling_characters': utils.int_with_default(key[4], '_'),
     }

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd20x24x.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd20x24x.json
@@ -44,7 +44,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                     },
                     "key_title": {
                         "type": "string"
@@ -154,7 +154,7 @@
                         "enum": ["Added entry", "No added entry"]
                     },
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                     },
                     "title": {
                         "type": "string"
@@ -276,7 +276,7 @@
                     "enum": ["Added entry", "No added entry"]
                 },
                 "nonfiling_characters": {
-                    "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                    "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                 },
                 "title": {
                     "type": "string"

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd4xx.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd4xx.json
@@ -278,7 +278,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                     },
                     "title": {
                         "type": "string"

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd70x75x.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd70x75x.json
@@ -518,7 +518,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                     },
                     "type_of_added_entry": {
                         "enum": ["No information provided", "Analytical entry"]

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd80x83x.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd80x83x.json
@@ -398,7 +398,7 @@
                 "type": "object",
                 "properties": {
                     "nonfiling_characters": {
-                        "enum": ["No nonfiling characters", "Number of nonfiling characters"]
+                        "enum": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
                     },
                     "authority_record_control_number_or_standard_number": {
                         "type": "array",

--- a/dojson/contrib/to_marc21/fields/bd1xx.py
+++ b/dojson/contrib/to_marc21/fields/bd1xx.py
@@ -246,8 +246,7 @@ def reverse_main_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_main_entry_uniform_title(self, key, value):
     """Reverse - Main Entry-Uniform Title."""
-    nonfiling_characters = [str(x) for x in range(10)]
-
+    valid_nonfiling_characters = [x for x in range(10)]
     field_map = {
         'uniform_title': 'a',
         'date_of_treaty_signing': 'd',
@@ -303,6 +302,6 @@ def reverse_main_entry_uniform_title(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') else '_',
+        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
         '$ind2': '_',
     }

--- a/dojson/contrib/to_marc21/fields/bd20x24x.py
+++ b/dojson/contrib/to_marc21/fields/bd20x24x.py
@@ -60,7 +60,7 @@ def reverse_abbreviated_title(self, key, value):
 @utils.filter_values
 def reverse_key_title(self, key, value):
     """Reverse - Key Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     field_map = {
         'key_title': 'a',
@@ -87,7 +87,7 @@ def reverse_key_title(self, key, value):
 @utils.filter_values
 def reverse_uniform_title(self, key, value):
     """Reverse - Uniform Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map1 = {
         'Not printed or displayed': '0',
@@ -152,7 +152,7 @@ def reverse_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_translation_of_title_by_cataloging_agency(self, key, value):
     """Reverse - Translation of Title by Cataloging Agency."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map1 = {
         'No added entry': '0',
@@ -199,7 +199,7 @@ def reverse_translation_of_title_by_cataloging_agency(self, key, value):
 @utils.filter_values
 def reverse_collective_uniform_title(self, key, value):
     """Reverse - Collective Uniform Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map1 = {
         'Not printed or displayed': '0',
@@ -260,7 +260,7 @@ def reverse_collective_uniform_title(self, key, value):
 @utils.filter_values
 def reverse_title_statement(self, key, value):
     """Reverse - Title Statement."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map1 = {
         'No added entry': '0',

--- a/dojson/contrib/to_marc21/fields/bd4xx.py
+++ b/dojson/contrib/to_marc21/fields/bd4xx.py
@@ -239,7 +239,7 @@ def reverse_series_statement_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_series_statement_added_entry_title(self, key, value):
     """Reverse - Series Statement/Added Entry-Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     field_map = {
         'title': 'a',
@@ -277,7 +277,7 @@ def reverse_series_statement_added_entry_title(self, key, value):
             value.get('field_link_and_sequence_number')
         ),
         '$ind1': '_',
-        '$ind2': value.get('nonfiling_characters', '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }
 
 

--- a/dojson/contrib/to_marc21/fields/bd6xx.py
+++ b/dojson/contrib/to_marc21/fields/bd6xx.py
@@ -385,7 +385,7 @@ def reverse_subject_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_subject_added_entry_uniform_title(self, key, value):
     """Reverse - Subject Added Entry-Uniform Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map2 = {
         'Library of Congress Subject Headings': '0',
@@ -487,7 +487,7 @@ def reverse_subject_added_entry_uniform_title(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': value.get('nonfiling_characters', '_'),
+        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
         '$ind2': indicator_map2.get(value.get('thesaurus'), '_'),
     }
 

--- a/dojson/contrib/to_marc21/fields/bd70x75x.py
+++ b/dojson/contrib/to_marc21/fields/bd70x75x.py
@@ -317,7 +317,7 @@ def reverse_added_entry_uncontrolled_name(self, key, value):
 @utils.filter_values
 def reverse_added_entry_uniform_title(self, key, value):
     """Reverse - Added Entry-Uniform Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map2 = {
         'No information provided': '_',
@@ -379,7 +379,7 @@ def reverse_added_entry_uniform_title(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': value.get('nonfiling_characters', '_'),
+        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
 
@@ -392,7 +392,7 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
         key,
         value):
     """Reverse - Added Entry-Uncontrolled Related/Analytical Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     indicator_map2 = {
         'No information provided': '_',
@@ -426,7 +426,7 @@ def reverse_added_entry_uncontrolled_related_analytical_title(
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')
         ),
-        '$ind1': value.get('nonfiling_characters', '_'),
+        '$ind1': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
         '$ind2': indicator_map2.get(value.get('type_of_added_entry'), '_'),
     }
 

--- a/dojson/contrib/to_marc21/fields/bd80x83x.py
+++ b/dojson/contrib/to_marc21/fields/bd80x83x.py
@@ -267,7 +267,7 @@ def reverse_series_added_entry_meeting_name(self, key, value):
 @utils.filter_values
 def reverse_series_added_entry_uniform_title(self, key, value):
     """Reverse - Series Added Entry-Uniform Title."""
-    valid_nonfiling_characters = [str(x) for x in range(10)]
+    valid_nonfiling_characters = [x for x in range(10)]
 
     field_map = {
         'uniform_title': 'a',
@@ -332,7 +332,5 @@ def reverse_series_added_entry_uniform_title(self, key, value):
         '8': utils.reverse_force_list(
             value.get('field_link_and_sequence_number')),
         '$ind1': '_',
-        '$ind2': value.get(
-            'nonfiling_characters',
-            '_'),
+        '$ind2': value.get('nonfiling_characters') if value.get('nonfiling_characters') in valid_nonfiling_characters else '_',
     }

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -19,6 +19,14 @@ import six
 from .errors import IgnoreKey
 
 
+def int_with_default(value, default):
+    """Parse and integer from a string and return default if it fails."""
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
 def ignore_value(f):
     """Remove key for None value.
 


### PR DESCRIPTION
- Corrects the valid values in JSON schema for non-filing character
  subfield.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
