### PR TITLE
marc21: add support for leader field

### DIFF
--- a/dojson/contrib/marc21/fields/bdleader.py
+++ b/dojson/contrib/marc21/fields/bdleader.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2016 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""MARC 21 model definition."""
+
+from dojson import utils
+
+from ..model import marc21
+
+
+@marc21.over('leader', '^leader')
+@utils.filter_values
+def leader(self, key, value):
+    """Leader."""
+    record_status = {
+        'a': 'increase_in_encoding_level',
+        'c': 'corrected_or_revised',
+        'd': 'deleted',
+        'n': 'new',
+        'p': 'increase_in_encoding_level_from_prepublication'
+    }
+    type_of_record = {
+        'a': 'language_material',
+        'c': 'notated_music',
+        'd': 'manuscript_notated_music',
+        'e': 'cartographic_material',
+        'f': 'manuscript_cartographic_material',
+        'g': 'projected_medium',
+        'i': 'nonmusical_sound_recording',
+        'j': 'musical_sound_recording',
+        'k': 'two-dimensional_nonprojectable_graphic',
+        'm': 'computer_file',
+        'o': 'kit',
+        'p': 'mixed_materials',
+        'r': 'three-dimensional_artifact_or_naturally_occuring_object',
+        't': 'manuscript_language_material',
+    }
+    bibliographic_level = {
+        'a': 'monographic_component_part',
+        'b': 'serial_component_part',
+        'c': 'collection',
+        'd': 'subunit',
+        'i': 'integrating_resource',
+        'm': 'monograph_item',
+        's': 'serial',
+    }
+    type_of_control = {
+        '#': 'no_specified_type',
+        'a': 'archival',
+    }
+    character_coding_scheme = {
+        '#': 'marc-8',
+        'a': 'ucs_unicode'
+    }
+    encoding_level = {
+        '#': 'full_level',
+        '1': 'full_level_material_not_examined',
+        '2': 'less-than-full_level_material_not_examined',
+        '3': 'abbreviated_level',
+        '4': 'core_level',
+        '5': 'partial_preliminary_level',
+        '7': 'minimal_level',
+        '8': 'prepublication_level',
+        'u': 'unknown',
+        'z': 'not_applicable',
+    }
+    descriptive_cataloging_form = {
+        '#': 'non-isbd',
+        'a': 'aacr_2',
+        'c': 'isbd_punctuation_omitteed',
+        'i': 'isbd_punctuation_included',
+        'u': 'unknown',
+    }
+    multipart_resource_record_level = {
+        '#': 'not_specified_or_not_applicable',
+        'a': 'set',
+        'b': 'part_with_independent_title',
+        'c': 'part_with_dependent_title',
+    }
+
+    length_of_the_length_of_field_portion = {
+        '4': 4,
+    }
+    length_of_the_starting_character_position_portion = {
+        '5': 5,
+    }
+    length_of_the_implementation_defined_portion = {
+        '0': 0,
+    }
+    undefined = {
+        '0': 0,
+    }
+
+    return {
+        'record_length': int(value[:5]),
+        'record_status': record_status.get(value[5]),
+        'type_of_record': type_of_record.get(value[6]),
+        'bibliographic_level': bibliographic_level.get(value[7]),
+        'type_of_control': type_of_control.get(value[8]),
+        'character_coding_scheme': character_coding_scheme.get(value[9]),
+        'indicator_count': int(value[10]),
+        'subfield_code_count': int(value[11]),
+        'base_address_of_data': int(value[12:17]),
+        'encoding_level': encoding_level.get(value[17]),
+        'descriptive_cataloging_form': descriptive_cataloging_form.get(value[18]),
+        'multipart_resource_record_level': multipart_resource_record_level.get(value[19]),
+        'length_of_the_length_of_field_portion':
+            length_of_the_length_of_field_portion.get(value[20]),
+        'length_of_the_starting_character_position_portion':
+            length_of_the_starting_character_position_portion.get(value[21]),
+        'length_of_the_implementation_defined_portion':
+            length_of_the_implementation_defined_portion.get(value[22]),
+        'undefined': undefined.get(value[23])
+    }

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd-v1.0.0.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd-v1.0.0.json
@@ -1,6 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "allOf": [
+        {"$ref": "bdleader.json"},
         {"$ref": "bd00x.json"},
         {"$ref": "bd01x09x.json"},
         {"$ref": "bd1xx.json"},

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bdleader.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bdleader.json
@@ -1,0 +1,62 @@
+{
+    "type": "object",
+    "properties": {
+        "leader": {
+            "description": "Leader",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "record_length": {
+                        "type": "integer"
+                    },
+                    "record_status": {
+                        "type": "string"
+                    },
+                    "type_of_record": {
+                        "type": "string"
+                    },
+                    "bibliographic_level": {
+                        "type": "string"
+                    },
+                    "type_of_control": {
+                        "type": "string"
+                    },
+                    "character_coding_scheme": {
+                        "type": "string"
+                    },
+                    "indicator_count": {
+                        "type": "integer"
+                    },
+                    "subfield_code_count": {
+                        "type": "integer"
+                    },
+                    "base_address_of_data": {
+                        "type": "integer"
+                    },
+                    "encoding_level": {
+                        "type": "string"
+                    },
+                    "descriptive_cataloging_form": {
+                        "type": "string"
+                    },
+                    "multipart_resource_record_level": {
+                        "type": "string"
+                    },
+                    "length_of_the_length_of_field_portion": {
+                        "type": "integer"
+                    },
+                    "length_of_the_starting_character_position_portion": {
+                        "type": "integer"
+                    },
+                    "length_of_the_implementation_defined_portion": {
+                        "type": "integer"
+                    },
+                    "undefined": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/dojson/contrib/to_marc21/fields/bdleader.py
+++ b/dojson/contrib/to_marc21/fields/bdleader.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2016 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""To MARC 21 model definition."""
+
+from dojson import utils
+
+from ..model import to_marc21
+
+
+@to_marc21.over('leader', '^leader')
+def to_leader(self, key, value):
+    """To Leader."""
+    record_status = {
+        'increase_in_encoding_level': 'a',
+        'corrected_or_revised': 'c',
+        'deleted': 'd',
+        'new': 'n',
+        'increase_in_encoding_level_from_prepublication': 'p'
+    }
+    type_of_record = {
+        'language_material': 'a',
+        'notated_music': 'c',
+        'manuscript_notated_music': 'd',
+        'cartographic_material': 'e',
+        'manuscript_cartographic_material': 'f',
+        'projected_medium': 'g',
+        'nonmusical_sound_recording': 'i',
+        'musical_sound_recording': 'j',
+        'two-dimensional_nonprojectable_graphic': 'k',
+        'computer_file': 'm',
+        'kit': 'o',
+        'mixed_materials': 'p',
+        'three-dimensional_artifact_or_naturally_occuring_object': 'r',
+        'manuscript_language_material': 't',
+    }
+    bibliographic_level = {
+        'monographic_component_part': 'a',
+        'serial_component_part': 'b',
+        'collection': 'c',
+        'subunit': 'd',
+        'integrating_resource': 'i',
+        'monograph_item': 'm',
+        'serial': 's',
+    }
+    type_of_control = {
+        'no_specified_type': '#',
+        'archival': 'a',
+    }
+    character_coding_scheme = {
+        'marc-8': '#',
+        'ucs_unicode': 'a'
+    }
+    encoding_level = {
+        'full_level': '#',
+        'full_level_material_not_examined': '1',
+        'less-than-full_level_material_not_examined': '2',
+        'abbreviated_level': '3',
+        'core_level': '4',
+        'partial_preliminary_level': '5',
+        'minimal_level': '7',
+        'prepublication_level': '8',
+        'unknown': 'u',
+        'not_applicable': 'z',
+    }
+    descriptive_cataloging_form = {
+        'non-isbd': '#',
+        'aacr_2': 'a',
+        'isbd_punctuation_omitteed': 'c',
+        'isbd_punctuation_included': 'i',
+        'unknown': 'u',
+    }
+    multipart_resource_record_level = {
+        'not_specified_or_not_applicable': '#',
+        'set': 'a',
+        'part_with_independent_title': 'b',
+        'part_with_dependent_title': 'c',
+    }
+
+    length_of_the_length_of_field_portion = {
+        4: '4',
+    }
+    length_of_the_starting_character_position_portion = {
+        5: '5',
+    }
+    length_of_the_implementation_defined_portion = {
+        0: '0',
+    }
+    undefined = {
+        0: '0',
+    }
+
+    leader_string = ''
+    leader_string += str(value.get('record_length', '     ')).zfill(5)
+    leader_string += record_status.get(value.get('record_status'), ' ')
+    leader_string += type_of_record.get(value.get('type_of_record'), ' ')
+    leader_string += bibliographic_level.get(value.get('bibliographic_level'), ' ')
+    leader_string += type_of_control.get(value.get('type_of_control'), ' ')
+    leader_string += character_coding_scheme.get(value.get('character_coding_scheme'), ' ')
+    leader_string += str(value.get('indicator_count', ' '))
+    leader_string += str(value.get('subfield_code_count', ' '))
+    leader_string += str(value.get('base_address_of_data', '     ')).zfill(5)
+    leader_string += encoding_level.get(value.get('encoding_level'), ' ')
+    leader_string += descriptive_cataloging_form.get(value.get('descriptive_cataloging_form'), ' ')
+    leader_string += multipart_resource_record_level.get(value.get('multipart_resource_record_level'), ' ')
+    leader_string += length_of_the_length_of_field_portion.\
+        get(value.get('length_of_the_length_of_field_portion'), ' ')
+    leader_string += length_of_the_starting_character_position_portion.\
+        get(value.get('length_of_the_starting_character_position_portion'), ' ')
+    leader_string += length_of_the_implementation_defined_portion.\
+        get(value.get('length_of_the_implementation_defined_portion'), ' ')
+    leader_string += undefined.get(value.get('undefined'), ' ')
+
+    assert len(leader_string) == 24
+
+    return leader_string

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -32,6 +32,10 @@ def dumps_etree(records, xslt_filename=None, prefix=None):
         """Dump a single record."""
         rec = E.record()
 
