### PR TITLE
utils: GroupableOrderedDict.__repr__()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+
+# Backup files
+*~

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -215,6 +215,15 @@ class GroupableOrderedDict(OrderedDict):
         OrderedDict.__setitem__(new, '__order__', tuple(ordering))
         return new
 
+    def __repr__(self):
+        """Output the representation of the GroupableOrderedDict."""
+        out = ("({!r}, {!r})".format(k, v)
+               for k, v in self.iteritems(repeated=True)
+               if k != '__order__')
+        return 'GroupableOrderedDict(({out}))'.format(out=', '.join(out))
+
+    __str__ = __repr__
+
     def __init__(self, *args, **kwargs):
         """Initialize the GroupableOrderedDict.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,6 +157,11 @@ def test_groupable_ordered_dict_recreate(god):
     assert god2 == god
 
 
+def test_groupable_ordered_dict_repr(god):
+    """Test that a eval(repr(god)) == god."""
+    assert eval(repr(god)) == god
+
+
 def test_empty_elements():
     """Test empty elements."""
     from dojson.contrib.marc21.utils import create_record


### PR DESCRIPTION
```
utils: GroupableOrderedDict.__repr__()

* FIX Implements GroupableOrderedDict.__repr__()
  allowing for having
  >>> assert eval(repr(god)) == god
  (closes #162)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>
```
