### PR TITLE
setup: remove unused action

### DIFF
--- a/.github/actions/pre-install/actions.yml
+++ b/.github/actions/pre-install/actions.yml
@@ -1,6 +1,0 @@
-runs:
-  using: composite
-  steps:
-    - name: install deps
-      run: |
-        sudo apt-get install libxml2-dev libxslt1-dev


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

The pre-install should have been called `action.yml` and been structured more like the one in https://github.com/inveniosoftware/citeproc-py-styles/pull/24/files. 

However...since the tests passed without installing libxml2-dev and libxslt1-dev we can probably just delete this and use the standard test workflow.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
