### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/.github/actions/pre-install/actions.yml
+++ b/.github/actions/pre-install/actions.yml
@@ -1,0 +1,6 @@
+runs:
+  using: composite
+  steps:
+    - name: install deps
+      run: |
+        sudo apt-get install libxml2-dev libxslt1-dev

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
-# Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2023-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details
@@ -16,28 +16,5 @@ on:
 
 jobs:
   Publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools wheel babel
-
-      - name: Build package
-        run: python setup.py sdist bdist_wheel
-
-      - name: Publish on PyPI
-        uses: pypa/gh-action-pypi-publish@v1.3.1
-        with:
-          user: __token__
-          # The token is provided by the inveniosoftware organization
-          password: ${{ secrets.pypi_token }}
+    uses: inveniosoftware/workflows/.github/workflows/pypi-publish.yml@master
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -25,39 +26,8 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-          python-version: [3.8, 3.9]
-          requirements-level: [pypi]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          sudo apt-get install libxml2-dev libxslt1-dev
-          python -m pip install --upgrade pip setuptools py wheel requirements-builder
-          requirements-builder -e all --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-          pip install .[all]
-          pip freeze
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master
+    with:
+      extras: tests,docs,jsonschema
+      search-service: '[""]'
+      db-service: '[""]'

--- a/dojson/cli/utils.py
+++ b/dojson/cli/utils.py
@@ -12,18 +12,17 @@
 import traceback
 
 import click
-import pkg_resources
+
+from ..utils import entry_points
 
 
 def open_entry_point(group_name):
     """Open entry point."""
     def loader(dummy_ctx, param, value):
         """Load entry point from group name based on given value."""
-        entry_points = list(pkg_resources.iter_entry_points(
-            group_name, value
-        ))
-        assert len(entry_points) == 1
-        return entry_points[0].load()
+        eps = [ep for ep in entry_points(group=group_name) if ep.name == value]
+        assert len(eps) == 1
+        return eps[0].load()
     return loader
 
 
@@ -35,7 +34,7 @@ def with_plugins(group_name):
             raise TypeError(
                 'Plugins can only be attached to an instance of click.Group.'
             )
-        for entry_point in pkg_resources.iter_entry_points(group_name):
+        for entry_point in entry_points(group=group_name):
             try:
                 group.add_command(entry_point.load())
             except Exception:

--- a/dojson/contrib/marc21/utils.py
+++ b/dojson/contrib/marc21/utils.py
@@ -9,10 +9,10 @@
 
 """Utilities for converting MARC21."""
 
+import importlib.resources
 import re
 from collections import Counter, OrderedDict
 
-import pkg_resources
 from lxml import etree
 
 from dojson._compat import StringIO, binary_type, iteritems, text_type
@@ -20,8 +20,8 @@ from dojson.utils import GroupableOrderedDict
 
 split_marc = re.compile('<record.*?>.*?</record>', re.DOTALL)
 
-MARC21_DTD = pkg_resources.resource_filename(
-    'dojson.contrib.marc21', 'MARC21slim.dtd')
+
+MARC21_DTD = importlib.resources.files('dojson.contrib.marc21') / 'MARC21slim.dtd'
 """Location of the MARC21 DTD file"""
 
 

--- a/dojson/contrib/to_marc21/utils.py
+++ b/dojson/contrib/to_marc21/utils.py
@@ -9,15 +9,15 @@
 
 """Utilities for converting to MARC21."""
 
-import pkg_resources
+import importlib.resources
+
 from lxml import etree
 from lxml.builder import ElementMaker
 
 from dojson._compat import iteritems, string_types
 from dojson.utils import GroupableOrderedDict
 
-MARC21_DTD = pkg_resources.resource_filename(
-    'dojson.contrib.marc21', 'MARC21slim.dtd')
+MARC21_DTD = importlib.resources.files('dojson.contrib.marc21') / 'MARC21slim.dtd'
 """Location of the MARC21 DTD file"""
 
 MARC21_NS = "http://www.loc.gov/MARC21/slim"

--- a/dojson/overdo.py
+++ b/dojson/overdo.py
@@ -11,11 +11,9 @@
 
 import re
 
