### PR TITLE
contrib: removal of duplicates in MARC21 schemas

### DIFF
--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd01x09x-v1.0.1.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd01x09x-v1.0.1.json
@@ -1025,9 +1025,6 @@
                             "type": "string"
                         }
                     },
-                    "source_of_code": {
-                        "type": "string"
-                    },
                     "linkage": {
                         "type": "string"
                     },
@@ -1245,9 +1242,6 @@
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "source_of_code": {
-                        "type": "string"
                     }
                 }
             }
@@ -1272,9 +1266,6 @@
                         "items": {
                             "type": "string"
                         }
-                    },
-                    "source_of_code": {
-                        "type": "string"
                     },
                     "soloist": {
                         "type": "array",

--- a/dojson/contrib/marc21/schemas/marc21/bibliographic/bd84188x-v1.0.1.json
+++ b/dojson/contrib/marc21/schemas/marc21/bibliographic/bd84188x-v1.0.1.json
@@ -166,9 +166,6 @@
                     "materials_specified": {
                         "type": "string"
                     },
-                    "access_method": {
-                        "type": "string"
-                    },
                     "linkage": {
                         "type": "string"
                     },


### PR DESCRIPTION
Allows [#3769](https://github.com/inveniosoftware/invenio/pull/3769) in invenio repo to be merged.

* FIX Removes duplicate fields (closes #189):
	access_method  in bd84188x-v1.0.1.json
   	source_of_code in bd01x09x-v1.0.1.json

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>