### PR TITLE
dojson: original blob passed to rules

### DIFF
--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -129,7 +129,9 @@ class Overdo(object):
         if ignore_missing:
             handlers.setdefault(MissingRule, clean_missing)
 
-        output = {}
+        output = {
+            "__original_blob__": blob,
+        }
 
         if self.index is None:
             self.build()
@@ -161,6 +163,7 @@ class Overdo(object):
                 else:
                     raise
 
+        del output["__original_blob__"]
         return output
 
     def missing(self, blob):


### PR DESCRIPTION
- NEW Extends the dictionary being passed to dojson rules in the self
  argument, by adding a new special key `__original_blob__` that can
  be used to build rules that depend on a global overview of the
  input. (closes #171)

Signed-off-by: Samuele Kaplun samuele.kaplun@cern.ch
