### PR TITLE
utils: force_list to return list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Backup files
+*~

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -30,7 +30,7 @@ def int_with_default(value, default):
 
 
 def ignore_value(f):
-    """Remove key for None value.
+    """Remove key for None or empty value value.
 
     .. versionadded:: 0.2.0
 
@@ -45,11 +45,14 @@ def ignore_value(f):
 
 
 def filter_values(f):
-    """Remove None values from dictionary."""
+    """Remove None or empty values from dictionary."""
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         out = f(*args, **kwargs)
-        return dict((k, v) for k, v in six.iteritems(out) if v is not None)
+        out = dict((k, v) for k, v in six.iteritems(out) if v or v is False or v == 0)
+        if '__order__' in out:
+            out['__order__'] = tuple(k for k in out['__order__'] if k in out)
+        return out
     return wrapper
 
 
@@ -96,8 +99,12 @@ def reverse_for_each_value(f):
 
 def force_list(data):
     """Wrap data in list."""
-    if data is not None and not isinstance(data, (list, tuple, set)):
-        return (data,)
+    if data is None:
+        return []
+    elif not isinstance(data, (list, tuple, set)):
+        return [data]
+    elif isinstance(data, (tuple, set)):
+        return list(data)
     return data
 
 

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -222,6 +222,15 @@ class GroupableOrderedDict(OrderedDict):
         OrderedDict.__setitem__(new, '__order__', tuple(ordering))
         return new
 
