### PR TITLE
global: allow skip single elements

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Contact us at `info@inveniosoftware.org
 
 Active contributors:
 
+* David Caro <david.caro@cern.ch>
 * Esteban J. G. Gabancho <esteban.jose.garcia.gabancho@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/dojson/errors.py
+++ b/dojson/errors.py
@@ -14,7 +14,6 @@ class DoJSONException(Exception):
     """Parent for all DoJSON exceptions.
 
     .. versionadded:: 1.0.0
-
     """
 
 
@@ -22,7 +21,13 @@ class IgnoreKey(DoJSONException):
     """The corresponding key has been ignored.
 
     .. versionadded:: 0.2.0
+    """
 
+
+class IgnoreElement(DoJSONException):
+    """The corresponding element for the current list key has been ignored.
+
+    .. versionadded:: 1.3.0
     """
 
 
@@ -30,5 +35,4 @@ class MissingRule(DoJSONException):
     """Raise when no matching rule was found.
 
     .. versionadded:: 1.0.0
-
     """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,12 @@ from dojson.contrib.marc21 import marc21
 from dojson.contrib.marc21.utils import create_record, load, split_stream
 from dojson.contrib.to_marc21 import to_marc21
 from dojson.contrib.to_marc21.utils import dumps
-from dojson.utils import flatten, for_each_value, ignore_value
+from dojson.utils import (
+    flatten,
+    for_each_value,
+    ignore_list_element,
+    ignore_value,
+)
 
 RECORD = """<record>
   <controlfield tag="001">17575</controlfield>
@@ -287,6 +292,25 @@ def test_no_none_value():
 
     data = overdo.do({'0247_': 'valid value'})
     assert data.get('024') == 'valid value'
+
+
+def test_none_element():
+    """Test none value for a list element."""
+    overdo = dojson.Overdo()
+
+    @overdo.over('b', 'b')
+    @for_each_value
+    @ignore_list_element
+    def match(self, key, value):
+        if value == 2:
+            return None
+
+        return value
+
+    source = {'b': ['', 0, 1, 2, 3, None]}
+    result = {'b': ['', 0, 1, 3]}
+
+    assert overdo.do(source) == result
 
 
 def test_marc21_loader():


### PR DESCRIPTION
- Add the possibility to skip single elements when using the for_each
  decorator, either raising the IgnoreElem exception or using the
  ignore_list_elem decorator.

Signed-off-by: David Caro david@dcaro.es
