### PR TITLE
fix publish

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details
@@ -15,7 +16,7 @@ on:
 
 jobs:
   Publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
@@ -24,15 +25,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel
+          pip install setuptools wheel babel
 
       - name: Build package
-        run: python setup.py compile_catalog sdist bdist_wheel
+        run: python setup.py sdist bdist_wheel
 
       - name: Publish on PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.1


### PR DESCRIPTION
- fix: pypi-publish missed installed package babel
- release: 1.5.1
