### PR TITLE
marc21: main_entry_uniform_title non-repeatable

### DIFF
--- a/dojson/contrib/marc21/fields/bd1xx.py
+++ b/dojson/contrib/marc21/fields/bd1xx.py
@@ -251,7 +251,6 @@ def main_entry_meeting_name(self, key, value):
 
 
 @marc21.over('main_entry_uniform_title', '^130[_0-9]_')
-@utils.for_each_value
 @utils.filter_values
 def main_entry_uniform_title(self, key, value):
     """Main Entry-Uniform Title."""

--- a/dojson/contrib/to_marc21/fields/bd1xx.py
+++ b/dojson/contrib/to_marc21/fields/bd1xx.py
@@ -241,7 +241,6 @@ def reverse_main_entry_meeting_name(self, key, value):
 
 
 @to_marc21.over('130', '^main_entry_uniform_title$')
-@utils.reverse_for_each_value
 @utils.filter_values
 def reverse_main_entry_uniform_title(self, key, value):
     """Reverse - Main Entry-Uniform Title."""

--- a/tests/data/test_9.xml
+++ b/tests/data/test_9.xml
@@ -9,6 +9,8 @@
       <subfield code="p">Fioretti.</subfield>
       <subfield code="l">English</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">
 Scientific reports (Australasian Antarctic Expedition (1911-1914)).
@@ -16,6 +18,8 @@ Scientific reports (Australasian Antarctic Expedition (1911-1914)).
       <subfield code="n">Series C,</subfield>
       <subfield code="p">Zoology and botany</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">Bible.</subfield>
       <subfield code="p">N.T.</subfield>
@@ -23,6 +27,8 @@ Scientific reports (Australasian Antarctic Expedition (1911-1914)).
       <subfield code="l">Polyglot.</subfield>
       <subfield code="d">1965</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">Bible.</subfield>
       <subfield code="p">O.T.</subfield>
@@ -31,6 +37,8 @@ Scientific reports (Australasian Antarctic Expedition (1911-1914)).
       <subfield code="s">Pope.</subfield>
       <subfield code="f">1977</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">Bible.</subfield>
       <subfield code="p">O.T.</subfield>
@@ -40,10 +48,14 @@ Scientific reports (Australasian Antarctic Expedition (1911-1914)).
       <subfield code="f">1957.</subfield>
       <subfield code="s">Pfeiffer</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">Bulletin</subfield>
       <subfield code="h">[1894-1908] (South Dakota Geological Survey)</subfield>
     </datafield>
+  </record>
+  <record>
     <datafield tag="130" ind1="0" ind2=" ">
       <subfield code="a">Talmud.</subfield>
       <subfield code="t">Minor tractates.</subfield>


### PR DESCRIPTION
- FIX Removes list definition from `main_entry_uniform_title` as
  according to Library of Congress is a non repeatable field.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