+    def __repr__(self):
+        """Output the representation of the GroupableOrderedDict."""
+        out = ("({!r}, {!r})".format(k, v)
+               for k, v in self.iteritems(repeated=True)
+               if k != '__order__')
+        return 'GroupableOrderedDict(({out}))'.format(out=', '.join(out))
+
+    __str__ = __repr__
+
     def __init__(self, *args, **kwargs):
         """Initialize the GroupableOrderedDict.
 

--- a/tests/data/library_of_congress/bd01x09x.xml
+++ b/tests/data/library_of_congress/bd01x09x.xml
@@ -309,14 +309,12 @@
     <datafield tag="017" ind1=" " ind2=" ">
       <subfield code="a">99-263</subfield>
       <subfield code="b">BwMiBKP </subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="017" ind1=" " ind2=" ">
       <subfield code="a">99-7356</subfield>
       <subfield code="b">RuMoRKP </subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -532,7 +530,6 @@
   </record>
   <record>
     <datafield tag="020" ind1=" " ind2=" ">
-      <subfield code="c"></subfield>
       <subfield code="8">.95</subfield>
     </datafield>
   </record>
@@ -2524,7 +2521,6 @@
   <record>
     <datafield tag="046" ind1=" " ind2=" ">
       <subfield code="j">2001-07-12</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -2608,13 +2604,11 @@
   <record>
     <datafield tag="047" ind1=" " ind2="7">
       <subfield code="a">hum</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="047" ind1=" " ind2="7">
       <subfield code="a">rgg</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -2662,7 +2656,6 @@
       <subfield code="a">pct01</subfield>
       <subfield code="a">pxy02</subfield>
       <subfield code="a">pta01</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -2671,7 +2664,6 @@
       <subfield code="a">tth01</subfield>
       <subfield code="a">tch01</subfield>
       <subfield code="a">kor01</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -3101,11 +3093,6 @@
   </record>
   <record>
     <datafield tag="066" ind1=" " ind2=" ">
-      <subfield code="b"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="066" ind1=" " ind2=" ">
       <subfield code="b">)Q</subfield>
     </datafield>
   </record>
@@ -3259,20 +3246,17 @@
   <record>
     <datafield tag="080" ind1=" " ind2=" ">
       <subfield code="a">001.81</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="080" ind1=" " ind2=" ">
       <subfield code="a">631.321:631.411.3 </subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="080" ind1=" " ind2=" ">
       <subfield code="a">821.113.1</subfield>
       <subfield code="x">(494) </subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -3293,7 +3277,6 @@
       <subfield code="x">(474) </subfield>
       <subfield code="x">"19"</subfield>
       <subfield code="x">(075)</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd20x24x.xml
+++ b/tests/data/library_of_congress/bd20x24x.xml
@@ -262,9 +262,6 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="240" ind1="1" ind2="0"/>
-  </record>
-  <record>
     <datafield tag="240" ind1="1" ind2="4">
       <subfield code="a">The Pickwick papers.</subfield>
       <subfield code="l">French</subfield>
@@ -416,26 +413,6 @@
   </record>
   <record>
     <datafield tag="245" ind1="0" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="0" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="0" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="0" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">4 corners power review.</subfield>
     </datafield>
   </record>
@@ -517,7 +494,6 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Assembly file analysis</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -582,7 +558,6 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">College English</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -609,7 +584,6 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Concerto per piano n. 21, K 467</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -641,7 +615,6 @@
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Daily report.</subfield>
       <subfield code="p">People's Republic of China</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -705,19 +678,16 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Florida bird songs</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Focus on grammar</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Folk songs of S.E. Tennessee</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -752,7 +722,6 @@
       <subfield code="a">Heritage Books archives.</subfield>
       <subfield code="p">Underwood biographical dictionary.</subfield>
       <subfield code="n">Volumes 1 &amp; 2 revised</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -830,7 +799,6 @@
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Life on earth.</subfield>
       <subfield code="p">The swarming hordes</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -920,13 +888,11 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Nineteenth century English drama</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Oklahoma</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -943,7 +909,6 @@
       <subfield code="a">Portals to the world.</subfield>
       <subfield code="p">Selected Internet resources.</subfield>
       <subfield code="p">Maldives</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -972,7 +937,6 @@
   <record>
     <datafield tag="245" ind1="0" ind2="0">
       <subfield code="a">Rubber world</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1058,13 +1022,11 @@
   <record>
     <datafield tag="245" ind1="0" ind2="3">
       <subfield code="a">La mer</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="245" ind1="0" ind2="3">
       <subfield code="a">Le Bureau</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1096,7 +1058,6 @@
   <record>
     <datafield tag="245" ind1="0" ind2="4">
       <subfield code="a">The Green bag</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1148,30 +1109,10 @@
     </datafield>
   </record>
   <record>
-    <datafield tag="245" ind1="0" ind2="5">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="6">880-02</subfield>
       <subfield code="a">Hung Jen-kan /</subfield>
       <subfield code="c">cShen Wei-pin chu.</subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="1" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="1" ind2="0">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="245" ind1="1" ind2="0">
-      <subfield code="a"></subfield>
     </datafield>
   </record>
   <record>
@@ -1253,7 +1194,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Conference on Industrial Development in the Arab Countries :</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -1325,7 +1265,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Gentlemen's quarterly</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1419,7 +1358,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Law and the family, New York /</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -1453,7 +1391,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Newspaper geog. list</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1493,7 +1430,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Proceedings of the Seminar on Cataloging Digital Documents, October 12-14, 1994</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1557,7 +1493,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Trade Union Fellowship Program :</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -1568,7 +1503,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="0">
       <subfield code="a">Vier letzte Lieder</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1679,7 +1613,6 @@
   <record>
     <datafield tag="245" ind1="1" ind2="4">
       <subfield code="a">The New Lost City Ramblers with Cousin Emmy</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -1732,13 +1665,11 @@
   <record>
     <datafield tag="245" ind1="1" ind2="4">
       <subfield code="a">The printer's manual</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="245" ind1="1" ind2="4">
       <subfield code="a">The royal gazette</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd25x28x.xml
+++ b/tests/data/library_of_congress/bd25x28x.xml
@@ -223,11 +223,6 @@
   </record>
   <record>
     <datafield tag="257" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="257" ind1=" " ind2=" ">
       <subfield code="a">France</subfield>
       <subfield code="a">Germany</subfield>
       <subfield code="a">Italy</subfield>
@@ -290,61 +285,6 @@
   </record>
   <record>
     <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="a">Amsterdam :</subfield>
       <subfield code="b">Elsevier,</subfield>
       <subfield code="c">1979-</subfield>
@@ -390,7 +330,6 @@
   <record>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="a">London :</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -420,7 +359,6 @@
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="a">London :</subfield>
       <subfield code="b">Howard League for Penal Reform,</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -536,7 +474,6 @@
       <subfield code="a">Paris :</subfield>
       <subfield code="b">Impr. Vincent,</subfield>
       <subfield code="c">1798</subfield>
-      <subfield code="a"></subfield>
     </datafield>
   </record>
   <record>
@@ -569,7 +506,6 @@
   <record>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="a">Victoria, B.C. :</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -599,16 +535,6 @@
       <subfield code="a">Washington, D.C. :</subfield>
       <subfield code="b">U.S. Dept. of Commerce, Bureau of the Census:</subfield>
       <subfield code="b">For sale by the Supt. of Docs., U.S. G.P.O.</subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="c"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -730,7 +656,6 @@
     <datafield tag="262" ind1=" " ind2=" ">
       <subfield code="a">Louisville, KY.,</subfield>
       <subfield code="b">Louisville Orchestra,</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -744,14 +669,12 @@
     <datafield tag="262" ind1=" " ind2=" ">
       <subfield code="b">RCA Victor</subfield>
       <subfield code="k">LM6130.</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="262" ind1=" " ind2=" ">
       <subfield code="b">Telefunken</subfield>
       <subfield code="k">SLT 43091.</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -781,13 +704,7 @@
   </record>
   <record>
     <datafield tag="264" ind1=" " ind2="1">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="264" ind1=" " ind2="1">
       <subfield code="a">Boston : </subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd3xx.xml
+++ b/tests/data/library_of_congress/bd3xx.xml
@@ -1365,19 +1365,16 @@
   <record>
     <datafield tag="348" ind1=" " ind2=" ">
       <subfield code="a">part</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="348" ind1=" " ind2=" ">
       <subfield code="a">piano conductor part</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="348" ind1=" " ind2=" ">
       <subfield code="a">score</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -1390,7 +1387,6 @@
   <record>
     <datafield tag="348" ind1=" " ind2=" ">
       <subfield code="a">vocal score</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -2356,25 +2352,21 @@
   <record>
     <datafield tag="388" ind1="1" ind2=" ">
       <subfield code="a">18th century</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="388" ind1="1" ind2=" ">
       <subfield code="a">19th century</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="388" ind1="1" ind2=" ">
       <subfield code="a">Ancient period</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="388" ind1="1" ind2=" ">
       <subfield code="a">Anglo-Saxon period</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -2387,7 +2379,6 @@
     <datafield tag="388" ind1="2" ind2=" ">
       <subfield code="a">20th century</subfield>
       <subfield code="a">21st century</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
 </collection>

--- a/tests/data/library_of_congress/bd5xx.xml
+++ b/tests/data/library_of_congress/bd5xx.xml
@@ -7,11 +7,6 @@
   </record>
   <record>
     <datafield tag="500" ind1=" " ind2=" ">
-      <subfield code="a"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="500" ind1=" " ind2=" ">
       <subfield code="a">"ISSN 0399-3388."</subfield>
     </datafield>
   </record>
@@ -574,7 +569,6 @@
   <record>
     <datafield tag="506" ind1=" " ind2=" ">
       <subfield code="a">Some restrictions apply. Consult restricted access file for restriction details:</subfield>
-      <subfield code="u"></subfield>
     </datafield>
   </record>
   <record>
@@ -1290,19 +1284,16 @@
     <datafield tag="520" ind1="4" ind2=" ">
       <subfield code="a">Contains strong sexual theme and fetish scenes</subfield>
       <subfield code="c">Central County Library</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="520" ind1="4" ind2=" ">
       <subfield code="a">Contains swear words, sex scenes and violence</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="520" ind1="4" ind2=" ">
       <subfield code="a">Contains violence</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -1687,7 +1678,6 @@
     <datafield tag="533" ind1=" " ind2=" ">
       <subfield code="3">v.40-49(1966-1975)</subfield>
       <subfield code="a">Electronic reproduction.</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -1702,19 +1692,16 @@
   <record>
     <datafield tag="533" ind1=" " ind2=" ">
       <subfield code="a">Microfiche.</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="533" ind1=" " ind2=" ">
       <subfield code="a">Microfiche.</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="533" ind1=" " ind2=" ">
       <subfield code="a">Microfiche.</subfield>
-      <subfield code="b"></subfield>
     </datafield>
   </record>
   <record>
@@ -1795,7 +1782,6 @@
       <subfield code="a">Microfilm.</subfield>
       <subfield code="b">Washington, D.C. :</subfield>
       <subfield code="c">United States Historical Documents Institute,</subfield>
-      <subfield code="d"></subfield>
     </datafield>
   </record>
   <record>
@@ -1826,7 +1812,6 @@
       <subfield code="m">1960-1968.</subfield>
       <subfield code="b">Washington, D.C. :</subfield>
       <subfield code="c">Library of Congress,</subfield>
-      <subfield code="d"></subfield>
     </datafield>
   </record>
   <record>
@@ -2012,7 +1997,6 @@
   <record>
     <datafield tag="534" ind1=" " ind2=" ">
       <subfield code="p">Originalversion:</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -2032,7 +2016,6 @@
     <datafield tag="534" ind1=" " ind2=" ">
       <subfield code="p">Originalversion:</subfield>
       <subfield code="t">A map of Virginia andMaryland.</subfield>
-      <subfield code="c"></subfield>
     </datafield>
   </record>
   <record>
@@ -2608,7 +2591,6 @@
       <subfield code="l">undetermined </subfield>
       <subfield code="m">undetermined</subfield>
       <subfield code="o">20071210 </subfield>
-      <subfield code="q"></subfield>
     </datafield>
   </record>
   <record>
@@ -2619,7 +2601,6 @@
       <subfield code="l">undetermined </subfield>
       <subfield code="m">undetermined</subfield>
       <subfield code="o">20071210 </subfield>
-      <subfield code="q"></subfield>
     </datafield>
   </record>
   <record>
@@ -3567,7 +3548,6 @@
     <datafield tag="583" ind1="0" ind2=" ">
       <subfield code="a">appraised</subfield>
       <subfield code="c">197508</subfield>
-      <subfield code="l"></subfield>
       <subfield code="2">5,000</subfield>
       <subfield code="k">Karl Schach</subfield>
     </datafield>

--- a/tests/data/library_of_congress/bd6xx.xml
+++ b/tests/data/library_of_congress/bd6xx.xml
@@ -894,7 +894,6 @@
       <subfield code="x">Nuclear reactor safety</subfield>
       <subfield code="y">1975-1985</subfield>
       <subfield code="z">United States.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1163,7 +1162,6 @@
       <subfield code="a">Fire reports</subfield>
       <subfield code="z">Atlanta, Georgia</subfield>
       <subfield code="y">1978.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1180,7 +1178,6 @@
       <subfield code="a">Agenda</subfield>
       <subfield code="x">Weekly</subfield>
       <subfield code="y">1980-1985.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1217,7 +1214,6 @@
     <datafield tag="655" ind1=" " ind2="7">
       <subfield code="a">Diaries</subfield>
       <subfield code="z">Belgium.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1274,7 +1270,6 @@
       <subfield code="a">Prayer books</subfield>
       <subfield code="z">Rhode Island</subfield>
       <subfield code="y">18th century.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1314,47 +1309,40 @@
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Anthropologists.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Chauffeurs</subfield>
       <subfield code="z">France.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Dentists.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Educators.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Migrant laborers.</subfield>
       <subfield code="k">School district case files.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="656" ind1=" " ind2="7">
       <subfield code="a">Plastic surgeons</subfield>
       <subfield code="z">Los Angeles (Calif.)</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="657" ind1=" " ind2="7">
       <subfield code="a">Annual inventory</subfield>
       <subfield code="x">Ladies' apparel.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1406,7 +1394,6 @@
     <datafield tag="658" ind1=" " ind2=" ">
       <subfield code="a">Math manipulatives</subfield>
       <subfield code="d">highly correlated.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd70x75x.xml
+++ b/tests/data/library_of_congress/bd70x75x.xml
@@ -694,7 +694,6 @@
     <datafield tag="730" ind1="0" ind2=" ">
       <subfield code="a">Index librorum prohibitorum.</subfield>
       <subfield code="f">1570.</subfield>
-      <subfield code="5"></subfield>
     </datafield>
   </record>
   <record>
@@ -809,7 +808,6 @@
   <record>
     <datafield tag="740" ind1="0" ind2="2">
       <subfield code="a">South Pacific</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>
@@ -988,7 +986,6 @@
       <subfield code="d">Mediterranean gecko</subfield>
       <subfield code="d">Mediterranean gekko</subfield>
       <subfield code="x">Hemidactylus turcicus.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1001,7 +998,6 @@
       <subfield code="a">Turcicus</subfield>
       <subfield code="d">Mediterranean gecko</subfield>
       <subfield code="d">Mediterranean gekko.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1012,7 +1008,6 @@
       <subfield code="a">Hemidactylus</subfield>
       <subfield code="c">species</subfield>
       <subfield code="a">Turcicus.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1029,7 +1024,6 @@
       <subfield code="x">Andropogon glomeratus</subfield>
       <subfield code="z">Species authority: (Walt.) BSP</subfield>
       <subfield code="z">Variety authority: Vasey turcicus.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1042,7 +1036,6 @@
       <subfield code="a">agraria</subfield>
       <subfield code="x">Barbula agraria.</subfield>
       <subfield code="z">Species authority: Hedw.turcicus.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1059,7 +1052,6 @@
       <subfield code="d">Eastern diamondback rattlesnake</subfield>
       <subfield code="d">Rattler</subfield>
       <subfield code="d">Rattlesnake.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1076,7 +1068,6 @@
       <subfield code="d">Pigmy rattlesnake</subfield>
       <subfield code="d">Rattler</subfield>
       <subfield code="d">Rattlesnake.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
@@ -1099,7 +1090,6 @@
       <subfield code="a">setigera</subfield>
       <subfield code="c">variety</subfield>
       <subfield code="a">tomentosa.</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
 </collection>

--- a/tests/data/library_of_congress/bd76x78x.xml
+++ b/tests/data/library_of_congress/bd76x78x.xml
@@ -205,7 +205,6 @@
       <subfield code="7">p1am</subfield>
       <subfield code="a">Hamilton, Milton W. (Milton Wheaton), 1901-</subfield>
       <subfield code="t">Sir William Johnson and the Indians of New York.</subfield>
-      <subfield code="d"></subfield>
     </datafield>
   </record>
   <record>
@@ -256,65 +255,55 @@
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="8">1\c</subfield>
       <subfield code="o">NYDA.1993.010.00130. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="8">2\c</subfield>
       <subfield code="o">NYDA.1993.010.00131. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="8">3\c</subfield>
       <subfield code="o">NYDA.1993.010.00132. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="8">4\c</subfield>
       <subfield code="o">NYDA.1993.010.00133. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="8">5\c</subfield>
       <subfield code="o">NYDA.1993.010.00134. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="o">NYDA.1993.010.00130. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="o">NYDA.1993.010.00131. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="o">NYDA.1993.010.00132. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="o">NYDA.1993.010.00133. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="774" ind1="0" ind2=" ">
       <subfield code="o">NYDA.1993.010.00134. </subfield>
-      <subfield code="n"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd80x83x.xml
+++ b/tests/data/library_of_congress/bd80x83x.xml
@@ -296,7 +296,6 @@
   <record>
     <datafield tag="830" ind1=" " ind2="0">
       <subfield code="a">Teenage years.</subfield>
-      <subfield code="h"></subfield>
     </datafield>
   </record>
   <record>

--- a/tests/data/library_of_congress/bd84188x.xml
+++ b/tests/data/library_of_congress/bd84188x.xml
@@ -93,7 +93,6 @@
   <record>
     <datafield tag="852" ind1=" " ind2="0">
       <subfield code="3">Correspondence</subfield>
-      <subfield code="a"></subfield>
     </datafield>
   </record>
   <record>
@@ -465,11 +464,6 @@
   </record>
   <record>
     <datafield tag="856" ind1="4" ind2="1">
-      <subfield code="u"></subfield>
-    </datafield>
-  </record>
-  <record>
-    <datafield tag="856" ind1="4" ind2="1">
       <subfield code="u">http://muse.jhu.edu/journals/american%5Fquarterly/</subfield>
     </datafield>
   </record>
@@ -648,13 +642,11 @@
   <record>
     <datafield tag="887" ind1=" " ind2=" ">
       <subfield code="a">&lt;Box&gt;&lt;eastlimit&gt;0&lt;/eastlimit&gt;&lt;westlimit&gt;180&lt;/westlimit&gt;&lt;/Box&gt;</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
   <record>
     <datafield tag="887" ind1=" " ind2=" ">
       <subfield code="a">&lt;TextPublicationDate&gt;20000617&lt;/TextPublicationDate&gt;</subfield>
-      <subfield code="2"></subfield>
     </datafield>
   </record>
 </collection>

--- a/tests/data/test_7.xml
+++ b/tests/data/test_7.xml
@@ -91,7 +91,6 @@
       <subfield code="0">(orcid)0000-0002-1825-0097</subfield>
     </datafield>
     <datafield tag="700" ind1=" " ind2=" ">
-      <subfield code="u"></subfield>
       <subfield code="4">oth</subfield>
       <subfield code="a">Hansen, Viggo</subfield>
     </datafield>
@@ -138,6 +137,5 @@
     <datafield tag="542" ind1=" " ind2=" ">
       <subfield code="l">open</subfield>
     </datafield>
-    <datafield tag="347" ind1=" " ind2=" "/>
   </record>
 </collection>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,7 +42,6 @@ RECORD = """<record>
     <subfield code="a">&lt;p&gt;Model definitions and data...&lt;/p&gt;</subfield>
   </datafield>
   <datafield tag="540" ind1=" " ind2=" ">
