### PR TITLE
utils: skipping of individual items

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Contact us at `info@inveniosoftware.org
 
 Active contributors:
 
+* David Caro <david@dcaro.es>
 * Esteban J. G. Gabancho <esteban.jose.garcia.gabancho@cern.ch>
 * Jiri Kuncar <jiri.kuncar@cern.ch>
 * Sami Hiltunen <sami.mikael.hiltunen@cern.ch>

--- a/dojson/errors.py
+++ b/dojson/errors.py
@@ -24,6 +24,13 @@ class IgnoreKey(DoJSONException):
     """
 
 
+class IgnoreItem(DoJSONException):
+    """The corresponding item from the current iterable has been ignored.
+
+    .. versionadded:: 1.3.0
+    """
+
+
 class MissingRule(DoJSONException):
     """Raise when no matching rule was found.
 

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -18,7 +18,7 @@ from collections import Counter, OrderedDict
 import simplejson as json
 
 from ._compat import iteritems
-from .errors import IgnoreKey
+from .errors import IgnoreItem, IgnoreKey
 
 
 def int_with_default(value, default):
@@ -73,9 +73,18 @@ def for_each_value(f):
 
     @functools.wraps(f)
     def wrapper(self, key, values, **kwargs):
-        if isinstance(values, (list, tuple, set)):
-            return [f(self, key, value, **kwargs) for value in values]
-        return [f(self, key, values, **kwargs)]
+        parsed_values = []
+
+        if not isinstance(values, (list, tuple, set)):
+            values = [values]
+
+        for value in values:
+            try:
+                parsed_values.append(f(self, key, value, **kwargs))
+            except IgnoreItem:
+                continue
+
+        return parsed_values
     return wrapper
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,6 +20,7 @@ from dojson.contrib.marc21 import marc21
 from dojson.contrib.marc21.utils import create_record, load, split_stream
 from dojson.contrib.to_marc21 import to_marc21
 from dojson.contrib.to_marc21.utils import dumps
+from dojson.errors import IgnoreItem
 from dojson.utils import flatten, for_each_value, ignore_value
 
 RECORD = """<record>
@@ -287,6 +288,23 @@ def test_no_none_value():
 
     data = overdo.do({'0247_': 'valid value'})
     assert data.get('024') == 'valid value'
+
+
+def test_ignore_item_exception():
+    """Test ignore item exception."""
+    overdo = dojson.Overdo()
+
+    @overdo.over('b', 'b')
+    @for_each_value
+    def match(self, key, value):
+        if not value:
+            raise IgnoreItem()
+        return value
+
+    source = {'b': ['', 0, 1, 2, 3, None]}
+    result = {'b': [1, 2, 3]}
+
+    assert overdo.do(source) == result
 
 
 def test_marc21_loader():


### PR DESCRIPTION
- NEW Adds the possibility to skip individual items when using the
  `for_each_value` decorator by raising the `IgnoreElement` exception.

Reviewed-by: Jiri Kuncar jiri.kuncar@cern.ch
Signed-off-by: David Caro david@dcaro.es
