### PR TITLE
cli: fix PY3 stdin encoding issue

### DIFF
--- a/dojson/_compat.py
+++ b/dojson/_compat.py
@@ -22,6 +22,7 @@ if PY3:
     import io
     StringIO = io.StringIO
     BytesIO = io.BytesIO
+    stdin = getattr(sys.stdin, 'buffer', sys.stdin)
 
     binary_type = bytes
     string_types = str,
@@ -35,6 +36,7 @@ if PY3:
 else:
     import StringIO
     StringIO = BytesIO = StringIO.StringIO
+    stdin = sys.stdin
 
     binary_type = str
     string_types = basestring,

--- a/dojson/cli/__init__.py
+++ b/dojson/cli/__init__.py
@@ -105,13 +105,14 @@ import sys
 
 import click
 
+from .._compat import stdin
 from .utils import open_entry_point, with_plugins
 
 
 @with_plugins('dojson.cli')
 @click.group(chain=True, invoke_without_command=True)
 @click.option('-i', '--input', 'source', type=click.File('rb'),
-              default=sys.stdin)
+              default=stdin)
 @click.option('-l', '--load', callback=open_entry_point('dojson.cli.load'),
               default='json')
 @click.option('-d', '--dump', callback=open_entry_point('dojson.cli.dump'),


### PR DESCRIPTION
- FIX Addresses issues with STDIN encoding on Python 3.

Signed-off-by: Jiri Kuncar jiri.kuncar@cern.ch
