### PR TITLE
contrib: fix of 044 being repeatable

### DIFF
--- a/dojson/contrib/marc21/fields/bd01x09x.py
+++ b/dojson/contrib/marc21/fields/bd01x09x.py
@@ -934,7 +934,6 @@ def geographic_area_code(self, key, value):
 
 
 @marc21.over('country_of_publishing_producing_entity_code', '^044__')
-@utils.for_each_value
 @utils.filter_values
 def country_of_publishing_producing_entity_code(self, key, value):
     """Country of Publishing/Producing Entity Code."""

--- a/tests/data/test_8.xml
+++ b/tests/data/test_8.xml
@@ -41,8 +41,6 @@
       <subfield code="a">gw</subfield>
       <subfield code="a">fr</subfield>
       <subfield code="a">au</subfield>
-    </datafield>
-    <datafield tag="044" ind1=" " ind2=" ">
       <subfield code="a">xxu</subfield>
       <subfield code="c">usa</subfield>
     </datafield>


### PR DESCRIPTION
- FIX Removes @utils.for_each_value decorator from conversion function
  for marc field 044, which is not repeatable. (closes #181)

Signed-off-by: Øystein Blixhavn oystein@blixhavn.no
