### PR TITLE
contrib: ignore subfield code case in marc21

### DIFF
--- a/dojson/contrib/marc21/utils.py
+++ b/dojson/contrib/marc21/utils.py
@@ -75,7 +75,7 @@ def create_record(marcxml, correct=False, keep_singletons=True):
         fields = []
         subfield_iterator = datafield.iter(tag='{*}subfield')
         for subfield in subfield_iterator:
-            code = subfield.attrib.get('code', '!')  # .encode("UTF-8")
+            code = subfield.attrib.get('code', '!').lower()  # .encode("UTF-8")
             text = subfield.text or ''
             if text or keep_singletons:
                 fields.append((code, text))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -484,6 +484,18 @@ def test_marc21_856_indicators():
         assert blob == back_blob, name
 
 
+def test_marc21_create_record_ignores_subfield_code_case():
+    record = '''
+        <datafield tag="100" ind1=" " ind2=" ">
+            <subfield code="A">Smith, John</subfield>
+        </datafield>
+        '''
+
+    blob = create_record(record)
+
+    assert blob['100__']['a'] == 'Smith, John'
+
+
 def test_leader():
     """Test XML parser for <leader/>."""
     from dojson.contrib.marc21.utils import create_record


### PR DESCRIPTION
* Invenio 1 is mostly case-insensitive as far as subfield codes are
concerned. With this commit, subfield codes are forced to lowercase in
`create_record`, in order to account for the possible irrelevant case
differences.