-    <subfield code="u"></subfield>
     <subfield code="a">Other (Open)</subfield>
   </datafield>
   <datafield tag="542" ind1=" " ind2=" ">

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -421,12 +421,12 @@ def test_marc21_856_indicators():
                 'electronic_location_and_access': [
                     {
                         '__order__': ('file_size', 'uniform_resource_identifier', 'public_note', 'access_method', 'relationship'),
-                        'public_note': ('0',),
+                        'public_note': ['0'],
                         'access_method': 'HTTP',
                         'relationship': 'No information provided',
-                        'uniform_resource_identifier': (
-                            'https://zenodo.org/record/17575/files/...',),
-                        'file_size': ('272681',)
+                        'uniform_resource_identifier': [
+                            'https://zenodo.org/record/17575/files/...'],
+                        'file_size': ['272681']
                     }
                 ]
             }
@@ -445,12 +445,12 @@ def test_marc21_856_indicators():
                 'electronic_location_and_access': [
                     {
                         '__order__': ('file_size', 'uniform_resource_identifier', 'public_note', 'access_method', 'relationship'),
-                        'public_note': ('0',),
+                        'public_note': ['0'],
                         'access_method': 'Awesome access method',
                         'relationship': 'No information provided',
-                        'uniform_resource_identifier': (
-                            'https://zenodo.org/record/17575/files/...',),
-                        'file_size': ('272681',)
+                        'uniform_resource_identifier': [
+                            'https://zenodo.org/record/17575/files/...'],
+                        'file_size': ['272681']
                     }
                 ]
             }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,13 +14,20 @@ import copy
 import pytest
 import simplejson as json
 
