### PR TITLE
marc21: main_entry_personal_name non repeatable

### DIFF
--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -15,7 +15,6 @@ from ..model import marc21
 
 
 @marc21.over('main_entry_personal_name', '^100[013_]_')
-@utils.for_each_value
 @utils.filter_values
 def main_entry_personal_name(self, key, value):
     """Main Entry-Personal Name."""

--- a/dojson/contrib/to_marc21/fields/bd1xx.py
+++ b/dojson/contrib/to_marc21/fields/bd1xx.py
@@ -15,7 +15,6 @@ from ..model import to_marc21
 
 
 @to_marc21.over('100', '^main_entry_personal_name$')
-@utils.reverse_for_each_value
 @utils.filter_values
 def reverse_main_entry_personal_name(self, key, value):
     """Reverse - Main Entry-Personal Name."""

--- a/tests/data/test_9.xml
+++ b/tests/data/test_9.xml
@@ -9,18 +9,6 @@
       <subfield code="p">Fioretti.</subfield>
       <subfield code="l">English</subfield>
     </datafield>
-    <datafield tag="100" ind1="0" ind2=" ">
-      <subfield code="a">M. Madeleva</subfield>
-      <subfield code="q">(Mary Madeleva),</subfield>
-      <subfield code="c">Sister,</subfield>
-      <subfield code="d">1887-1964</subfield>
-    </datafield>
-    <datafield tag="100" ind1="0" ind2=" ">
-      <subfield code="a">John</subfield>
-      <subfield code="b">XXIII,</subfield>
-      <subfield code="c">Pope,</subfield>
-      <subfield code="d">1881-1963</subfield>
-    </datafield>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">
 Scientific reports (Australasian Antarctic Expedition (1911-1914)).

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,12 +91,10 @@ def test_cli_do_marc21_from_xml():
     """Test MARC21 loading from XML."""
     expected = [{
         '__order__': ['main_entry_personal_name'],
-        'main_entry_personal_name': [
-            {
-                '__order__': ['personal_name'],
-                'personal_name': 'Donges, Jonathan F',
-            }
-        ],
+        'main_entry_personal_name': {
+            '__order__': ['personal_name'],
+            'personal_name': 'Donges, Jonathan F',
+        }
     }]
 
     runner = CliRunner()
@@ -157,12 +155,10 @@ def test_cli_do_marc21_from_json():
     expected = [{
         '$schema': '/schema.json',
         '__order__': ['main_entry_personal_name'],
-        'main_entry_personal_name': [
-            {
-                '__order__': ['personal_name'],
-                'personal_name': 'Donges, Jonathan F',
-            }
-        ],
+        'main_entry_personal_name': {
+            '__order__': ['personal_name'],
+            'personal_name': 'Donges, Jonathan F',
+        }
     }]
 
     runner = CliRunner()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -217,12 +217,10 @@ def test_simple_record_from_xml():
     data = marc21.do(blob)
     expected = {
         '__order__': ['main_entry_personal_name'],
-        'main_entry_personal_name': [
-            {
-                '__order__': ('personal_name',),
-                'personal_name': 'Donges, Jonathan F',
-            }
-        ],
+        'main_entry_personal_name': {
+            '__order__': ('personal_name',),
+            'personal_name': 'Donges, Jonathan F',
+        }
     }
 
     assert data == expected


### PR DESCRIPTION
- FIX Removes list definition from `main_entry_personal_name` as
  according to Library of Congress is a non repeatable field.

Signed-off-by: Esteban J. G. Gabancho esteban.gabancho@gmail.com
