### PR TITLE
utils: fix GroupableOrderedDict items method

### DIFF
--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -376,10 +376,16 @@ class GroupableOrderedDict(OrderedDict):
         if not repeated:
             if with_order:
                 yield '__order__', dict.__getitem__(self, '__order__')
+            occurences = {
+                k: len(list(v))
+                for k, v in itertools.groupby(sorted(self.keys()))
+            }
             for key, value in OrderedDict.items(self):
                 if key == '__order__':
                     continue
-                if len(value) == 1:
+                if isinstance(value, (list, tuple)) and \
+                        len(value) == 1 and \
+                        occurences[key] == 1:
                     yield key, value[0]
                 else:
                     yield key, value

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -155,3 +155,15 @@ def test_groupable_ordered_dict_recreate(god):
                                  'c': 'invenio'})
 
     assert god2 == god
+
+
+def test_empty_elements():
+    """Test empty elements."""
+    from dojson.contrib.marc21.utils import create_record
+    xml = (
+        '<record><datafield tag="037" ind1=" " ind2=" "></datafield></record>'
+    )
+    data = create_record(xml)
+    assert '037__' in data.keys()
+    assert data['037__'] == {}
+    assert (('__order__', ('037__', )), ('037__', {})) == data.items()


### PR DESCRIPTION
- FIX Removes invalid check for length of yielded value causing
  exception when value is dictionary with one item.  (closes #150)

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
