### PR TITLE
dojson: missing schema additions

### DIFF
--- a/dojson/contrib/marc21/fields/bd3xx.py
+++ b/dojson/contrib/marc21/fields/bd3xx.py
@@ -677,8 +677,8 @@ def digital_file_characteristics(self, key, value):
 @marc21.over('format_of_notated_music', '^348__')
 @utils.for_each_value
 @utils.filter_values
-def reverse_digital_file_characteristics(self, key, value):
-    """Reverse - Digital File Characteristics."""
+def format_of_notated_music(self, key, value):
+    """Format of Notated Music."""
     field_map = {
         'a': 'format_of_notated_music_term',
         'b': 'format_of_notated_music_code',
@@ -1080,6 +1080,7 @@ def trade_availability_information(self, key, value):
 @utils.for_each_value
 @utils.filter_values
 def associated_place(self, key, value):
+    """Associated Place."""
     field_map = {
         'c': 'associated_country',
         'f': 'other_associated_place',
@@ -1469,8 +1470,8 @@ def creator_contributor_characteristics(self, key, value):
 @marc21.over('time_period_of_creation', '^388[_12]_')
 @utils.for_each_value
 @utils.filter_values
-def creator_contributor_characteristics(self, key, value):
-    """Creator/Contributor Characteristics."""
+def time_period_of_creation(self, key, value):
+    """Time Period of Creation."""
     indicator_map1 = {
         '_': 'No information provided',
         '1': 'Creation of work',

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd00x.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd00x.json
@@ -17,6 +17,10 @@
             "description": "Fixed-Length Data Elements-Additional Material Characteristics",
             "type": "string"
         },
+        "physical_description_fixed_field": {
+            "description": "Physical Description Fixed Field",
+            "type": "string"
+        },
         "fixed_length_data_elements": {
             "description": "Fixed-Length Data Elements",
             "type": "string"

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd3xx.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd3xx.json
@@ -734,6 +734,48 @@
                 }
             }
         },
+        "format_of_notated_music": {
+            "description": "Format of Notated Music",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "format_of_notated_music_term": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "format_of_notated_music_code": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "authority_record_control_number_or_standard_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_term": {
+                        "type": "string"
+                    },
+                    "materials_specified": {
+                        "type": "string"
+                    },
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "organization_and_arrangement_of_materials": {
             "description": "Organization and Arrangement of Materials",
             "type": "array",
@@ -1126,6 +1168,69 @@
                 }
             }
         },
+        "associated_place": {
+            "description": "Associated Place",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "associated_country": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "other_associated_place": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "place_of_origin_of_work": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "start_period": {
+                        "type": "string"
+                    },
+                    "end_period": {
+                        "type": "string"
+                    },
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_information": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "authority_record_control_number_or_standard_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_term": {
+                        "type": "string"
+                    },
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "associated_language": {
             "description": "Associated Language",
             "type": "array",
@@ -1469,6 +1574,45 @@
                         "items": {
                             "type": "string"
                         }
+                    }
+                }
+            }
+        },
+        "time_period_of_creation": {
+            "description": "Time Period of Creation",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "time_period_of_creation_term": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "authority_record_control_number_or_standard_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "source_of_term": {
+                        "type": "string"
+                    },
+                    "materials_specified": {
+                        "type": "string"
+                    },
+                    "linkage": {
+                        "type": "string"
+                    },
+                    "field_link_and_sequence_number": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "type_of_time_period": {
+                        "type" : "string"
                     }
                 }
             }

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd84188x.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd84188x.json
@@ -375,6 +375,33 @@
                 }
             }
         },
