### PR TITLE
to_marc21: XML prefix name

### DIFF
--- a/tests/demo_marc21_to_dc.converted.xml
+++ b/tests/demo_marc21_to_dc.converted.xml
@@ -1,6 +1,8 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc:collection xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-  <dc:dc>
-    <dc:creator>Donges, Jonathan F</dc:creator>
-  </dc:dc>
-</dc:collection>
+<oai_dc:dcCollection xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+  <oai_dc:dc>
+    <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Donges, Jonathan F</dc:creator>
+    <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+    <dc:language xmlns:dc="http://purl.org/dc/elements/1.1/"/>
+  </oai_dc:dc>
+</oai_dc:dcCollection>

--- a/tests/demo_marc21_to_dc.xslt
+++ b/tests/demo_marc21_to_dc.xslt
@@ -1,95 +1,200 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="1.0"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:marc="http://www.loc.gov/MARC21/slim"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:dc="http://purl.org/dc/elements/1.1/"
-  exclude-result-prefixes="marc fn">
-  <xsl:output method="xml"  indent="yes" encoding="UTF-8" omit-xml-declaration="yes"/>
-  <xsl:template match="/">
-    <xsl:if test="collection">
-      <dc:collection xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-        <xsl:for-each select="collection">
-          <xsl:for-each select="record">
-            <dc:dc>
-              <xsl:apply-templates select="."/>
-            </dc:dc>
-          </xsl:for-each>
-        </xsl:for-each>
-      </dc:collection>
-    </xsl:if>
-    <xsl:if test="record">
-      <dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:invenio="http://invenio-software.org/elements/1.0">
-        <xsl:apply-templates/>
-      </dc:dc>
-    </xsl:if>
-  </xsl:template>
-  <xsl:template match="record">
-    <!-- DOI -->
-    <xsl:if test="datafield[@tag=024 and @ind1=7 and (subfield[@code='2']='doi' or subfield[@code='2']='DOI')]">
-      <xsl:for-each select="datafield[@tag=024 and @ind1=7 and (subfield[@code='2']='doi' or subfield[@code='2']='DOI')]">
-        <dc:identifier><xsl:text>doi:</xsl:text><xsl:value-of select="subfield[@code='a']"/></dc:identifier>
-      </xsl:for-each>
-    </xsl:if>
-    <!-- Language -->
-    <xsl:for-each select="datafield[@tag=041]">
-      <dc:language>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:language>
-    </xsl:for-each>
-    <!-- Author/Creator -->
-    <xsl:for-each select="datafield[@tag=100]">
-      <dc:creator>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:creator>
-    </xsl:for-each>
-    <xsl:for-each select="datafield[@tag=700]">
-      <dc:creator>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:creator>
-    </xsl:for-each>
-    <!-- Corporate Author/Creator, if no main author/creator -->
-    <xsl:if test="not (datafield[@tag=100 and subfield[@code='a']] or datafield[@tag=700 and subfield[@code='a']])">
-      <xsl:for-each select="datafield[@tag=110 and subfield[@code='a']]">
-        <dc:creator><xsl:value-of select="subfield[@code='a']"/></dc:creator>
-      </xsl:for-each>
-      <xsl:for-each select="datafield[@tag=710 and subfield[@code='a']]">
-        <dc:creator><xsl:value-of select="subfield[@code='a']"/></dc:creator>
-      </xsl:for-each>
-    </xsl:if>
-    <!-- Title -->
-    <xsl:for-each select="datafield[@tag=245]">
-      <dc:title>
-        <xsl:value-of select="subfield[@code='a']"/>
-        <xsl:if test="subfield[@code='b']">
-          <xsl:text>: </xsl:text><xsl:value-of select="subfield[@code='b']"/>
-        </xsl:if>
-      </dc:title>
-    </xsl:for-each>
-    <xsl:for-each select="datafield[@tag=111]">
-      <dc:title>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:title>
-    </xsl:for-each>
-    <!-- Subject -->
-    <xsl:for-each select="datafield[@tag=650 and @ind1=1 and @ind2=7]">
-      <dc:subject>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:subject>
-    </xsl:for-each>
-    <!-- Main report number-->
-    <xsl:for-each select="datafield[@tag=037]">
-      <dc:identifier><xsl:value-of select="subfield[@code='a']"/></dc:identifier>
-    </xsl:for-each>
-    <!-- Additional report number-->
-    <xsl:for-each select="datafield[@tag=088]">
-      <dc:identifier><xsl:value-of select="subfield[@code='a']"/></dc:identifier>
-    </xsl:for-each>
-    <!-- Abstract -->
-    <xsl:for-each select="datafield[@tag=520]">
-      <dc:description>
-        <xsl:value-of select="subfield[@code='a']"/>
-      </dc:description>
-    </xsl:for-each>
-  </xsl:template>
+<xsl:stylesheet version="1.0" xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" exclude-result-prefixes="marc">
+	<xsl:import href="http://www.loc.gov/standards/marcxml/xslt/MARC21slimUtils.xsl"/>
+	<xsl:output method="xml" indent="yes"/>
+	<!--
+	Fixed 530 Removed type="original" from dc:relation 2010-11-19 tmee
+	Fixed 500 fields. 2006-12-11 ntra
+	Added ISBN and deleted attributes 6/04 jer
+	-->
+	<xsl:template match="/">
+		<xsl:if test="marc:collection">
+			<oai_dc:dcCollection xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+				<xsl:for-each select="marc:collection">
+					<xsl:for-each select="marc:record">
+						<oai_dc:dc>
+							<xsl:apply-templates select="."/>
+						</oai_dc:dc>
+					</xsl:for-each>
+				</xsl:for-each>
+			</oai_dc:dcCollection>
+		</xsl:if>
+		<xsl:if test="marc:record">
+			<oai_dc:dc xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+				<xsl:apply-templates/>
+			</oai_dc:dc>
+		</xsl:if>
+	</xsl:template>
+	<xsl:template match="marc:record">
+		<xsl:variable name="leader" select="marc:leader"/>
+		<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+		<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+		<xsl:variable name="controlField008" select="marc:controlfield[@tag=008]"/>
+		<xsl:for-each select="marc:datafield[@tag=245]">
+			<dc:title>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abfghk</xsl:with-param>
+				</xsl:call-template>
+			</dc:title>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=100]|marc:datafield[@tag=110]|marc:datafield[@tag=111]|marc:datafield[@tag=700]|marc:datafield[@tag=710]|marc:datafield[@tag=711]|marc:datafield[@tag=720]">
+			<dc:creator>
+				<xsl:value-of select="."/>
+			</dc:creator>
+		</xsl:for-each>
+		<dc:type>
+			<xsl:if test="$leader7='c'">
+				<!--Remove attribute 6/04 jer-->
+				<!--<xsl:attribute name="collection">yes</xsl:attribute>-->
+				<xsl:text>collection</xsl:text>
+			</xsl:if>
+			<xsl:if test="$leader6='d' or $leader6='f' or $leader6='p' or $leader6='t'">
+				<!--Remove attribute 6/04 jer-->
+				<!--<xsl:attribute name="manuscript">yes</xsl:attribute>-->
+				<xsl:text>manuscript</xsl:text>
+			</xsl:if>
+			<xsl:choose>
+				<xsl:when test="$leader6='a' or $leader6='t'">text</xsl:when>
+				<xsl:when test="$leader6='e' or $leader6='f'">cartographic</xsl:when>
+				<xsl:when test="$leader6='c' or $leader6='d'">notated music</xsl:when>
+				<xsl:when test="$leader6='i' or $leader6='j'">sound recording</xsl:when>
+				<xsl:when test="$leader6='k'">still image</xsl:when>
+				<xsl:when test="$leader6='g'">moving image</xsl:when>
+				<xsl:when test="$leader6='r'">three dimensional object</xsl:when>
+				<xsl:when test="$leader6='m'">software, multimedia</xsl:when>
+				<xsl:when test="$leader6='p'">mixed material</xsl:when>
+			</xsl:choose>
+		</dc:type>
+		<xsl:for-each select="marc:datafield[@tag=655]">
+			<dc:type>
+				<xsl:value-of select="."/>
+			</dc:type>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=260]">
+			<dc:publisher>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">ab</xsl:with-param>
+				</xsl:call-template>
+			</dc:publisher>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=260]/marc:subfield[@code='c']">
+			<dc:date>
+				<xsl:value-of select="."/>
+			</dc:date>
+		</xsl:for-each>
+		<dc:language>
+			<xsl:value-of select="substring($controlField008,36,3)"/>
+		</dc:language>
+		<xsl:for-each select="marc:datafield[@tag=856]/marc:subfield[@code='q']">
+			<dc:format>
+				<xsl:value-of select="."/>
+			</dc:format>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=520]">
+			<dc:description>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:description>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=521]">
+			<dc:description>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:description>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[500&lt;= @tag and @tag&lt;= 599 ][not(@tag=506 or @tag=530 or @tag=540 or @tag=546)]">
+			<dc:description>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:description>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=600]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=610]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=611]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=630]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=650]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=653]">
+			<dc:subject>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdq</xsl:with-param>
+				</xsl:call-template>
+			</dc:subject>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=752]">
+			<dc:coverage>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcd</xsl:with-param>
+				</xsl:call-template>
+			</dc:coverage>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=530]">
+			<dc:relation>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">abcdu</xsl:with-param>
+				</xsl:call-template>
+			</dc:relation>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=760]|marc:datafield[@tag=762]|marc:datafield[@tag=765]|marc:datafield[@tag=767]|marc:datafield[@tag=770]|marc:datafield[@tag=772]|marc:datafield[@tag=773]|marc:datafield[@tag=774]|marc:datafield[@tag=775]|marc:datafield[@tag=776]|marc:datafield[@tag=777]|marc:datafield[@tag=780]|marc:datafield[@tag=785]|marc:datafield[@tag=786]|marc:datafield[@tag=787]">
+			<dc:relation>
+				<xsl:call-template name="subfieldSelect">
+					<xsl:with-param name="codes">ot</xsl:with-param>
+				</xsl:call-template>
+			</dc:relation>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=856]">
+			<dc:identifier>
+				<xsl:value-of select="marc:subfield[@code='u']"/>
+			</dc:identifier>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=020]">
+			<dc:identifier>
+				<xsl:text>URN:ISBN:</xsl:text>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:identifier>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=506]">
+			<dc:rights>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:rights>
+		</xsl:for-each>
+		<xsl:for-each select="marc:datafield[@tag=540]">
+			<dc:rights>
+				<xsl:value-of select="marc:subfield[@code='a']"/>
+			</dc:rights>
+		</xsl:for-each>
+		<!--</oai_dc:dc>-->
+	</xsl:template>
 </xsl:stylesheet>