-from pkg_resources import iter_entry_points
-
 from ._compat import iteritems, zip_longest
 from .errors import IgnoreKey, MissingRule
-from .utils import GroupableOrderedDict
+from .utils import GroupableOrderedDict, entry_points
 
 try:
     from _sre import MAXGROUPS
@@ -75,8 +73,7 @@ class Overdo(object):
     def _collect_entry_points(self):
         """Collect entry points."""
         if self.entry_point_group is not None:
-            for entry_point in iter_entry_points(
-                    group=self.entry_point_group, name=None):
+            for entry_point in entry_points(group=self.entry_point_group):
                 entry_point.load()
 
     def build(self):

--- a/dojson/utils.py
+++ b/dojson/utils.py
@@ -11,14 +11,29 @@
 
 import codecs
 import functools
+import importlib.metadata as m
 import itertools
 import warnings
 from collections import Counter, OrderedDict
+from sys import version_info
 
 import simplejson as json
 
 from ._compat import iteritems
 from .errors import IgnoreItem, IgnoreKey
+
+
+def entry_points(group):
+    """Entry points."""
+    # copy pasted from invenio-base
+    if version_info < (3, 10):
+        eps = m.entry_points()
+        if isinstance(eps, dict):
+            eps = eps.get(group, [])
+    else:
+        eps = m.entry_points(group=group)
+
+    return set(eps)
 
 
 def int_with_default(value, default):

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ with open(os.path.join('dojson', 'version.py'), 'rt') as f:
     ).group('version')
 
 tests_require = [
+    'importlib_metadata>=8.0.0',
     'jsonschema>=3.0',
     'mock>=1.3.0',
     'pytest-invenio>=1.4.0',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,9 +12,9 @@
 from __future__ import absolute_import
 
 import codecs
+import importlib.resources
 import os
 
-import pkg_resources
 import pytest
 import simplejson as json
 from click.testing import CliRunner
@@ -68,10 +68,7 @@ def test_xml_to_marc21_to_xml(file_name):
             'utf-8') as myfile:
         expect = myfile.read()
 
-    schema = pkg_resources.resource_filename(
-        'dojson.contrib.marc21.schemas',
-        'marc21/bibliographic/bd-v1.0.2.json'
-    )
+    schema = str(importlib.resources.files('dojson.contrib.marc21.schemas') / 'marc21/bibliographic/bd-v1.0.2.json')
 
     runner = CliRunner()
     result = runner.invoke(
@@ -111,10 +108,7 @@ def test_xml_to_marc21_authority_to_xml(file_name):
             'utf-8') as myfile:
         expect = myfile.read()
 
-    schema = pkg_resources.resource_filename(
-        'dojson.contrib.marc21.schemas',
-        'marc21/authority/ad-v1.0.2.json'
-    )
+    schema = str(importlib.resources.files('dojson.contrib.marc21.schemas') / 'marc21/authority/ad-v1.0.2.json')
 
     runner = CliRunner()
     result = runner.invoke(

--- a/tests/test_contrib_to_marc21_utils.py
+++ b/tests/test_contrib_to_marc21_utils.py
@@ -11,7 +11,6 @@
 
 import os
 
-import pkg_resources
 import pytest
 from click.testing import CliRunner
 from lxml import etree
@@ -19,6 +18,7 @@ from lxml.etree import _Element
 
 from dojson.contrib.marc21.utils import load
 from dojson.contrib.to_marc21.utils import dumps, dumps_etree
+from dojson.utils import entry_points
 from test_core import RECORD_SIMPLE
 
 
@@ -47,9 +47,8 @@ def test_xslt_dump():
 
 def test_entry_points():
     """Test entry points."""
-    dump = list(pkg_resources.iter_entry_points(
-        'dojson.cli.dump', 'marcxml'
-    ))[0].load()
+    eps = [ep for ep in entry_points('dojson.cli.dump') if ep.name == 'marcxml']
+    dump = eps[0].load()
     path = os.path.dirname(__file__)
     with open("{0}/demo_marc21_to_dc.converted.xml".format(path)) as myfile:
         expect = myfile.read()


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