+        "description_conversion_information": {
+            "description": "Description Conversion Information",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "conversion_process": {
+                        "type": "string"
+                    },
+                    "conversion_date": {
+                        "type": "string"
+                    },
+                    "identifier_of_source_metadata": {
+                        "type": "string"
+                    },
+                    "conversion_agency": {
+                        "type": "string"
+                    },
+                    "uniform_resource_identifier": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "non_marc_information_field": {
             "description": "Non-MARC Information Field",
             "type": "array",

--- a/dojson/contrib/to_marc21/fields/bd3xx.py
+++ b/dojson/contrib/to_marc21/fields/bd3xx.py
@@ -568,8 +568,8 @@ def reverse_digital_file_characteristics(self, key, value):
 @to_marc21.over('348', '^format_of_notated_music$')
 @utils.reverse_for_each_value
 @utils.filter_values
-def reverse_digital_file_characteristics(self, key, value):
-    """Reverse - Digital File Characteristics."""
+def reverse_format_of_notated_music(self, key, value):
+    """Reverse - Format of Notated Music."""
     field_map = {
         'format_of_notated_music_term': 'a',
         'format_of_notated_music_code': 'b',
@@ -943,7 +943,7 @@ def reverse_trade_availability_information(self, key, value):
 @to_marc21.over('370', '^associated_place$')
 @utils.for_each_value
 @utils.filter_values
-def associated_place(self, key, value):
+def reverse_associated_place(self, key, value):
     field_map = {
         'associated_country': 'c',
         'other_associated_place': 'f',
@@ -1238,7 +1238,7 @@ def reverse_audience_characteristics(self, key, value):
 @to_marc21.over('386', '^creator_contributor_characteristics$')
 @utils.reverse_for_each_value
 @utils.filter_values
-def creator_contributor_characteristics(self, key, value):
+def reverse_creator_contributor_characteristics(self, key, value):
     """Creator/Contributor Characteristics."""
     field_map = {
         'creator_contributor_term': 'a',
@@ -1281,8 +1281,8 @@ def creator_contributor_characteristics(self, key, value):
 @to_marc21.over('388', '^time_period_of_creation$')
 @utils.reverse_for_each_value
 @utils.filter_values
-def reverse_creator_contributor_characteristics(self, key, value):
-    """Reverse - Creator/Contributor Characteristics."""
+def reverse_time_period_of_creation(self, key, value):
+    """Reverse - Time Period of Creation."""
     indicator_map1 = {
         'No information provided': '_',
         'Creation of work': '1',

--- a/dojson/contrib/to_marc21/fields/bd4xx.py
+++ b/dojson/contrib/to_marc21/fields/bd4xx.py
@@ -14,6 +14,7 @@ from dojson import utils
 from ..model import to_marc21
 
 
+@utils.deprecated('deprecated datafield: https://www.loc.gov/marc/bibliographic/bdapndxh.html')
 @to_marc21.over('400', '^series_statement_added_entry_personal_name$')
 @utils.reverse_for_each_value
 @utils.filter_values
@@ -82,6 +83,7 @@ def reverse_series_statement_added_entry_personal_name(self, key, value):
     }
 
 
+@utils.deprecated('deprecated datafield: https://www.loc.gov/marc/bibliographic/bdapndxh.html')
 @to_marc21.over('410', '^series_statement_added_entry_corporate_name$')
 @utils.reverse_for_each_value
 @utils.filter_values
@@ -158,6 +160,7 @@ def reverse_series_statement_added_entry_corporate_name(self, key, value):
     }
 
 
+@utils.deprecated('deprecated datafield: https://www.loc.gov/marc/bibliographic/bdapndxh.html')
 @to_marc21.over('411', '^series_statement_added_entry_meeting_name$')
 @utils.reverse_for_each_value
 @utils.filter_values
@@ -234,6 +237,7 @@ def reverse_series_statement_added_entry_meeting_name(self, key, value):
     }
 
 
+@utils.deprecated('deprecated datafield: https://www.loc.gov/marc/bibliographic/bdapndxh.html')
 @to_marc21.over('440', '^series_statement_added_entry_title$')
 @utils.reverse_for_each_value
 @utils.filter_values

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -11,6 +11,7 @@
 
 import codecs
 import functools
+import warnings
 from collections import Counter, OrderedDict
 
 import simplejson as json
@@ -102,6 +103,18 @@ def load(stream):
 def dump(iterator):
     """Dump JSON from iteraror."""
     return json.dumps(list(iterator))
+
+
+def deprecated(explanation):
+    """Decorate as deprecated."""
+    def decorator(f):
+        @functools.wraps(f)
+        def wrapper(self, key, values, **kwargs):
+            warnings.warn('{0}: {1}'.format(key, explanation),
+                          DeprecationWarning)
+            return f(self, key, values, **kwargs)
+
+    return decorator
 
 
 def map_order(field_map, value):


### PR DESCRIPTION
- Adds missing schemas for fields bd388, bd370, bd348, bd884.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