+
+<!-- Stylus Studio meta-information - (c) 2004-2005. Progress Software Corporation. All rights reserved.
+<metaInformation>
+<scenarios ><scenario default="yes" name="Scenario1" userelativepaths="yes" externalpreview="no" url="..\..\..\..\..\..\..\..\..\..\javadev4\testsets\diacriticu8.xml" htmlbaseurl="" outputurl="" processortype="internal" useresolver="yes" profilemode="0" profiledepth="" profilelength="" urlprofilexml="" commandline="" additionalpath="" additionalclasspath="" postprocessortype="none" postprocesscommandline="" postprocessadditionalpath="" postprocessgeneratedext="" validateoutput="no" validator="internal" customvalidator=""/></scenarios><MapperMetaTag><MapperInfo srcSchemaPathIsRelative="yes" srcSchemaInterpretAsXML="no" destSchemaPath="" destSchemaRoot="" destSchemaPathIsRelative="yes" destSchemaInterpretAsXML="no"/><MapperBlockPosition></MapperBlockPosition><TemplateContext></TemplateContext><MapperFilter side="source"></MapperFilter></MapperMetaTag>
+</metaInformation>
+-->

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -354,7 +354,7 @@ def test_toxml_from_xml():
         back_blob = to_marc21.do(rec)
 
         assert blob == back_blob
-        xml = dumps(back_blob)
+        xml = dumps([back_blob])
 
         options = {'xml_declaration': True,
                    'encoding': 'utf8',


### PR DESCRIPTION
- BETTER Adds new argument to specify namespace prefix in generated
  MARCXML.
- INCOMPATIBLE Removes automatic wrapping to `<collection/>` for
  single record passed to `dumps_etree`.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
