### PR TITLE
marc21: addition of authority leader field

### DIFF
--- a/dojson/contrib/marc21/fields/adleader.py
+++ b/dojson/contrib/marc21/fields/adleader.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of DoJSON
+# Copyright (C) 2015 CERN.
+#
+# DoJSON is free software; you can redistribute it and/or
+# modify it under the terms of the Revised BSD License; see LICENSE
+# file for more details.
+
+"""MARC 21 model definition."""
+
+from dojson import utils
+
+from ..model import marc21_authority
+
+
+@marc21_authority.over('leader', '^leader')
+@utils.filter_values
+def leader(self, key, value):
+    """Leader."""
+    record_status = {
+        'a': 'increase_in_encoding_level',
+        'c': 'corrected_or_revised',
+        'd': 'deleted',
+        'n': 'new',
+        'o': 'obsolete',
+        's': 'deleted_heading_split_into_two_or_more_headings',
+        'x': 'deleted_heading_replaced_by_another_heading',
+    }
+    type_of_record = {
+        'z': 'authority_data',
+    }
+    character_coding_scheme = {
+        '#': 'marc-8',
+        'a': 'ucs_unicode'
+    }
+    indicator_count = {
+        '2': 'number_of_character_positions_used_for_a_subfield_code',
+    }
+    subfield_code_length = {
+        '2': 'number_of_character_positions_used_for_indicators',
+    }
+    encoding_level = {
+        'n': 'complete_authority_record',
+        'o': 'incomplete_authority_record',
+    }
+
+    length_of_the_length_of_field_portion = {
+        '4': 4,
+    }
+    length_of_the_starting_character_position_portion = {
+        '5': 5,
+    }
+    length_of_the_implementation_defined_portion = {
+        '0': 0,
+    }
+    undefined = {
+        '0': 0,
+    }
+
+    return {
+        'record_length': int(value[:5]),
+        'record_status': record_status.get(value[5]),
+        'type_of_record': type_of_record.get(value[6]),
+        'character_coding_scheme': character_coding_scheme.get(value[9]),
+        'indicator_count': int(value[10]),
+        'subfield_code_length': int(value[11]),
+        'base_address_of_data': int(value[12:17]),
+        'encoding_level': encoding_level.get(value[17]),
+        'length_of_the_length_of_field_portion':
+            length_of_the_length_of_field_portion.get(value[20]),
+        'length_of_the_starting_character_position_portion':
+            length_of_the_starting_character_position_portion.get(value[21]),
+        'length_of_the_implementation_defined_portion':
+            length_of_the_implementation_defined_portion.get(value[22]),
+        'undefined': undefined.get(value[23])
+    }

--- a/dojson/contrib/marc21/schemas/marc21/authority/ad-v1.0.1.json
+++ b/dojson/contrib/marc21/schemas/marc21/authority/ad-v1.0.1.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "allOf": [
+        {"$ref": "adleader.json"},
+        {"$ref": "ad00x.json"},
+        {"$ref": "ad01x09x.json"},
+        {"$ref": "ad1xx3xx.json"},
+        {"$ref": "ad260360.json"},
+        {"$ref": "ad4xx.json"},
+        {"$ref": "ad5xx.json"},
+        {"$ref": "ad64x.json"},
+        {"$ref": "ad663666.json"},
+        {"$ref": "ad66768x.json"},
+        {"$ref": "ad7xx.json"},
+        {"$ref": "ad8xx.json"}
+    ]
+}

--- a/dojson/contrib/marc21/schemas/marc21/authority/adleader.json
+++ b/dojson/contrib/marc21/schemas/marc21/authority/adleader.json
@@ -1,0 +1,50 @@
+{
+    "type": "object",
+    "properties": {
+        "leader": {
+            "description": "Leader",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "record_length": {
+                        "type": "integer"
+                    },
+                    "record_status": {
+                        "type": "string"
+                    },
+                    "type_of_record": {
+                        "type": "string"
+                    },
+                    "character_coding_scheme": {
+                        "type": "string"
+                    },
+                    "indicator_count": {
+                        "type": "integer"
+                    },
+                    "subfield_code_length": {
+                        "type": "integer"
+                    },
+                    "base_address_of_data": {
+                        "type": "integer"
+                    },
+                    "encoding_level": {
+                        "type": "string"
+                    },
+                    "length_of_the_length_of_field_portion": {
+                        "type": "integer"
+                    },
+                    "length_of_the_starting_character_position_portion": {
+                        "type": "integer"
+                    },
+                    "length_of_the_implementation_defined_portion": {
+                        "type": "integer"
+                    },
+                    "undefined": {
+                        "type": "integer"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,7 @@ setup(
             'bd84188x = dojson.contrib.to_marc21.fields.bd84188x',
         ],
         'dojson.contrib.marc21_authority': [
+            'adleader = dojson.contrib.marc21.fields.adleader',
             'ad00x = dojson.contrib.marc21.fields.ad00x',
             'ad01x09x = dojson.contrib.marc21.fields.ad01x09x',
             'ad1xx3xx = dojson.contrib.marc21.fields.ad1xx3xx',


### PR DESCRIPTION
- BETTER Adds conversion support for `leader` field in authority
  records, as well as schema support.

Signed-off-by: Øystein Blixhavn oystein@blixhavn.no