-from dojson.utils import GroupableOrderedDict
+from dojson.utils import GroupableOrderedDict, filter_values, force_list
 
 
 @pytest.fixture
 def god():
     """Create a GroupableOrderedDict for testing."""
     return GroupableOrderedDict([('a', 'dojson'), ('b', 2), ('c', 'invenio'),
+                                 ('a', 4), ('b', 5)])
+
+
+@pytest.fixture
+def god_with_none():
+    """Create a GroupableOrderedDict for testing, with a None value."""
+    return GroupableOrderedDict([('a', 'dojson'), ('b', 2), ('c', None),
                                  ('a', 4), ('b', 5)])
 
 
@@ -167,3 +174,22 @@ def test_empty_elements():
     assert '037__' in data.keys()
     assert data['037__'] == {}
     assert (('__order__', ('037__', )), ('037__', {})) == data.items()
+
+
+def test_force_list():
+    """Test the behavior of force_list()."""
+    assert force_list([1, 2, 3]) == [1, 2, 3]
+    assert sorted(force_list(set([1, 2, 3]))) == sorted([1, 2, 3])
+    assert force_list((1, 2, 3)) == [1, 2, 3]
+    assert force_list(None) == []
+    assert force_list("foo") == ["foo"]
+
+
+def test_filter_value_on_groupable_ordered_dict(god_with_none):
+    @filter_values
+    def dummy(god):
+        return god
+    assert dummy(god_with_none) == GroupableOrderedDict([('a', 'dojson'),
+                                                         ('b', 2),
+                                                         ('a', 4),
+                                                         ('b', 5)])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,6 +164,11 @@ def test_groupable_ordered_dict_recreate(god):
     assert god2 == god
 
 
+def test_groupable_ordered_dict_repr(god):
+    """Test that a eval(repr(god)) == god."""
+    assert eval(repr(god)) == god
+
+
 def test_empty_elements():
     """Test empty elements."""
     from dojson.contrib.marc21.utils import create_record


### PR DESCRIPTION
- FIX Fixes utils.force_list() to actually return a list, rather
  than a tuple or None.
  (Closes #154)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