+        leader = record.get('leader')
+        if leader:
+            rec.append(E.leader(leader))
+
         if isinstance(record, GroupableOrderedDict):
             items = record.iteritems(with_order=False, repeated=True)
         else:
@@ -50,6 +54,10 @@ def dumps_etree(records, xslt_filename=None, prefix=None):
                         controlfield.attrib['tag'] = df[0:3]
                         rec.append(controlfield)
             else:
+                # Skip leader.
+                if df == 'leader':
+                    continue
+
                 if not isinstance(subfields, (list, tuple, set)):
                     subfields = (subfields,)
 

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup(
             'dojson = dojson.cli:cli',
         ],
         'dojson.contrib.marc21': [
+            'bdleader = dojson.contrib.marc21.fields.bdleader',
             'bd00x = dojson.contrib.marc21.fields.bd00x',
             'bd01x09x = dojson.contrib.marc21.fields.bd01x09x',
             'bd1xx = dojson.contrib.marc21.fields.bd1xx',
@@ -109,6 +110,7 @@ setup(
             'bd84188x = dojson.contrib.marc21.fields.bd84188x',
         ],
         'dojson.contrib.to_marc21': [
+            'bdleader = dojson.contrib.to_marc21.fields.bdleader',
             'bd00x = dojson.contrib.to_marc21.fields.bd00x',
             'bd01x09x = dojson.contrib.to_marc21.fields.bd01x09x',
             'bd1xx = dojson.contrib.to_marc21.fields.bd1xx',


### PR DESCRIPTION
- Adds bdleader files for conversion to and from marc
- Adds setup entrypoints for new python files

Signed-off-by: Øystein Blixhavn oystein@tind.io
