### PR TITLE
utils: deepcopy fix for GroupableOrderedDict

### DIFF
--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -233,7 +233,7 @@ class GroupableOrderedDict(OrderedDict):
         """A copy of D."""
         return GroupableOrderedDict(self)
 
-    def __deepcopy__(self):
+    def __deepcopy__(self, memo=None):
         """A copy of D."""
         return self.__copy__()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -108,6 +108,14 @@ def test_groupable_ordered_dict_copy(god):
     assert god == god2
 
 
+def test_groupable_ordered_dict_deepcopy(god):
+    """Test that a GroupableOrderedDict can be copied deeply."""
+    god2 = copy.deepcopy(god)
+
+    assert id(god) != id(god2)
+    assert god == god2
+
+
 def test_groupable_ordered_dict_new(god):
     """Test that a GroupableOrderedDict can be created from a same element."""
     god2 = GroupableOrderedDict(god)


### PR DESCRIPTION
- FIX Adds missing default argument to `__deepcopy__` method on
  GroupableOrderedDict.  (closes #167)

Reviewed-by: Jiri Kuncar jiri.kuncar@cern.ch
Signed-off-by: zazasa salvatore.zaza@gmail.com
## 

closes #168
